### PR TITLE
fix pessimizing move warnings

### DIFF
--- a/src/blobstore/implementations/onblocks/datatreestore/DataTree.cpp
+++ b/src/blobstore/implementations/onblocks/datatreestore/DataTree.cpp
@@ -246,7 +246,7 @@ unique_ref<DataNode> DataTree::addChildTo(DataInnerNode *node) {
   new_leaf->resize(_nodeStore->layout().maxBytesPerLeaf());
   auto chain = createChainOfInnerNodes(node->depth()-1, std::move(new_leaf));
   node->addChild(*chain);
-  return std::move(chain);
+  return chain;
 }
 
 uint32_t DataTree::leavesPerFullChild(const DataInnerNode &root) const {

--- a/src/blockstore/implementations/ondisk/OnDiskBlockStore.cpp
+++ b/src/blockstore/implementations/ondisk/OnDiskBlockStore.cpp
@@ -58,7 +58,7 @@ bool OnDiskBlockStore::_isValidBlockKey(const string &key) {
 
 optional<unique_ref<Block>> OnDiskBlockStore::tryCreate(const Key &key, Data data) {
   //TODO Easier implementation? This is only so complicated because of the cast OnDiskBlock -> Block
-  auto result = std::move(OnDiskBlock::CreateOnDisk(_rootdir, key, std::move(data)));
+  auto result = OnDiskBlock::CreateOnDisk(_rootdir, key, std::move(data));
   if (result == boost::none) {
     return boost::none;
   }

--- a/src/cpp-utils/data/Data.cpp
+++ b/src/cpp-utils/data/Data.cpp
@@ -34,7 +34,7 @@ std::streampos Data::_getStreamSize(istream &stream) {
 Data Data::LoadFromStream(istream &stream, size_t size) {
   Data result(size);
   stream.read(static_cast<char*>(result.data()), result.size());
-  return std::move(result);
+  return result;
 }
 
 }


### PR DESCRIPTION
This fixes warnings emitted by clang:

src/cpp-utils/data/Data.cpp:37:10:
warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
        return std::move(result);
               ^
src/blockstore/implementations/ondisk/OnDiskBlockStore.cpp:61:17:
warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
        auto result = std::move(OnDiskBlock::CreateOnDisk(_rootdir, key, std::move(data)));
                      ^
src/blobstore/implementations/onblocks/datatreestore/DataTree.cpp:249:10:
warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
        return std::move(chain);
               ^

See also:
http://vmpstr.blogspot.ch/2015/12/redundant-stdmove.html