### PR TITLE
print defaults for cipher and blocksize in cli help

### DIFF
--- a/src/cryfs-cli/program_options/Parser.cpp
+++ b/src/cryfs-cli/program_options/Parser.cpp
@@ -2,11 +2,13 @@
 #include "utils.h"
 #include <iostream>
 #include <boost/optional.hpp>
+#include <cryfs/config/CryConfigConsole.h>
 #include <cryfs-cli/Environment.h>
 
 namespace po = boost::program_options;
 namespace bf = boost::filesystem;
 using namespace cryfs::program_options;
+using cryfs::CryConfigConsole;
 using std::pair;
 using std::vector;
 using std::cerr;
@@ -118,12 +120,16 @@ vector<const char*> Parser::_to_const_char_vector(const vector<string> &options)
 
 void Parser::_addAllowedOptions(po::options_description *desc) {
     po::options_description options("Allowed options");
+    string cipher_description = "Cipher to use for encryption. See possible values by calling cryfs with --show-ciphers. Default: ";
+    cipher_description += CryConfigConsole::DEFAULT_CIPHER;
+    string blocksize_description = "The block size used when storing ciphertext blocks (in bytes). Default: ";
+    blocksize_description += std::to_string(CryConfigConsole::DEFAULT_BLOCKSIZE_BYTES);
     options.add_options()
             ("help,h", "show help message")
             ("config,c", po::value<string>(), "Configuration file")
             ("foreground,f", "Run CryFS in foreground.")
-            ("cipher", po::value<string>(), "Cipher to use for encryption. See possible values by calling cryfs with --show-ciphers.")
-            ("blocksize", po::value<uint32_t>(), "The block size used when storing ciphertext blocks (in bytes).")
+            ("cipher", po::value<string>(), cipher_description.c_str())
+            ("blocksize", po::value<uint32_t>(), blocksize_description.c_str())
             ("show-ciphers", "Show list of supported ciphers.")
             ("unmount-idle", po::value<double>(), "Automatically unmount after specified number of idle minutes.")
             ("logfile", po::value<string>(), "Specify the file to write log messages to. If this is not specified, log messages will go to stdout, or syslog if CryFS is running in the background.")


### PR DESCRIPTION
Results in the following cli output:
```
Allowed options:
  -h [ --help ]          show help message
  -c [ --config ] arg    Configuration file
  -f [ --foreground ]    Run CryFS in foreground.
  --cipher arg           Cipher to use for encryption. See possible values by 
                         calling cryfs with --show-ciphers. Default: 
                         aes-256-gcm
  --blocksize arg        The block size used when storing ciphertext blocks (in
                         bytes). Default: 32768
  --show-ciphers         Show list of supported ciphers.
  --unmount-idle arg     Automatically unmount after specified number of idle 
                         minutes.
  --logfile arg          Specify the file to write log messages to. If this is 
                         not specified, log messages will go to stdout, or 
                         syslog if CryFS is running in the background.
```

Closes #94.