### PR TITLE
Revise package building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ There are additional requirements if you want to create packages. They are:
  2. Build
 
         $ mkdir cmake && cd cmake
+        $ conan install .. --build=missing
         $ cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TESTING=off
         $ make package
 


### PR DESCRIPTION
Do the package building instructions need to be revised?

Seems they are missing the "conan install .. --build=missing" step.

Also, when I built cryfs, I had to include the "-s compiler.libcxx=libstdc++11" flag to get conan to work. (Fedora 31, ppc64le).