### PR TITLE
Patch get_total_memory() for freebsd compatibility

### DIFF
--- a/src/cpp-utils/system/get_total_memory.cpp
+++ b/src/cpp-utils/system/get_total_memory.cpp
@@ -8,13 +8,13 @@ namespace cpputils{
     namespace system {
         uint64_t get_total_memory() {
             uint64_t mem;
-#ifdef __APPLE__
+#if defined(__APPLE__)
             size_t size = sizeof(mem);
   int result = sysctlbyname("hw.memsize", &mem, &size, nullptr, 0);
   if (0 != result) {
     throw std::runtime_error("sysctlbyname syscall failed");
   }
-#elif __linux__ || __FreeBSD__
+#elif defined(__linux__) || defined(__FreeBSD__)
             long numRAMPages = sysconf(_SC_PHYS_PAGES);
             long pageSize = sysconf(_SC_PAGESIZE);
             mem = numRAMPages * pageSize;


### PR DESCRIPTION
Build is failing on freebsd

https://buildd.debian.org/status/package.php?p=cryfs

get_total_memory(0) is not recognizing the __FreeBSD__ define.

`cd /«PKGBUILDDIR»/obj-x86_64-kfreebsd-gnu/src/cpp-utils && /usr/bin/c++    -I/«PKGBUILDDIR»/src -isystem /«PKGBUILDDIR»/vendor/scrypt/scrypt-1.2.0 -isystem /«PKGBUILDDIR»/vendor/spdlog  -g -O2 -fdebug-prefix-map=/«PKGBUILDDIR»=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2  -O3 -DNDEBUG   -Wall -Wextra -std=gnu++14 -o CMakeFiles/cpp-utils.dir/system/get_total_memory.cpp.o -c /«PKGBUILDDIR»/src/cpp-utils/system/get_total_memory.cpp
/«PKGBUILDDIR»/src/cpp-utils/system/get_total_memory.cpp:22:2: error: #error Not supported on windows yet, TODO http:
 #error Not supported on windows yet, TODO http://stackoverflow.com/a/2513561/829568
  ^~~~~
src/cpp-utils/CMakeFiles/cpp-utils.dir/build.make:881: recipe for target 'src/cpp-utils/CMakeFiles/cpp-utils.dir/system/get_total_memory.cpp.o' failed`

This patch is not yet tested.