### PR TITLE
Fix broken link to https biicode page

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Building from source
 
 Requirements
 ------------
-  - [biicode](https://www.biicode.com/downloads)
+  - [biicode](http://www.biicode.com/downloads)
 
         # After installing, call
         $ bii setup:cpp


### PR DESCRIPTION
When you click on the link to biicode in the README you are directed to a https site with an invalid certificate. The non-https site works fine, so I changed the link to that one.