### PR TITLE
implement pthread_getname_np_gcompat for musl

### DIFF
--- a/src/cpp-utils/thread/debugging.h
+++ b/src/cpp-utils/thread/debugging.h
@@ -9,7 +9,11 @@ namespace cpputils {
 
 void set_thread_name(const char* name);
 std::string get_thread_name();
+
+#if defined(__GLIBC__) || defined(__APPLE__) || defined(_MSC_VER)
+// this is not supported on musl systems, that's why we ifdef it for glibc only.
 std::string get_thread_name(std::thread* thread);
+#endif
 
 }
 

--- a/src/cpp-utils/thread/debugging_nonwindows.cpp
+++ b/src/cpp-utils/thread/debugging_nonwindows.cpp
@@ -5,6 +5,14 @@
 #include <thread>
 #include <pthread.h>
 #include <cpp-utils/assert/assert.h>
+#if !(defined(__GLIBC__) || defined(__APPLE__))
+// for pthread_getname_np_gcompat
+#include <errno.h> // errno
+#include <fcntl.h> // O_CLOEXEC, O_RDONLY
+#include <unistd.h> // open, read
+#include <boost/filesystem/path.hpp>
+#include <sys/types.h>
+#endif
 
 namespace cpputils {
 
@@ -28,9 +36,47 @@ void set_thread_name(const char* name) {
 }
 
 namespace {
+#if !(defined(__GLIBC__) || defined(__APPLE__))
+
+struct OpenFileRAII final {
+    explicit OpenFileRAII(const char* filename) : fd(::open(filename, O_RDONLY | O_CLOEXEC)) {}
+    ~OpenFileRAII() {
+        int result = close(fd);
+        if (result != 0) {
+            throw std::runtime_error("Error closing file. Errno: " + std::to_string(errno));
+        }
+    }
+
+    int fd;
+};
+
+// get the name of a thread
+int pthread_getname_np_gcompat(pthread_t thread, char *name, size_t len) {
+  ASSERT(thread == pthread_self(), "On musl systems, it's only supported to get the name of the current thread.");
+
+  auto file = OpenFileRAII("/proc/thread-self/comm");
+  ssize_t n;
+  if (file.fd < 0)
+    return errno;
+  n = read(file.fd, name, len);
+  if (n < 0)
+    return errno;
+  // if the trailing newline was not read, the buffer was too small
+  if (n == 0 || name[n - 1] != '\n')
+    return ERANGE;
+  // null-terminate string
+  name[n - 1] = '\0';
+  return 0;
+}
+#endif
+
 std::string get_thread_name(pthread_t thread) {
   char name[MAX_NAME_LEN];
+#if defined(__GLIBC__) || defined(__APPLE__)
   int result = pthread_getname_np(thread, name, MAX_NAME_LEN);
+#else
+  int result = pthread_getname_np_gcompat(thread, name, MAX_NAME_LEN);
+#endif
   if (0 != result) {
     throw std::runtime_error("Error getting thread name with pthread_getname_np. Code: " + std::to_string(result));
   }
@@ -39,16 +85,19 @@ std::string get_thread_name(pthread_t thread) {
   name[MAX_NAME_LEN - 1] = '\0';
   return name;
 }
+
 }
 
 std::string get_thread_name() {
   return get_thread_name(pthread_self());
 }
 
+#if defined(__GLIBC__) || defined(__APPLE__)
 std::string get_thread_name(std::thread* thread) {
   ASSERT(thread->joinable(), "Thread not running");
   return get_thread_name(thread->native_handle());
 }
+#endif
 
 }
 


### PR DESCRIPTION
- musl does not implement pthread_getname_np
  - https://www.openwall.com/lists/musl/2016/04/08/1
- use gcompat implementation of pthread_getname_np
  - https://code.foxkit.us/adelie/gcompat/merge_requests/4/diffs#4286050449051ee882437df617bf078f8b8bdcd2_1_1
- put behind if-else `__GLIBC__` preprocessor control flow to ensure
  only libcs besides glibc use it