### PR TITLE
Fixes compilation on FreeBSD 11.1 (RELEASE branch)

### DIFF
--- a/src/cpp-utils/system/get_total_memory.cpp
+++ b/src/cpp-utils/system/get_total_memory.cpp
@@ -1,6 +1,6 @@
 #include "get_total_memory.h"
-#include <sys/sysctl.h>
 #include <sys/types.h>
+#include <sys/sysctl.h>
 #include <unistd.h>
 #include <stdexcept>
 

--- a/src/fspp/fuse/params.h
+++ b/src/fspp/fuse/params.h
@@ -3,7 +3,7 @@
 #define MESSMER_FSPP_FUSE_PARAMS_H_
 
 #define FUSE_USE_VERSION 26
-#if defined __linux__ || defined __FreeBSD__
+#if defined(__linux__) || defined(__FreeBSD__)
 #include <fuse.h>
 #elif __APPLE__
 #include <osxfuse/fuse.h>

--- a/src/fspp/fuse/params.h
+++ b/src/fspp/fuse/params.h
@@ -3,7 +3,7 @@
 #define MESSMER_FSPP_FUSE_PARAMS_H_
 
 #define FUSE_USE_VERSION 26
-#ifdef __linux__
+#if defined __linux__ || defined __FreeBSD__
 #include <fuse.h>
 #elif __APPLE__
 #include <osxfuse/fuse.h>


### PR DESCRIPTION
1. FreeBSD sysctl.h uses types declared in <sys/types.h>.
2. fuse.h should be included on FreeBSD as well as on Linux.
