### PR TITLE
feat: make volname default to mountdir

### DIFF
--- a/src/fspp/fuse/Fuse.cpp
+++ b/src/fspp/fuse/Fuse.cpp
@@ -250,7 +250,7 @@ void Fuse::run(const bf::path &mountdir, const vector<string> &fuseOptions) {
 
 vector<char *> Fuse::_build_argv(const bf::path &mountdir, const vector<string> &fuseOptions) {
   vector<char *> argv;
-  argv.reserve(6 + fuseOptions.size()); // fuseOptions + executable name + mountdir + 2x fuse options (subtype, fsname), each taking 2 entries ("-o", "key=value").
+  argv.reserve(8 + fuseOptions.size()); // fuseOptions + executable name + mountdir + 3x fuse options (subtype, fsname), each taking 2 entries ("-o", "key=value").
   argv.push_back(_create_c_string(_fstype)); // The first argument (executable name) is the file system type
   argv.push_back(_create_c_string(mountdir.string())); // The second argument is the mountdir
   for (const string &option : fuseOptions) {
@@ -258,6 +258,7 @@ vector<char *> Fuse::_build_argv(const bf::path &mountdir, const vector<string> 
   }
   _add_fuse_option_if_not_exists(&argv, "subtype", _fstype);
   _add_fuse_option_if_not_exists(&argv, "fsname", _fsname.get_value_or(_fstype));
+  _add_fuse_option_if_not_exists(&argv, "volname", mountdir.filename().string());
   // TODO Also set read/write size for osxfuse. The options there are called differently.
   // large_read not necessary because reads are large anyhow. This option is only important for 2.4.
   //argv.push_back(_create_c_string("-o"));

--- a/src/fspp/fuse/Fuse.cpp
+++ b/src/fspp/fuse/Fuse.cpp
@@ -250,7 +250,7 @@ void Fuse::run(const bf::path &mountdir, const vector<string> &fuseOptions) {
 
 vector<char *> Fuse::_build_argv(const bf::path &mountdir, const vector<string> &fuseOptions) {
   vector<char *> argv;
-  argv.reserve(8 + fuseOptions.size()); // fuseOptions + executable name + mountdir + 3x fuse options (subtype, fsname), each taking 2 entries ("-o", "key=value").
+  argv.reserve(6 + fuseOptions.size()); // fuseOptions + executable name + mountdir + 2x fuse options (subtype, fsname), each taking 2 entries ("-o", "key=value").
   argv.push_back(_create_c_string(_fstype)); // The first argument (executable name) is the file system type
   argv.push_back(_create_c_string(mountdir.string())); // The second argument is the mountdir
   for (const string &option : fuseOptions) {
@@ -258,7 +258,10 @@ vector<char *> Fuse::_build_argv(const bf::path &mountdir, const vector<string> 
   }
   _add_fuse_option_if_not_exists(&argv, "subtype", _fstype);
   _add_fuse_option_if_not_exists(&argv, "fsname", _fsname.get_value_or(_fstype));
+#ifdef __APPLE__
+  // Make volume name default to mountdir on macOS
   _add_fuse_option_if_not_exists(&argv, "volname", mountdir.filename().string());
+#endif
   // TODO Also set read/write size for osxfuse. The options there are called differently.
   // large_read not necessary because reads are large anyhow. This option is only important for 2.4.
   //argv.push_back(_create_c_string("-o"));


### PR DESCRIPTION
This PR makes the mounted volume name default to `mountdir`.

Fixes #75.

Disclaimer: I'm quite new to C++, let me know if you'd like any changes. 🙂 