### PR TITLE
Handle the noatime option

### DIFF
--- a/doc/man/cryfs.1
+++ b/doc/man/cryfs.1
@@ -16,7 +16,7 @@ cryfs \- cryptographic filesystem for the cloud
 [\fB\-f\fR]
 [\fIoptions\fR]
 .I basedir mountpoint
-[\fB\-\-\fR \fIfuse-options\fR]
+[\fB\-o\fR \fIfuse-options\fR]
 .br
 .\" show-ciphers syntax
 .B cryfs \-\-help\fR|\fB\-\-version\fR|\fB\-\-show-ciphers

--- a/src/cryfs-cli/Cli.cpp
+++ b/src/cryfs-cli/Cli.cpp
@@ -244,8 +244,7 @@ namespace cryfs_cli {
               }
             };
             const bool missingBlockIsIntegrityViolation = config.configFile->config()->missingBlockIsIntegrityViolation();
-            _device = optional<unique_ref<CryDevice>>(make_unique_ref<CryDevice>(std::move(config.configFile), std::move(blockStore), std::move(localStateDir), config.myClientId,
-                                                                                 options.allowIntegrityViolations(), missingBlockIsIntegrityViolation, std::move(onIntegrityViolation)));
+            _device = optional<unique_ref<CryDevice>>(make_unique_ref<CryDevice>(std::move(config.configFile), std::move(blockStore), std::move(localStateDir), config.myClientId, options.allowIntegrityViolations(), missingBlockIsIntegrityViolation, std::move(onIntegrityViolation), options.timestampUpdateBehavior()));
             _sanityCheckFilesystem(_device->get());
 
             auto initFilesystem = [&] (fspp::fuse::Fuse *fs){

--- a/src/cryfs-cli/program_options/ProgramOptions.cpp
+++ b/src/cryfs-cli/program_options/ProgramOptions.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <cpp-utils/assert/assert.h>
 #include <cpp-utils/system/path.h>
+#include <cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h>
 
 using namespace cryfs_cli::program_options;
 using std::string;
@@ -15,13 +16,16 @@ ProgramOptions::ProgramOptions(bf::path baseDir, bf::path mountDir, optional<bf:
                                optional<uint32_t> blocksizeBytes,
                                bool allowIntegrityViolations,
                                boost::optional<bool> missingBlockIsIntegrityViolation,
+                               cryfs::fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior,
                                vector<string> fuseOptions)
     : _configFile(std::move(configFile)), _baseDir(bf::absolute(std::move(baseDir))), _mountDir(std::move(mountDir)),
       _mountDirIsDriveLetter(cpputils::path_is_just_drive_letter(_mountDir)),
 	  _foreground(foreground),
 	  _allowFilesystemUpgrade(allowFilesystemUpgrade), _allowReplacedFilesystem(allowReplacedFilesystem), _allowIntegrityViolations(allowIntegrityViolations),
       _cipher(std::move(cipher)), _blocksizeBytes(std::move(blocksizeBytes)), _unmountAfterIdleMinutes(std::move(unmountAfterIdleMinutes)),
-      _missingBlockIsIntegrityViolation(std::move(missingBlockIsIntegrityViolation)), _logFile(std::move(logFile)), _fuseOptions(std::move(fuseOptions)) {
+      _missingBlockIsIntegrityViolation(std::move(missingBlockIsIntegrityViolation)), _logFile(std::move(logFile)),
+      _timestampUpdateBehavior(timestampUpdateBehavior),
+      _fuseOptions(std::move(fuseOptions)) {
 	if (!_mountDirIsDriveLetter) {
 		_mountDir = bf::absolute(std::move(_mountDir));
 	}
@@ -77,6 +81,10 @@ bool ProgramOptions::allowReplacedFilesystem() const {
 
 const optional<bool> &ProgramOptions::missingBlockIsIntegrityViolation() const {
     return _missingBlockIsIntegrityViolation;
+}
+
+cryfs::fsblobstore::TimestampUpdateBehavior ProgramOptions::timestampUpdateBehavior() const {
+    return _timestampUpdateBehavior;
 }
 
 const vector<string> &ProgramOptions::fuseOptions() const {

--- a/src/cryfs-cli/program_options/ProgramOptions.h
+++ b/src/cryfs-cli/program_options/ProgramOptions.h
@@ -7,6 +7,7 @@
 #include <boost/optional.hpp>
 #include <cpp-utils/macros.h>
 #include <boost/filesystem.hpp>
+#include <cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h>
 
 namespace cryfs_cli {
     namespace program_options {
@@ -20,6 +21,7 @@ namespace cryfs_cli {
                            boost::optional<uint32_t> blocksizeBytes,
                            bool allowIntegrityViolations,
                            boost::optional<bool> missingBlockIsIntegrityViolation,
+                           cryfs::fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior,
                            std::vector<std::string> fuseOptions);
             ProgramOptions(ProgramOptions &&rhs) = default;
 
@@ -36,6 +38,7 @@ namespace cryfs_cli {
             bool allowIntegrityViolations() const;
             const boost::optional<bool> &missingBlockIsIntegrityViolation() const;
             const boost::optional<boost::filesystem::path> &logFile() const;
+            cryfs::fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior() const;
             const std::vector<std::string> &fuseOptions() const;
 
         private:
@@ -52,6 +55,7 @@ namespace cryfs_cli {
             boost::optional<double> _unmountAfterIdleMinutes;
             boost::optional<bool> _missingBlockIsIntegrityViolation;
             boost::optional<boost::filesystem::path> _logFile;
+            cryfs::fsblobstore::TimestampUpdateBehavior _timestampUpdateBehavior;
             std::vector<std::string> _fuseOptions;
 
             DISALLOW_COPY_AND_ASSIGN(ProgramOptions);

--- a/src/cryfs/impl/filesystem/CryDevice.h
+++ b/src/cryfs/impl/filesystem/CryDevice.h
@@ -15,11 +15,14 @@
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/FileBlobRef.h"
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/SymlinkBlobRef.h"
 
+#include "cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h"
+
+
 namespace cryfs {
 
 class CryDevice final: public fspp::Device {
 public:
-  CryDevice(std::shared_ptr<CryConfigFile> config, cpputils::unique_ref<blockstore::BlockStore2> blockStore, const LocalStateDir& localStateDir, uint32_t myClientId, bool allowIntegrityViolations, bool missingBlockIsIntegrityViolation, std::function<void ()> onIntegrityViolation);
+  CryDevice(std::shared_ptr<CryConfigFile> config, cpputils::unique_ref<blockstore::BlockStore2> blockStore, const LocalStateDir& localStateDir, uint32_t myClientId, bool allowIntegrityViolations, bool missingBlockIsIntegrityViolation, std::function<void ()> onIntegrityViolation, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior);
 
   statvfs statfs() override;
 
@@ -53,6 +56,8 @@ private:
   blockstore::BlockId _rootBlobId;
   std::shared_ptr<CryConfigFile> _configFile;
   std::vector<std::function<void()>> _onFsAction;
+
+  fsblobstore::TimestampUpdateBehavior _timestampUpdateBehavior;
 
   blockstore::BlockId GetOrCreateRootBlobId(CryConfigFile *config);
   blockstore::BlockId CreateRootBlobAndReturnId();

--- a/src/cryfs/impl/filesystem/CryDir.cpp
+++ b/src/cryfs/impl/filesystem/CryDir.cpp
@@ -29,8 +29,8 @@ using cryfs::parallelaccessfsblobstore::DirBlobRef;
 
 namespace cryfs {
 
-CryDir::CryDir(CryDevice *device, optional<unique_ref<DirBlobRef>> parent, optional<unique_ref<DirBlobRef>> grandparent, const BlockId &blockId)
-: CryNode(device, std::move(parent), std::move(grandparent), blockId) {
+CryDir::CryDir(CryDevice *device, optional<unique_ref<DirBlobRef>> parent, optional<unique_ref<DirBlobRef>> grandparent, const BlockId &blockId, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior)
+: CryNode(device, std::move(parent), std::move(grandparent), blockId, timestampUpdateBehavior) {
 }
 
 CryDir::~CryDir() {
@@ -72,7 +72,7 @@ unique_ref<vector<fspp::Dir::Entry>> CryDir::children() {
   device()->callFsActionCallbacks();
   if (!isRootDir()) { // NOLINT (workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82481 )
     //TODO Instead of doing nothing when we're the root directory, handle timestamps in the root dir correctly (and delete isRootDir() function)
-    parent()->updateAccessTimestampForChild(blockId(), fsblobstore::TimestampUpdateBehavior::RELATIME);
+    parent()->updateAccessTimestampForChild(blockId(), timestampUpdateBehavior());
   }
   auto children = make_unique_ref<vector<fspp::Dir::Entry>>();
   children->push_back(fspp::Dir::Entry(fspp::Dir::EntryType::DIR, "."));

--- a/src/cryfs/impl/filesystem/CryDir.cpp
+++ b/src/cryfs/impl/filesystem/CryDir.cpp
@@ -46,7 +46,7 @@ unique_ref<fspp::OpenFile> CryDir::createAndOpenFile(const string &name, fspp::m
   auto now = cpputils::time::now();
   auto dirBlob = LoadBlob();
   dirBlob->AddChildFile(name, child->blockId(), mode, uid, gid, now, now);
-  return make_unique_ref<CryOpenFile>(device(), std::move(dirBlob), std::move(child));
+  return make_unique_ref<CryOpenFile>(device(), std::move(dirBlob), std::move(child), timestampUpdateBehavior());
 }
 
 void CryDir::createDir(const string &name, fspp::mode_t mode, fspp::uid_t uid, fspp::gid_t gid) {

--- a/src/cryfs/impl/filesystem/CryDir.h
+++ b/src/cryfs/impl/filesystem/CryDir.h
@@ -5,12 +5,13 @@
 #include <fspp/fs_interface/Dir.h>
 #include "CryNode.h"
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/DirBlobRef.h"
+#include "cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h"
 
 namespace cryfs {
 
 class CryDir final: public fspp::Dir, public CryNode {
 public:
-  CryDir(CryDevice *device, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> parent, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> grandparent, const blockstore::BlockId &blockId);
+  CryDir(CryDevice *device, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> parent, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> grandparent, const blockstore::BlockId &blockId, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior);
   ~CryDir();
 
   //TODO return type variance to CryFile/CryDir?

--- a/src/cryfs/impl/filesystem/CryFile.cpp
+++ b/src/cryfs/impl/filesystem/CryFile.cpp
@@ -2,6 +2,7 @@
 
 #include "CryDevice.h"
 #include "CryOpenFile.h"
+#include "cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h"
 #include <fspp/fs_interface/FuseErrnoException.h>
 
 
@@ -18,8 +19,8 @@ using cryfs::parallelaccessfsblobstore::FileBlobRef;
 
 namespace cryfs {
 
-CryFile::CryFile(CryDevice *device, unique_ref<DirBlobRef> parent, optional<unique_ref<DirBlobRef>> grandparent, const BlockId &blockId)
-: CryNode(device, std::move(parent), std::move(grandparent), blockId) {
+CryFile::CryFile(CryDevice *device, unique_ref<DirBlobRef> parent, optional<unique_ref<DirBlobRef>> grandparent, const BlockId &blockId, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior)
+: CryNode(device, std::move(parent), std::move(grandparent), blockId, timestampUpdateBehavior) {
 }
 
 CryFile::~CryFile() {

--- a/src/cryfs/impl/filesystem/CryFile.cpp
+++ b/src/cryfs/impl/filesystem/CryFile.cpp
@@ -38,7 +38,7 @@ unique_ref<fspp::OpenFile> CryFile::open(fspp::openflags_t flags) {
   UNUSED(flags);
   device()->callFsActionCallbacks();
   auto blob = LoadBlob();
-  return make_unique_ref<CryOpenFile>(device(), parent(), std::move(blob));
+  return make_unique_ref<CryOpenFile>(device(), parent(), std::move(blob), timestampUpdateBehavior());
 }
 
 void CryFile::truncate(fspp::num_bytes_t size) {

--- a/src/cryfs/impl/filesystem/CryFile.h
+++ b/src/cryfs/impl/filesystem/CryFile.h
@@ -4,6 +4,7 @@
 
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/FileBlobRef.h"
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/DirBlobRef.h"
+#include "cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h"
 #include <fspp/fs_interface/File.h>
 #include "CryNode.h"
 
@@ -11,7 +12,7 @@ namespace cryfs {
 
 class CryFile final: public fspp::File, public CryNode {
 public:
-  CryFile(CryDevice *device, cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef> parent, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> grandparent, const blockstore::BlockId &blockId);
+  CryFile(CryDevice *device, cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef> parent, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> grandparent, const blockstore::BlockId &blockId, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior);
   ~CryFile();
 
   cpputils::unique_ref<fspp::OpenFile> open(fspp::openflags_t flags) override;

--- a/src/cryfs/impl/filesystem/CryNode.cpp
+++ b/src/cryfs/impl/filesystem/CryNode.cpp
@@ -3,6 +3,7 @@
 #include "CryDevice.h"
 #include "CryDir.h"
 #include "CryFile.h"
+#include "cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h"
 #include <fspp/fs_interface/FuseErrnoException.h>
 #include <cpp-utils/pointer/cast.h>
 #include <cpp-utils/system/time.h>
@@ -25,11 +26,12 @@ using fspp::fuse::FuseErrnoException;
 
 namespace cryfs {
 
-CryNode::CryNode(CryDevice *device, optional<unique_ref<DirBlobRef>> parent, optional<unique_ref<DirBlobRef>> grandparent, const BlockId &blockId)
+CryNode::CryNode(CryDevice *device, optional<unique_ref<DirBlobRef>> parent, optional<unique_ref<DirBlobRef>> grandparent, const BlockId &blockId, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior)
 : _device(device),
   _parent(none),
   _grandparent(none),
-  _blockId(blockId) {
+  _blockId(blockId),
+  _timestampUpdateBehavior(timestampUpdateBehavior) {
 
   ASSERT(parent != none || grandparent == none, "Grandparent can only be set when parent is not none");
 
@@ -68,6 +70,10 @@ optional<DirBlobRef*> CryNode::grandparent() {
     return none;
   }
   return _grandparent->get();
+}
+
+fsblobstore::TimestampUpdateBehavior CryNode::timestampUpdateBehavior() const {
+  return _timestampUpdateBehavior;
 }
 
 void CryNode::rename(const bf::path &to) {

--- a/src/cryfs/impl/filesystem/CryNode.h
+++ b/src/cryfs/impl/filesystem/CryNode.h
@@ -6,6 +6,7 @@
 #include <cpp-utils/macros.h>
 #include <fspp/fs_interface/Dir.h>
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/DirBlobRef.h"
+#include "cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h"
 #include "CryDevice.h"
 
 namespace cryfs {
@@ -15,7 +16,8 @@ public:
   virtual ~CryNode();
 
   // TODO grandparent is only needed to set the timestamps of the parent directory on rename and remove. Delete grandparent parameter once we store timestamps in the blob itself instead of in the directory listing.
-  CryNode(CryDevice *device, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> parent, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> grandparent, const blockstore::BlockId &blockId);
+  CryNode(CryDevice *device, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> parent, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> grandparent, const blockstore::BlockId &blockId, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior);
+
   void access(int mask) const override;
   stat_info stat() const override;
   void chmod(fspp::mode_t mode) override;
@@ -37,6 +39,7 @@ protected:
   std::shared_ptr<const parallelaccessfsblobstore::DirBlobRef> parent() const;
   std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> parent();
   boost::optional<parallelaccessfsblobstore::DirBlobRef*> grandparent();
+  fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior() const;
 
   virtual fspp::Dir::EntryType getType() const = 0;
 
@@ -50,6 +53,8 @@ private:
   boost::optional<std::shared_ptr<parallelaccessfsblobstore::DirBlobRef>> _parent;
   boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> _grandparent;
   blockstore::BlockId _blockId;
+
+  fsblobstore::TimestampUpdateBehavior _timestampUpdateBehavior;
 
   DISALLOW_COPY_AND_ASSIGN(CryNode);
 };

--- a/src/cryfs/impl/filesystem/CryOpenFile.h
+++ b/src/cryfs/impl/filesystem/CryOpenFile.h
@@ -5,13 +5,14 @@
 #include <fspp/fs_interface/OpenFile.h>
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/FileBlobRef.h"
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/DirBlobRef.h"
+#include "cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h"
 
 namespace cryfs {
 class CryDevice;
 
 class CryOpenFile final: public fspp::OpenFile {
 public:
-  explicit CryOpenFile(const CryDevice *device, std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> parent, cpputils::unique_ref<parallelaccessfsblobstore::FileBlobRef> fileBlob);
+  explicit CryOpenFile(const CryDevice *device, std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> parent, cpputils::unique_ref<parallelaccessfsblobstore::FileBlobRef> fileBlob, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior);
   ~CryOpenFile();
 
   stat_info stat() const override;
@@ -21,11 +22,13 @@ public:
   void flush() override;
   void fsync() override;
   void fdatasync() override;
+  fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior() const;
 
 private:
   const CryDevice *_device;
   std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> _parent;
   cpputils::unique_ref<parallelaccessfsblobstore::FileBlobRef> _fileBlob;
+  fsblobstore::TimestampUpdateBehavior _timestampUpdateBehavior;
 
   DISALLOW_COPY_AND_ASSIGN(CryOpenFile);
 };

--- a/src/cryfs/impl/filesystem/CrySymlink.cpp
+++ b/src/cryfs/impl/filesystem/CrySymlink.cpp
@@ -22,8 +22,8 @@ using cryfs::parallelaccessfsblobstore::DirBlobRef;
 
 namespace cryfs {
 
-CrySymlink::CrySymlink(CryDevice *device, unique_ref<DirBlobRef> parent, optional<unique_ref<DirBlobRef>> grandparent, const BlockId &blockId)
-: CryNode(device, std::move(parent), std::move(grandparent), blockId) {
+CrySymlink::CrySymlink(CryDevice *device, unique_ref<DirBlobRef> parent, optional<unique_ref<DirBlobRef>> grandparent, const BlockId &blockId, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior)
+: CryNode(device, std::move(parent), std::move(grandparent), blockId, timestampUpdateBehavior) {
 }
 
 CrySymlink::~CrySymlink() {
@@ -43,7 +43,7 @@ fspp::Dir::EntryType CrySymlink::getType() const {
 
 bf::path CrySymlink::target() {
   device()->callFsActionCallbacks();
-  parent()->updateAccessTimestampForChild(blockId(), fsblobstore::TimestampUpdateBehavior::RELATIME);
+  parent()->updateAccessTimestampForChild(blockId(), timestampUpdateBehavior());
   auto blob = LoadBlob(); // NOLINT (workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82481 )
   return blob->target();
 }

--- a/src/cryfs/impl/filesystem/CrySymlink.h
+++ b/src/cryfs/impl/filesystem/CrySymlink.h
@@ -6,12 +6,13 @@
 #include "CryNode.h"
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/SymlinkBlobRef.h"
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/DirBlobRef.h"
+#include "cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h"
 
 namespace cryfs {
 
 class CrySymlink final: public fspp::Symlink, public CryNode {
 public:
-  CrySymlink(CryDevice *device, cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef> parent, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> grandparent, const blockstore::BlockId &blockId);
+  CrySymlink(CryDevice *device, cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef> parent, boost::optional<cpputils::unique_ref<parallelaccessfsblobstore::DirBlobRef>> grandparent, const blockstore::BlockId &blockId, fsblobstore::TimestampUpdateBehavior timestampUpdateBehavior);
   ~CrySymlink();
 
   boost::filesystem::path target() override;

--- a/src/cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h
+++ b/src/cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h
@@ -7,8 +7,9 @@ namespace cryfs {
 namespace fsblobstore {
 
 enum class TimestampUpdateBehavior : uint8_t {
-    // currently only relatime supported
-    RELATIME
+    // currently only relatime and noatime supported
+      RELATIME
+    , NOATIME
 };
 
 }

--- a/test/cryfs-cli/program_options/ProgramOptionsTest.cpp
+++ b/test/cryfs-cli/program_options/ProgramOptionsTest.cpp
@@ -1,5 +1,6 @@
 #include "testutils/ProgramOptionsTestBase.h"
 #include <cryfs-cli/program_options/ProgramOptions.h>
+#include <cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h>
 #include <cpp-utils/pointer/unique_ref_boost_optional_gtest_workaround.h>
 
 using namespace cryfs_cli::program_options;
@@ -22,118 +23,118 @@ namespace boost {
 class ProgramOptionsTest: public ProgramOptionsTestBase {};
 
 TEST_F(ProgramOptionsTest, BaseDir) {
-    ProgramOptions testobj("/home/user/mydir", "", none, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("/home/user/mydir", "", none, false, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ("/home/user/mydir", testobj.baseDir());
 }
 
 TEST_F(ProgramOptionsTest, MountDir) {
-    ProgramOptions testobj("", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ("/home/user/mydir", testobj.mountDir());
 }
 
 TEST_F(ProgramOptionsTest, ConfigfileNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ(none, testobj.configFile());
 }
 
 TEST_F(ProgramOptionsTest, ConfigfileSome) {
-    ProgramOptions testobj("", "", bf::path("/home/user/configfile"), true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", bf::path("/home/user/configfile"), true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ("/home/user/configfile", testobj.configFile().get());
 }
 
 TEST_F(ProgramOptionsTest, ForegroundFalse) {
-    ProgramOptions testobj("", "", none, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, false, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_FALSE(testobj.foreground());
 }
 
 TEST_F(ProgramOptionsTest, ForegroundTrue) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_TRUE(testobj.foreground());
 }
 
 TEST_F(ProgramOptionsTest, AllowFilesystemUpgradeFalse) {
-    ProgramOptions testobj("", "", none, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, false, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_FALSE(testobj.allowFilesystemUpgrade());
 }
 
 TEST_F(ProgramOptionsTest, AllowFilesystemUpgradeTrue) {
-  ProgramOptions testobj("", "", none, false, true, false, none, none, none, none, false, none, {"./myExecutable"});
+  ProgramOptions testobj("", "", none, false, true, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_TRUE(testobj.allowFilesystemUpgrade());
 }
 
 TEST_F(ProgramOptionsTest, LogfileNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ(none, testobj.logFile());
 }
 
 TEST_F(ProgramOptionsTest, LogfileSome) {
-    ProgramOptions testobj("", "", none, true, false, false, none, bf::path("logfile"), none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, bf::path("logfile"), none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ("logfile", testobj.logFile().get());
 }
 
 TEST_F(ProgramOptionsTest, UnmountAfterIdleMinutesNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ(none, testobj.unmountAfterIdleMinutes());
 }
 
 TEST_F(ProgramOptionsTest, UnmountAfterIdleMinutesSome) {
-    ProgramOptions testobj("", "", none, true, false, false, 10, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, 10, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ(10, testobj.unmountAfterIdleMinutes().get());
 }
 
 TEST_F(ProgramOptionsTest, CipherNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ(none, testobj.cipher());
 }
 
 TEST_F(ProgramOptionsTest, CipherSome) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, string("aes-256-gcm"), none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, string("aes-256-gcm"), none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ("aes-256-gcm", testobj.cipher().get());
 }
 
 TEST_F(ProgramOptionsTest, BlocksizeBytesNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ(none, testobj.blocksizeBytes());
 }
 
 TEST_F(ProgramOptionsTest, BlocksizeBytesSome) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, 10*1024, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, 10*1024, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ(10*1024u, testobj.blocksizeBytes().get());
 }
 
 TEST_F(ProgramOptionsTest, MissingBlockIsIntegrityViolationTrue) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, true, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, true, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_TRUE(testobj.missingBlockIsIntegrityViolation().value());
 }
 
 TEST_F(ProgramOptionsTest, MissingBlockIsIntegrityViolationFalse) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, false, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, false, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_FALSE(testobj.missingBlockIsIntegrityViolation().value());
 }
 
 TEST_F(ProgramOptionsTest, MissingBlockIsIntegrityViolationNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_EQ(none, testobj.missingBlockIsIntegrityViolation());
 }
 
 TEST_F(ProgramOptionsTest, AllowIntegrityViolationsFalse) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_FALSE(testobj.allowIntegrityViolations());
 }
 
 TEST_F(ProgramOptionsTest, AllowIntegrityViolationsTrue) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, true, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, true, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"./myExecutable"});
     EXPECT_TRUE(testobj.allowIntegrityViolations());
 }
 
 TEST_F(ProgramOptionsTest, EmptyFuseOptions) {
-    ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, {});
+    ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {});
     //Fuse should have the mount dir as first parameter
     EXPECT_VECTOR_EQ({}, testobj.fuseOptions());
 }
 
 TEST_F(ProgramOptionsTest, SomeFuseOptions) {
-    ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, {"-f", "--longoption"});
+    ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME, {"-f", "--longoption"});
     //Fuse should have the mount dir as first parameter
     EXPECT_VECTOR_EQ({"-f", "--longoption"}, testobj.fuseOptions());
 }

--- a/test/cryfs/impl/filesystem/CryFsTest.cpp
+++ b/test/cryfs/impl/filesystem/CryFsTest.cpp
@@ -7,6 +7,7 @@
 #include <cryfs/impl/filesystem/CryDir.h>
 #include <cryfs/impl/filesystem/CryFile.h>
 #include <cryfs/impl/filesystem/CryOpenFile.h>
+#include <cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h>
 #include "../testutils/MockConsole.h"
 #include <cryfs/impl/config/CryConfigLoader.h>
 #include <cryfs/impl/config/CryPresetPasswordBasedKeyProvider.h>
@@ -64,20 +65,20 @@ auto failOnIntegrityViolation() {
 
 TEST_F(CryFsTest, CreatedRootdirIsLoadableAfterClosing) {
   {
-    CryDevice dev(loadOrCreateConfig(), blockStore(), localStateDir, 0x12345678, false, false, failOnIntegrityViolation());
+    CryDevice dev(loadOrCreateConfig(), blockStore(), localStateDir, 0x12345678, false, false, failOnIntegrityViolation(), fsblobstore::TimestampUpdateBehavior::RELATIME);
   }
-  CryDevice dev(loadOrCreateConfig(), blockStore(), localStateDir, 0x12345678, false, false, failOnIntegrityViolation());
+  CryDevice dev(loadOrCreateConfig(), blockStore(), localStateDir, 0x12345678, false, false, failOnIntegrityViolation(), fsblobstore::TimestampUpdateBehavior::RELATIME);
   auto rootDir = dev.LoadDir(bf::path("/"));
   rootDir.value()->children();
 }
 
 TEST_F(CryFsTest, LoadingFilesystemDoesntModifyConfigFile) {
   {
-    CryDevice dev(loadOrCreateConfig(), blockStore(), localStateDir, 0x12345678, false, false, failOnIntegrityViolation());
+    CryDevice dev(loadOrCreateConfig(), blockStore(), localStateDir, 0x12345678, false, false, failOnIntegrityViolation(), fsblobstore::TimestampUpdateBehavior::RELATIME);
   }
   Data configAfterCreating = Data::LoadFromFile(config.path()).value();
   {
-    CryDevice dev(loadOrCreateConfig(), blockStore(), localStateDir, 0x12345678, false, false, failOnIntegrityViolation());
+    CryDevice dev(loadOrCreateConfig(), blockStore(), localStateDir, 0x12345678, false, false, failOnIntegrityViolation(), fsblobstore::TimestampUpdateBehavior::RELATIME);
   }
   Data configAfterLoading = Data::LoadFromFile(config.path()).value();
   EXPECT_EQ(configAfterCreating, configAfterLoading);

--- a/test/cryfs/impl/filesystem/FileSystemTest.cpp
+++ b/test/cryfs/impl/filesystem/FileSystemTest.cpp
@@ -2,6 +2,7 @@
 #include <fspp/fstest/FsTest.h>
 #include <cpp-utils/tempfile/TempFile.h>
 #include <cpp-utils/io/NoninteractiveConsole.h>
+#include <cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h>
 #include <cryfs/impl/filesystem/CryDevice.h>
 #include <cryfs/impl/config/CryConfigLoader.h>
 #include <cryfs/impl/config/CryPresetPasswordBasedKeyProvider.h>
@@ -41,7 +42,7 @@ public:
     auto keyProvider = make_unique_ref<CryPresetPasswordBasedKeyProvider>("mypassword", make_unique_ref<SCrypt>(SCrypt::TestSettings));
     auto config = CryConfigLoader(_console, Random::PseudoRandom(), std::move(keyProvider), localStateDir, none, none, none)
             .loadOrCreate(configFile.path(), false, false).value();
-    return make_unique_ref<CryDevice>(std::move(config.configFile), std::move(blockStore), localStateDir, config.myClientId, false, false, failOnIntegrityViolation());
+    return make_unique_ref<CryDevice>(std::move(config.configFile), std::move(blockStore), localStateDir, config.myClientId, false, false, failOnIntegrityViolation(), fsblobstore::TimestampUpdateBehavior::RELATIME);
   }
 
   cpputils::TempDir tempLocalStateDir;

--- a/test/cryfs/impl/filesystem/testutils/CryTestBase.h
+++ b/test/cryfs/impl/filesystem/testutils/CryTestBase.h
@@ -1,6 +1,7 @@
 #ifndef MESSMER_CRYFS_TEST_CRYFS_FILESYSTEM_CRYTESTBASE_H
 #define MESSMER_CRYFS_TEST_CRYFS_FILESYSTEM_CRYTESTBASE_H
 
+#include <cryfs/impl/filesystem/fsblobstore/utils/TimestampUpdateBehavior.h>
 #include <cryfs/impl/filesystem/CryDevice.h>
 #include <cryfs/impl/config/CryPresetPasswordBasedKeyProvider.h>
 #include <blockstore/implementations/inmemory/InMemoryBlockStore2.h>
@@ -19,7 +20,7 @@ class CryTestBase : public TestWithFakeHomeDirectory {
 public:
     CryTestBase(): _tempLocalStateDir(), _localStateDir(_tempLocalStateDir.path()), _configFile(false), _device(nullptr) {
         auto fakeBlockStore = cpputils::make_unique_ref<blockstore::inmemory::InMemoryBlockStore2>();
-        _device = std::make_unique<cryfs::CryDevice>(configFile(), std::move(fakeBlockStore), _localStateDir, 0x12345678, false, false, failOnIntegrityViolation());
+        _device = std::make_unique<cryfs::CryDevice>(configFile(), std::move(fakeBlockStore), _localStateDir, 0x12345678, false, false, failOnIntegrityViolation(), cryfs::fsblobstore::TimestampUpdateBehavior::RELATIME);
     }
 
     std::shared_ptr<cryfs::CryConfigFile> configFile() {


### PR DESCRIPTION
Some time ago we had discussed on issue #133 that the ability to mount with the noatime option would be useful. This because some people have workflows where they frequently scan their whole cleartext trees, and with the (until now) default behavior, these scans would cause **all** underlying encrypted blobs to change (highly undesirable).

Initially I had developed a quick fix, but now I have properly forked the develop branch and did my best to handle the `TimestampUpdateBehavior` being passed around.

AFAIK there are no compiler warnings and all the pre-existing tests pass. I have not had time until now to add test cases for the new `noatime` behavior. Would someone like to add these tests maybe?

Will gladly accept suggestions on how to improve this patch :)