### PR TITLE
Added an option to create a mountpoint with a missing directory

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -13,6 +13,7 @@ New features:
   Noatime reduces the amount of write necessary and with that reduces the probability for synchronization conflicts
   or corrupted file systems if a power outage happens while writing.
 * Add an --immediate flag to cryfs-unmount that tries to unmount immediately and doesn't wait for processes to release their locks on the file system.
+* Add a --create-missing-basedir and --create-missing-mountpoint flag to create the base directory and mount directory respectively, if they don't exist, skipping the confirmation prompt.
 
 
 Version 0.10.3 (unreleased)

--- a/doc/man/cryfs.1
+++ b/doc/man/cryfs.1
@@ -180,6 +180,12 @@ By default, CryFS remembers file systems it has seen in this base directory and 
 .
 .
 .TP
+\fB\-\-create-missing-basedir\fI
+.
+Creates the base directory even if there is no directory currently there, skipping the normal confirmation message to create it later.
+.
+.
+.TP
 \fB\-\-create-missing-mountpoint\fI
 .
 Creates the mountpoint even if there is no directory currently there, skipping the normal confirmation message to create it later.

--- a/doc/man/cryfs.1
+++ b/doc/man/cryfs.1
@@ -180,6 +180,12 @@ By default, CryFS remembers file systems it has seen in this base directory and 
 .
 .
 .TP
+\fB\-\-create-missing-mountpoint\fI
+.
+Creates the mountpoint even if there is no directory currently there, skipping the normal confirmation message to create it later.
+.
+.
+.TP
 \fB\-\-missing-block-is-integrity-violation\fR=true
 .
 When CryFS encounters a missing ciphertext block, it cannot cannot (yet) know if it was deleted by an unauthorized adversary or by a second authorized client. This is one of the restrictions of the integrity checks currently in place. You can enable this flag to treat missing ciphertext blocks as integrity violations, but then your file system will not be usable by multiple clients anymore. By default, this flag is disabled.

--- a/src/blockstore/implementations/compressing/compressors/RunLengthEncoding.cpp
+++ b/src/blockstore/implementations/compressing/compressors/RunLengthEncoding.cpp
@@ -114,7 +114,7 @@ namespace blockstore {
         }
 
         void RunLengthEncoding::_decodeArbitraryWords(istringstream *stream, ostringstream *decompressed) {
-            uint16_t size;
+            uint16_t size = 0;
             stream->read(reinterpret_cast<char*>(&size), sizeof(uint16_t));
             ASSERT(stream->good(), "Premature end of stream");
             Data run(size);
@@ -124,10 +124,10 @@ namespace blockstore {
         }
 
         void RunLengthEncoding::_decodeIdenticalWords(istringstream *stream, ostringstream *decompressed) {
-            uint16_t size;
+            uint16_t size = 0;
             stream->read(reinterpret_cast<char*>(&size), sizeof(uint16_t));
             ASSERT(stream->good(), "Premature end of stream");
-            uint8_t value;
+            uint8_t value = 0;
             stream->read(reinterpret_cast<char*>(&value), 1);
             ASSERT(stream->good(), "Premature end of stream");
             Data run(size);

--- a/src/cryfs-cli/Cli.cpp
+++ b/src/cryfs-cli/Cli.cpp
@@ -324,7 +324,7 @@ namespace cryfs_cli {
     }
 
 	void Cli::_sanityChecks(const ProgramOptions &options) {
-		_checkDirAccessible(bf::absolute(options.baseDir()), "base directory", options.createMissingMountpoint(), ErrorCode::InaccessibleBaseDir);
+		_checkDirAccessible(bf::absolute(options.baseDir()), "base directory", options.createMissingBasedir(), ErrorCode::InaccessibleBaseDir);
 
 		if (!options.mountDirIsDriveLetter()) {
 			_checkDirAccessible(options.mountDir(), "mount directory", options.createMissingMountpoint(), ErrorCode::InaccessibleMountDir);
@@ -336,11 +336,11 @@ namespace cryfs_cli {
 		}
     }
 
-    void Cli::_checkDirAccessible(const bf::path &dir, const std::string &name, bool createMissingMountpoint, ErrorCode errorCode) {
+    void Cli::_checkDirAccessible(const bf::path &dir, const std::string &name, bool createMissingDir, ErrorCode errorCode) {
         if (!bf::exists(dir)) {
-            bool create = createMissingMountpoint;
+            bool create = createMissingDir;
             if (create) {
-                cout << "Automatically creating " + name << endl;
+                LOG(INFO, "Automatically creating {}", name);
             } else {
                 create = _console->askYesNo("Could not find " + name + ". Do you want to create it?", false);
             }

--- a/src/cryfs-cli/Cli.h
+++ b/src/cryfs-cli/Cli.h
@@ -37,7 +37,7 @@ namespace cryfs_cli {
         void _sanityChecks(const program_options::ProgramOptions &options);
         void _checkMountdirDoesntContainBasedir(const program_options::ProgramOptions &options);
         bool _pathContains(const boost::filesystem::path &parent, const boost::filesystem::path &child);
-        void _checkDirAccessible(const boost::filesystem::path &dir, const std::string &name, bool createMissingMountpoint, cryfs::ErrorCode errorCode);
+        void _checkDirAccessible(const boost::filesystem::path &dir, const std::string &name, bool createMissingDir, cryfs::ErrorCode errorCode);
         std::shared_ptr<cpputils::TempFile> _checkDirWriteable(const boost::filesystem::path &dir, const std::string &name, cryfs::ErrorCode errorCode);
         void _checkDirReadable(const boost::filesystem::path &dir, std::shared_ptr<cpputils::TempFile> tempfile, const std::string &name, cryfs::ErrorCode errorCode);
         boost::optional<cpputils::unique_ref<CallAfterTimeout>> _createIdleCallback(boost::optional<double> minutes, std::function<void()> callback);

--- a/src/cryfs-cli/Cli.h
+++ b/src/cryfs-cli/Cli.h
@@ -37,7 +37,7 @@ namespace cryfs_cli {
         void _sanityChecks(const program_options::ProgramOptions &options);
         void _checkMountdirDoesntContainBasedir(const program_options::ProgramOptions &options);
         bool _pathContains(const boost::filesystem::path &parent, const boost::filesystem::path &child);
-        void _checkDirAccessible(const boost::filesystem::path &dir, const std::string &name, cryfs::ErrorCode errorCode);
+        void _checkDirAccessible(const boost::filesystem::path &dir, const std::string &name, bool createMissingMountpoint, cryfs::ErrorCode errorCode);
         std::shared_ptr<cpputils::TempFile> _checkDirWriteable(const boost::filesystem::path &dir, const std::string &name, cryfs::ErrorCode errorCode);
         void _checkDirReadable(const boost::filesystem::path &dir, std::shared_ptr<cpputils::TempFile> tempfile, const std::string &name, cryfs::ErrorCode errorCode);
         boost::optional<cpputils::unique_ref<CallAfterTimeout>> _createIdleCallback(boost::optional<double> minutes, std::function<void()> callback);

--- a/src/cryfs-cli/program_options/Parser.cpp
+++ b/src/cryfs-cli/program_options/Parser.cpp
@@ -58,6 +58,7 @@ ProgramOptions Parser::parse(const vector<string> &supportedCiphers) const {
     bool foreground = vm.count("foreground");
     bool allowFilesystemUpgrade = vm.count("allow-filesystem-upgrade");
     bool allowReplacedFilesystem = vm.count("allow-replaced-filesystem");
+    bool createMissingMountpoint = vm.count("create-missing-mountpoint");
     optional<double> unmountAfterIdleMinutes = 0.0;  // first setting to 0 and then to none is somehow needed to silence a GCC warning from -Wmaybe-uninitialized
     unmountAfterIdleMinutes = none;
     if (vm.count("unmount-idle")) {
@@ -90,7 +91,7 @@ ProgramOptions Parser::parse(const vector<string> &supportedCiphers) const {
         }
     }
 
-    return ProgramOptions(std::move(baseDir), std::move(mountDir), std::move(configfile), foreground, allowFilesystemUpgrade, allowReplacedFilesystem, std::move(unmountAfterIdleMinutes), std::move(logfile), std::move(cipher), blocksizeBytes, allowIntegrityViolations, std::move(missingBlockIsIntegrityViolation), std::move(fuseOptions));
+    return ProgramOptions(std::move(baseDir), std::move(mountDir), std::move(configfile), foreground, allowFilesystemUpgrade, allowReplacedFilesystem, createMissingMountpoint, std::move(unmountAfterIdleMinutes), std::move(logfile), std::move(cipher), blocksizeBytes, allowIntegrityViolations, std::move(missingBlockIsIntegrityViolation), std::move(fuseOptions));
 }
 
 void Parser::_checkValidCipher(const string &cipher, const vector<string> &supportedCiphers) {
@@ -165,6 +166,7 @@ void Parser::_addAllowedOptions(po::options_description *desc) {
             ("allow-integrity-violations", "Disable integrity checks. Integrity checks ensure that your file system was not manipulated or rolled back to an earlier version. Disabling them is needed if you want to load an old snapshot of your file system.")
             ("allow-filesystem-upgrade", "Allow upgrading the file system if it was created with an old CryFS version. After the upgrade, older CryFS versions might not be able to use the file system anymore.")
             ("allow-replaced-filesystem", "By default, CryFS remembers file systems it has seen in this base directory and checks that it didn't get replaced by an attacker with an entirely different file system since the last time it was loaded. However, if you do want to replace the file system with an entirely new one, you can pass in this option to disable the check.")
+            ("create-missing-mountpoint", "Creates the mountpoint even if there is no directory currently there, skipping the normal confirmation message to create it later.")
             ("show-ciphers", "Show list of supported ciphers.")
             ("unmount-idle", po::value<double>(), "Automatically unmount after specified number of idle minutes.")
             ("logfile", po::value<string>(), "Specify the file to write log messages to. If this is not specified, log messages will go to stdout, or syslog if CryFS is running in the background.")

--- a/src/cryfs-cli/program_options/Parser.cpp
+++ b/src/cryfs-cli/program_options/Parser.cpp
@@ -58,6 +58,7 @@ ProgramOptions Parser::parse(const vector<string> &supportedCiphers) const {
     bool foreground = vm.count("foreground");
     bool allowFilesystemUpgrade = vm.count("allow-filesystem-upgrade");
     bool allowReplacedFilesystem = vm.count("allow-replaced-filesystem");
+    bool createMissingBasedir = vm.count("create-missing-basedir");
     bool createMissingMountpoint = vm.count("create-missing-mountpoint");
     optional<double> unmountAfterIdleMinutes = 0.0;  // first setting to 0 and then to none is somehow needed to silence a GCC warning from -Wmaybe-uninitialized
     unmountAfterIdleMinutes = none;
@@ -91,7 +92,7 @@ ProgramOptions Parser::parse(const vector<string> &supportedCiphers) const {
         }
     }
 
-    return ProgramOptions(std::move(baseDir), std::move(mountDir), std::move(configfile), foreground, allowFilesystemUpgrade, allowReplacedFilesystem, createMissingMountpoint, std::move(unmountAfterIdleMinutes), std::move(logfile), std::move(cipher), blocksizeBytes, allowIntegrityViolations, std::move(missingBlockIsIntegrityViolation), std::move(fuseOptions));
+    return ProgramOptions(std::move(baseDir), std::move(mountDir), std::move(configfile), foreground, allowFilesystemUpgrade, allowReplacedFilesystem, createMissingBasedir, createMissingMountpoint, std::move(unmountAfterIdleMinutes), std::move(logfile), std::move(cipher), blocksizeBytes, allowIntegrityViolations, std::move(missingBlockIsIntegrityViolation), std::move(fuseOptions));
 }
 
 void Parser::_checkValidCipher(const string &cipher, const vector<string> &supportedCiphers) {
@@ -166,6 +167,7 @@ void Parser::_addAllowedOptions(po::options_description *desc) {
             ("allow-integrity-violations", "Disable integrity checks. Integrity checks ensure that your file system was not manipulated or rolled back to an earlier version. Disabling them is needed if you want to load an old snapshot of your file system.")
             ("allow-filesystem-upgrade", "Allow upgrading the file system if it was created with an old CryFS version. After the upgrade, older CryFS versions might not be able to use the file system anymore.")
             ("allow-replaced-filesystem", "By default, CryFS remembers file systems it has seen in this base directory and checks that it didn't get replaced by an attacker with an entirely different file system since the last time it was loaded. However, if you do want to replace the file system with an entirely new one, you can pass in this option to disable the check.")
+            ("create-missing-basedir", "Creates the base directory even if there is no directory currently there, skipping the normal confirmation message to create it later.")
             ("create-missing-mountpoint", "Creates the mountpoint even if there is no directory currently there, skipping the normal confirmation message to create it later.")
             ("show-ciphers", "Show list of supported ciphers.")
             ("unmount-idle", po::value<double>(), "Automatically unmount after specified number of idle minutes.")

--- a/src/cryfs-cli/program_options/ProgramOptions.cpp
+++ b/src/cryfs-cli/program_options/ProgramOptions.cpp
@@ -11,7 +11,7 @@ namespace bf = boost::filesystem;
 
 ProgramOptions::ProgramOptions(bf::path baseDir, bf::path mountDir, optional<bf::path> configFile,
                                bool foreground, bool allowFilesystemUpgrade, bool allowReplacedFilesystem, 
-                               bool createMissingMountpoint,
+                               bool createMissingBasedir, bool createMissingMountpoint,
                                optional<double> unmountAfterIdleMinutes,
                                optional<bf::path> logFile, optional<string> cipher,
                                optional<uint32_t> blocksizeBytes,
@@ -22,7 +22,7 @@ ProgramOptions::ProgramOptions(bf::path baseDir, bf::path mountDir, optional<bf:
       _mountDirIsDriveLetter(cpputils::path_is_just_drive_letter(_mountDir)),
 	  _foreground(foreground),
 	  _allowFilesystemUpgrade(allowFilesystemUpgrade), _allowReplacedFilesystem(allowReplacedFilesystem),
-      _createMissingMountpoint(createMissingMountpoint),
+      _createMissingBasedir(createMissingBasedir), _createMissingMountpoint(createMissingMountpoint),
       _allowIntegrityViolations(allowIntegrityViolations),
       _cipher(std::move(cipher)), _blocksizeBytes(std::move(blocksizeBytes)), _unmountAfterIdleMinutes(std::move(unmountAfterIdleMinutes)),
       _missingBlockIsIntegrityViolation(std::move(missingBlockIsIntegrityViolation)), _logFile(std::move(logFile)),
@@ -54,6 +54,10 @@ bool ProgramOptions::foreground() const {
 
 bool ProgramOptions::allowFilesystemUpgrade() const {
   return _allowFilesystemUpgrade;
+}
+
+bool ProgramOptions::createMissingBasedir() const {
+    return _createMissingBasedir;
 }
 
 bool ProgramOptions::createMissingMountpoint() const {

--- a/src/cryfs-cli/program_options/ProgramOptions.cpp
+++ b/src/cryfs-cli/program_options/ProgramOptions.cpp
@@ -10,7 +10,9 @@ using boost::optional;
 namespace bf = boost::filesystem;
 
 ProgramOptions::ProgramOptions(bf::path baseDir, bf::path mountDir, optional<bf::path> configFile,
-                               bool foreground, bool allowFilesystemUpgrade, bool allowReplacedFilesystem, optional<double> unmountAfterIdleMinutes,
+                               bool foreground, bool allowFilesystemUpgrade, bool allowReplacedFilesystem, 
+                               bool createMissingMountpoint,
+                               optional<double> unmountAfterIdleMinutes,
                                optional<bf::path> logFile, optional<string> cipher,
                                optional<uint32_t> blocksizeBytes,
                                bool allowIntegrityViolations,
@@ -19,7 +21,9 @@ ProgramOptions::ProgramOptions(bf::path baseDir, bf::path mountDir, optional<bf:
     : _configFile(std::move(configFile)), _baseDir(bf::absolute(std::move(baseDir))), _mountDir(std::move(mountDir)),
       _mountDirIsDriveLetter(cpputils::path_is_just_drive_letter(_mountDir)),
 	  _foreground(foreground),
-	  _allowFilesystemUpgrade(allowFilesystemUpgrade), _allowReplacedFilesystem(allowReplacedFilesystem), _allowIntegrityViolations(allowIntegrityViolations),
+	  _allowFilesystemUpgrade(allowFilesystemUpgrade), _allowReplacedFilesystem(allowReplacedFilesystem),
+      _createMissingMountpoint(createMissingMountpoint),
+      _allowIntegrityViolations(allowIntegrityViolations),
       _cipher(std::move(cipher)), _blocksizeBytes(std::move(blocksizeBytes)), _unmountAfterIdleMinutes(std::move(unmountAfterIdleMinutes)),
       _missingBlockIsIntegrityViolation(std::move(missingBlockIsIntegrityViolation)), _logFile(std::move(logFile)),
       _fuseOptions(std::move(fuseOptions)) {
@@ -50,6 +54,10 @@ bool ProgramOptions::foreground() const {
 
 bool ProgramOptions::allowFilesystemUpgrade() const {
   return _allowFilesystemUpgrade;
+}
+
+bool ProgramOptions::createMissingMountpoint() const {
+    return _createMissingMountpoint;
 }
 
 const optional<double> &ProgramOptions::unmountAfterIdleMinutes() const {

--- a/src/cryfs-cli/program_options/ProgramOptions.cpp
+++ b/src/cryfs-cli/program_options/ProgramOptions.cpp
@@ -18,15 +18,16 @@ ProgramOptions::ProgramOptions(bf::path baseDir, bf::path mountDir, optional<bf:
                                bool allowIntegrityViolations,
                                boost::optional<bool> missingBlockIsIntegrityViolation,
                                vector<string> fuseOptions)
-    : _configFile(std::move(configFile)), _baseDir(bf::absolute(std::move(baseDir))), _mountDir(std::move(mountDir)),
-      _mountDirIsDriveLetter(cpputils::path_is_just_drive_letter(_mountDir)),
+    : _baseDir(bf::absolute(std::move(baseDir))), _mountDir(std::move(mountDir)), _configFile(std::move(configFile)),
 	  _foreground(foreground),
 	  _allowFilesystemUpgrade(allowFilesystemUpgrade), _allowReplacedFilesystem(allowReplacedFilesystem),
       _createMissingBasedir(createMissingBasedir), _createMissingMountpoint(createMissingMountpoint),
+      _unmountAfterIdleMinutes(std::move(unmountAfterIdleMinutes)), _logFile(std::move(logFile)),
+      _cipher(std::move(cipher)), _blocksizeBytes(std::move(blocksizeBytes)),
       _allowIntegrityViolations(allowIntegrityViolations),
-      _cipher(std::move(cipher)), _blocksizeBytes(std::move(blocksizeBytes)), _unmountAfterIdleMinutes(std::move(unmountAfterIdleMinutes)),
-      _missingBlockIsIntegrityViolation(std::move(missingBlockIsIntegrityViolation)), _logFile(std::move(logFile)),
-      _fuseOptions(std::move(fuseOptions)) {
+      _missingBlockIsIntegrityViolation(std::move(missingBlockIsIntegrityViolation)),
+      _fuseOptions(std::move(fuseOptions)),
+      _mountDirIsDriveLetter(cpputils::path_is_just_drive_letter(_mountDir)) {
 	if (!_mountDirIsDriveLetter) {
 		_mountDir = bf::absolute(std::move(_mountDir));
 	}

--- a/src/cryfs-cli/program_options/ProgramOptions.h
+++ b/src/cryfs-cli/program_options/ProgramOptions.h
@@ -27,38 +27,38 @@ namespace cryfs_cli {
 
             const boost::filesystem::path &baseDir() const;
             const boost::filesystem::path &mountDir() const;
-			bool mountDirIsDriveLetter() const;
             const boost::optional<boost::filesystem::path> &configFile() const;
             bool foreground() const;
             bool allowFilesystemUpgrade() const;
             bool allowReplacedFilesystem() const;
             bool createMissingBasedir() const;
             bool createMissingMountpoint() const;
+            const boost::optional<double> &unmountAfterIdleMinutes() const;
+            const boost::optional<boost::filesystem::path> &logFile() const;
             const boost::optional<std::string> &cipher() const;
             const boost::optional<uint32_t> &blocksizeBytes() const;
-            const boost::optional<double> &unmountAfterIdleMinutes() const;
             bool allowIntegrityViolations() const;
             const boost::optional<bool> &missingBlockIsIntegrityViolation() const;
-            const boost::optional<boost::filesystem::path> &logFile() const;
             const std::vector<std::string> &fuseOptions() const;
+			bool mountDirIsDriveLetter() const;
 
         private:
-			boost::optional<boost::filesystem::path> _configFile;
             boost::filesystem::path _baseDir; // this is always absolute
             boost::filesystem::path _mountDir; // this is absolute iff !_mountDirIsDriveLetter
-			bool _mountDirIsDriveLetter;
+			boost::optional<boost::filesystem::path> _configFile;
             bool _foreground;
             bool _allowFilesystemUpgrade;
             bool _allowReplacedFilesystem;
-            bool _allowIntegrityViolations;
             bool _createMissingBasedir;
             bool _createMissingMountpoint;
+            boost::optional<double> _unmountAfterIdleMinutes;
+            boost::optional<boost::filesystem::path> _logFile;
             boost::optional<std::string> _cipher;
             boost::optional<uint32_t> _blocksizeBytes;
-            boost::optional<double> _unmountAfterIdleMinutes;
+            bool _allowIntegrityViolations;
             boost::optional<bool> _missingBlockIsIntegrityViolation;
-            boost::optional<boost::filesystem::path> _logFile;
             std::vector<std::string> _fuseOptions;
+			bool _mountDirIsDriveLetter;
 
             DISALLOW_COPY_AND_ASSIGN(ProgramOptions);
         };

--- a/src/cryfs-cli/program_options/ProgramOptions.h
+++ b/src/cryfs-cli/program_options/ProgramOptions.h
@@ -15,7 +15,7 @@ namespace cryfs_cli {
             ProgramOptions(boost::filesystem::path baseDir, boost::filesystem::path mountDir,
                            boost::optional<boost::filesystem::path> configFile,
                            bool foreground, bool allowFilesystemUpgrade, bool allowReplacedFilesystem,
-                           bool createMissingMountpoint,
+                           bool createMissingBasedir, bool createMissingMountpoint,
                            boost::optional<double> unmountAfterIdleMinutes,
                            boost::optional<boost::filesystem::path> logFile,
                            boost::optional<std::string> cipher,
@@ -32,6 +32,7 @@ namespace cryfs_cli {
             bool foreground() const;
             bool allowFilesystemUpgrade() const;
             bool allowReplacedFilesystem() const;
+            bool createMissingBasedir() const;
             bool createMissingMountpoint() const;
             const boost::optional<std::string> &cipher() const;
             const boost::optional<uint32_t> &blocksizeBytes() const;
@@ -50,6 +51,7 @@ namespace cryfs_cli {
             bool _allowFilesystemUpgrade;
             bool _allowReplacedFilesystem;
             bool _allowIntegrityViolations;
+            bool _createMissingBasedir;
             bool _createMissingMountpoint;
             boost::optional<std::string> _cipher;
             boost::optional<uint32_t> _blocksizeBytes;

--- a/src/cryfs-cli/program_options/ProgramOptions.h
+++ b/src/cryfs-cli/program_options/ProgramOptions.h
@@ -14,7 +14,9 @@ namespace cryfs_cli {
         public:
             ProgramOptions(boost::filesystem::path baseDir, boost::filesystem::path mountDir,
                            boost::optional<boost::filesystem::path> configFile,
-                           bool foreground, bool allowFilesystemUpgrade, bool allowReplacedFilesystem, boost::optional<double> unmountAfterIdleMinutes,
+                           bool foreground, bool allowFilesystemUpgrade, bool allowReplacedFilesystem,
+                           bool createMissingMountpoint,
+                           boost::optional<double> unmountAfterIdleMinutes,
                            boost::optional<boost::filesystem::path> logFile,
                            boost::optional<std::string> cipher,
                            boost::optional<uint32_t> blocksizeBytes,
@@ -30,6 +32,7 @@ namespace cryfs_cli {
             bool foreground() const;
             bool allowFilesystemUpgrade() const;
             bool allowReplacedFilesystem() const;
+            bool createMissingMountpoint() const;
             const boost::optional<std::string> &cipher() const;
             const boost::optional<uint32_t> &blocksizeBytes() const;
             const boost::optional<double> &unmountAfterIdleMinutes() const;
@@ -47,6 +50,7 @@ namespace cryfs_cli {
             bool _allowFilesystemUpgrade;
             bool _allowReplacedFilesystem;
             bool _allowIntegrityViolations;
+            bool _createMissingMountpoint;
             boost::optional<std::string> _cipher;
             boost::optional<uint32_t> _blocksizeBytes;
             boost::optional<double> _unmountAfterIdleMinutes;

--- a/src/cryfs/impl/filesystem/cachingfsblobstore/DirBlobRef.h
+++ b/src/cryfs/impl/filesystem/cachingfsblobstore/DirBlobRef.h
@@ -98,11 +98,11 @@ public:
         return _base->AppendChildrenTo(result);
     }
 
-    const blockstore::BlockId &blockId() const {
+    const blockstore::BlockId &blockId() const override override {
         return _base->blockId();
     }
 
-    fspp::num_bytes_t lstat_size() const {
+    fspp::num_bytes_t lstat_size() const override override {
         return _base->lstat_size();
     }
 

--- a/src/cryfs/impl/filesystem/cachingfsblobstore/DirBlobRef.h
+++ b/src/cryfs/impl/filesystem/cachingfsblobstore/DirBlobRef.h
@@ -98,11 +98,11 @@ public:
         return _base->AppendChildrenTo(result);
     }
 
-    const blockstore::BlockId &blockId() const override override {
+    const blockstore::BlockId &blockId() const override {
         return _base->blockId();
     }
 
-    fspp::num_bytes_t lstat_size() const override override {
+    fspp::num_bytes_t lstat_size() const override {
         return _base->lstat_size();
     }
 

--- a/src/cryfs/impl/filesystem/cachingfsblobstore/FileBlobRef.h
+++ b/src/cryfs/impl/filesystem/cachingfsblobstore/FileBlobRef.h
@@ -36,11 +36,11 @@ public:
         return _base->flush();
     }
 
-    const blockstore::BlockId &blockId() const {
+    const blockstore::BlockId &blockId() const override override {
         return _base->blockId();
     }
 
-    fspp::num_bytes_t lstat_size() const {
+    fspp::num_bytes_t lstat_size() const override override {
         return _base->lstat_size();
     }
 

--- a/src/cryfs/impl/filesystem/cachingfsblobstore/FileBlobRef.h
+++ b/src/cryfs/impl/filesystem/cachingfsblobstore/FileBlobRef.h
@@ -36,11 +36,11 @@ public:
         return _base->flush();
     }
 
-    const blockstore::BlockId &blockId() const override override {
+    const blockstore::BlockId &blockId() const override {
         return _base->blockId();
     }
 
-    fspp::num_bytes_t lstat_size() const override override {
+    fspp::num_bytes_t lstat_size() const override {
         return _base->lstat_size();
     }
 

--- a/src/cryfs/impl/filesystem/cachingfsblobstore/SymlinkBlobRef.h
+++ b/src/cryfs/impl/filesystem/cachingfsblobstore/SymlinkBlobRef.h
@@ -20,11 +20,11 @@ public:
         return _base->target();
     }
 
-    const blockstore::BlockId &blockId() const {
+    const blockstore::BlockId &blockId() const override override {
         return _base->blockId();
     }
 
-    fspp::num_bytes_t lstat_size() const {
+    fspp::num_bytes_t lstat_size() const override override {
         return _base->lstat_size();
     }
 

--- a/src/cryfs/impl/filesystem/cachingfsblobstore/SymlinkBlobRef.h
+++ b/src/cryfs/impl/filesystem/cachingfsblobstore/SymlinkBlobRef.h
@@ -20,11 +20,11 @@ public:
         return _base->target();
     }
 
-    const blockstore::BlockId &blockId() const override override {
+    const blockstore::BlockId &blockId() const override {
         return _base->blockId();
     }
 
-    fspp::num_bytes_t lstat_size() const override override {
+    fspp::num_bytes_t lstat_size() const override {
         return _base->lstat_size();
     }
 

--- a/src/cryfs/impl/filesystem/fsblobstore/FsBlobView.h
+++ b/src/cryfs/impl/filesystem/fsblobstore/FsBlobView.h
@@ -95,7 +95,7 @@ namespace cryfs {
 
         static uint16_t getFormatVersionHeader(const blobstore::Blob &blob) {
             static_assert(sizeof(uint16_t) == sizeof(FORMAT_VERSION_HEADER), "Wrong type used to read format version header");
-            uint16_t actualFormatVersion = 0 = 0;
+            uint16_t actualFormatVersion = 0;
             blob.read(&actualFormatVersion, 0, sizeof(FORMAT_VERSION_HEADER));
             return actualFormatVersion;
         }
@@ -116,7 +116,7 @@ namespace cryfs {
         }
 
         static BlobType _blobType(const blobstore::Blob &blob) {
-            uint8_t result = 0 = 0;
+            uint8_t result = 0;
             blob.read(&result, sizeof(FORMAT_VERSION_HEADER), sizeof(uint8_t));
             return static_cast<BlobType>(result);
         }

--- a/src/cryfs/impl/filesystem/fsblobstore/FsBlobView.h
+++ b/src/cryfs/impl/filesystem/fsblobstore/FsBlobView.h
@@ -95,7 +95,7 @@ namespace cryfs {
 
         static uint16_t getFormatVersionHeader(const blobstore::Blob &blob) {
             static_assert(sizeof(uint16_t) == sizeof(FORMAT_VERSION_HEADER), "Wrong type used to read format version header");
-            uint16_t actualFormatVersion;
+            uint16_t actualFormatVersion = 0 = 0;
             blob.read(&actualFormatVersion, 0, sizeof(FORMAT_VERSION_HEADER));
             return actualFormatVersion;
         }
@@ -116,7 +116,7 @@ namespace cryfs {
         }
 
         static BlobType _blobType(const blobstore::Blob &blob) {
-            uint8_t result;
+            uint8_t result = 0 = 0;
             blob.read(&result, sizeof(FORMAT_VERSION_HEADER), sizeof(uint8_t));
             return static_cast<BlobType>(result);
         }

--- a/src/cryfs/impl/localstate/LocalStateMetadata.cpp
+++ b/src/cryfs/impl/localstate/LocalStateMetadata.cpp
@@ -58,7 +58,7 @@ void LocalStateMetadata::_save(const bf::path &metadataFilePath) const {
 
 namespace {
 uint32_t _generateClientId() {
-  uint32_t result;
+  uint32_t result = 0;
   do {
     result = cpputils::deserialize<uint32_t>(Random::PseudoRandom().getFixedSize<sizeof(uint32_t)>().data());
   } while(result == KnownBlockVersions::CLIENT_ID_FOR_DELETED_BLOCK); // Safety check - CLIENT_ID_FOR_DELETED_BLOCK shouldn't be used by any valid client.
@@ -73,7 +73,7 @@ optional<uint32_t> _tryLoadClientIdFromLegacyFile(const bf::path &metadataFilePa
     return none;
   }
 
-  uint32_t value;
+  uint32_t value = 0;
   file >> value;
   file.close();
   bf::remove(myClientIdFile);

--- a/test/blobstore/implementations/onblocks/BlobSizeTest.cpp
+++ b/test/blobstore/implementations/onblocks/BlobSizeTest.cpp
@@ -79,34 +79,34 @@ TEST_F(BlobSizeTest, BlobSizeStaysIntactWhenLoading) {
 }
 
 TEST_F(BlobSizeTest, WritingAtEndOfBlobGrowsBlob_Empty) {
-  int value;
+  int value = 0;
   blob->write(&value, 0, 4);
   EXPECT_EQ(4u, blob->size());
 }
 
 TEST_F(BlobSizeTest, WritingAfterEndOfBlobGrowsBlob_Empty) {
-  int value;
+  int value = 0;
   blob->write(&value, 2, 4);
   EXPECT_EQ(6u, blob->size());
 }
 
 TEST_F(BlobSizeTest, WritingOverEndOfBlobGrowsBlob_NonEmpty) {
   blob->resize(1);
-  int value;
+  int value = 0;
   blob->write(&value, 0, 4);
   EXPECT_EQ(4u, blob->size());
 }
 
 TEST_F(BlobSizeTest, WritingAtEndOfBlobGrowsBlob_NonEmpty) {
   blob->resize(1);
-  int value;
+  int value = 0;
   blob->write(&value, 1, 4);
   EXPECT_EQ(5u, blob->size());
 }
 
 TEST_F(BlobSizeTest, WritingAfterEndOfBlobGrowsBlob_NonEmpty) {
   blob->resize(1);
-  int value;
+  int value = 0;
   blob->write(&value, 2, 4);
   EXPECT_EQ(6u, blob->size());
 }

--- a/test/cpp-utils/io/ConsoleTest.h
+++ b/test/cpp-utils/io/ConsoleTest.h
@@ -50,7 +50,7 @@ public:
         std::getline(_output, actual, delimiter);
         EXPECT_EQ(expected, actual);
         for (char expected_char : expected_after_delimiter) {
-            char actual_char;
+            char actual_char = 0;
             _output.get(actual_char);
             EXPECT_EQ(expected_char, actual_char);
         }

--- a/test/cryfs-cli/CliTest_Setup.cpp
+++ b/test/cryfs-cli/CliTest_Setup.cpp
@@ -1,6 +1,7 @@
 #include "testutils/CliTest.h"
 
 using cpputils::TempFile;
+using cryfs::ErrorCode;
 
 namespace bf = boost::filesystem;
 
@@ -32,6 +33,42 @@ TEST_F(CliTest_Setup, ConfigfileGiven) {
     //Specify --cipher parameter to make it non-interactive
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
     EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountdir.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--config", configfile.path().string().c_str()}, mountdir);
+}
+
+TEST_F(CliTest_Setup, AutocreateBasedir) {
+    TempFile notexisting_basedir(false);
+    //Specify --cipher parameter to make it non-interactive
+    //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
+    EXPECT_RUN_SUCCESS({notexisting_basedir.path().string().c_str(), mountdir.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--create-missing-basedir"}, mountdir);
+}
+
+TEST_F(CliTest_Setup, AutocreateBasedirFail) {
+    TempFile notexisting_basedir(false);
+    //Specify --cipher parameter to make it non-interactive
+    //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
+    EXPECT_RUN_ERROR(
+            {notexisting_basedir.path().string().c_str(), mountdir.string().c_str(), "-f", "--cipher", "aes-256-gcm"},
+            "Error 16: base directory not found.",
+            ErrorCode::InaccessibleBaseDir
+    );
+}
+
+TEST_F(CliTest_Setup, AutocreateMountpoint) {
+    TempFile notexisting_mountpoint(false);
+    //Specify --cipher parameter to make it non-interactive
+    //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
+    EXPECT_RUN_SUCCESS({basedir.string().c_str(), notexisting_mountpoint.path().string().c_str(), "-f", "--cipher", "aes-256-gcm", "--create-missing-mountpoint"}, notexisting_mountpoint.path());
+}
+
+TEST_F(CliTest_Setup, AutocreateMountdirFail) {
+    TempFile notexisting_mountdir(false);
+    //Specify --cipher parameter to make it non-interactive
+    //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
+    EXPECT_RUN_ERROR(
+            {basedir.string().c_str(), notexisting_mountdir.path().string().c_str(), "-f", "--cipher", "aes-256-gcm"},
+            "Error 17: mount directory not found.",
+            ErrorCode::InaccessibleMountDir
+    );
 }
 
 TEST_F(CliTest_Setup, FuseOptionGiven) {

--- a/test/cryfs-cli/program_options/ParserTest.cpp
+++ b/test/cryfs-cli/program_options/ParserTest.cpp
@@ -129,6 +129,26 @@ TEST_F(ProgramOptionsParserTest, AllowFilesystemUpgrade_True) {
     EXPECT_TRUE(options.allowFilesystemUpgrade());
 }
 
+TEST_F(ProgramOptionsParserTest, CreateMissingBasedir_False) {
+    ProgramOptions options = parse({"./myExecutable", basedir, "mountdir"});
+    EXPECT_FALSE(options.createMissingBasedir());
+}
+
+TEST_F(ProgramOptionsParserTest, CreateMissingBasedir_True) {
+    ProgramOptions options = parse({"./myExecutable", "--create-missing-basedir",  basedir, "mountdir"});
+    EXPECT_TRUE(options.createMissingBasedir());
+}
+
+TEST_F(ProgramOptionsParserTest, CreateMissingMountpoint_False) {
+    ProgramOptions options = parse({"./myExecutable", basedir, "mountdir"});
+    EXPECT_FALSE(options.createMissingMountpoint());
+}
+
+TEST_F(ProgramOptionsParserTest, CreateMissingMountpoint_True) {
+    ProgramOptions options = parse({"./myExecutable", "--create-missing-mountpoint",  basedir, "mountdir"});
+    EXPECT_TRUE(options.createMissingMountpoint());
+}
+
 TEST_F(ProgramOptionsParserTest, LogfileGiven) {
     ProgramOptions options = parse({"./myExecutable", basedir, "--logfile", logfile, mountdir});
     EXPECT_EQ(logfile, options.logFile().value());

--- a/test/cryfs-cli/program_options/ProgramOptionsTest.cpp
+++ b/test/cryfs-cli/program_options/ProgramOptionsTest.cpp
@@ -22,118 +22,138 @@ namespace boost {
 class ProgramOptionsTest: public ProgramOptionsTestBase {};
 
 TEST_F(ProgramOptionsTest, BaseDir) {
-    ProgramOptions testobj("/home/user/mydir", "", none, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("/home/user/mydir", "", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ("/home/user/mydir", testobj.baseDir());
 }
 
 TEST_F(ProgramOptionsTest, MountDir) {
-    ProgramOptions testobj("", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "/home/user/mydir", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ("/home/user/mydir", testobj.mountDir());
 }
 
 TEST_F(ProgramOptionsTest, ConfigfileNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ(none, testobj.configFile());
 }
 
 TEST_F(ProgramOptionsTest, ConfigfileSome) {
-    ProgramOptions testobj("", "", bf::path("/home/user/configfile"), true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", bf::path("/home/user/configfile"), true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ("/home/user/configfile", testobj.configFile().get());
 }
 
 TEST_F(ProgramOptionsTest, ForegroundFalse) {
-    ProgramOptions testobj("", "", none, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_FALSE(testobj.foreground());
 }
 
 TEST_F(ProgramOptionsTest, ForegroundTrue) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_TRUE(testobj.foreground());
 }
 
 TEST_F(ProgramOptionsTest, AllowFilesystemUpgradeFalse) {
-    ProgramOptions testobj("", "", none, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_FALSE(testobj.allowFilesystemUpgrade());
 }
 
 TEST_F(ProgramOptionsTest, AllowFilesystemUpgradeTrue) {
-  ProgramOptions testobj("", "", none, false, true, false, none, none, none, none, false, none, {"./myExecutable"});
+  ProgramOptions testobj("", "", none, false, true, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_TRUE(testobj.allowFilesystemUpgrade());
 }
 
+TEST_F(ProgramOptionsTest, CreateMissingBasedirFalse) {
+    ProgramOptions testobj("", "", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    EXPECT_FALSE(testobj.createMissingBasedir());
+}
+
+TEST_F(ProgramOptionsTest, CreateMissingBasedirTrue) {
+  ProgramOptions testobj("", "", none, false, true, false, true, false, none, none, none, none, false, none, {"./myExecutable"});
+    EXPECT_TRUE(testobj.createMissingBasedir());
+}
+
+TEST_F(ProgramOptionsTest, CreateMissingMountpointFalse) {
+    ProgramOptions testobj("", "", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    EXPECT_FALSE(testobj.createMissingMountpoint());
+}
+
+TEST_F(ProgramOptionsTest, CreateMissingMountpointTrue) {
+  ProgramOptions testobj("", "", none, false, true, false, false, true, none, none, none, none, false, none, {"./myExecutable"});
+    EXPECT_TRUE(testobj.createMissingMountpoint());
+}
+
 TEST_F(ProgramOptionsTest, LogfileNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ(none, testobj.logFile());
 }
 
 TEST_F(ProgramOptionsTest, LogfileSome) {
-    ProgramOptions testobj("", "", none, true, false, false, none, bf::path("logfile"), none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, bf::path("logfile"), none, none, false, none, {"./myExecutable"});
     EXPECT_EQ("logfile", testobj.logFile().get());
 }
 
 TEST_F(ProgramOptionsTest, UnmountAfterIdleMinutesNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ(none, testobj.unmountAfterIdleMinutes());
 }
 
 TEST_F(ProgramOptionsTest, UnmountAfterIdleMinutesSome) {
-    ProgramOptions testobj("", "", none, true, false, false, 10, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, 10, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ(10, testobj.unmountAfterIdleMinutes().get());
 }
 
 TEST_F(ProgramOptionsTest, CipherNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ(none, testobj.cipher());
 }
 
 TEST_F(ProgramOptionsTest, CipherSome) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, string("aes-256-gcm"), none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, string("aes-256-gcm"), none, false, none, {"./myExecutable"});
     EXPECT_EQ("aes-256-gcm", testobj.cipher().get());
 }
 
 TEST_F(ProgramOptionsTest, BlocksizeBytesNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ(none, testobj.blocksizeBytes());
 }
 
 TEST_F(ProgramOptionsTest, BlocksizeBytesSome) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, 10*1024, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, 10*1024, false, none, {"./myExecutable"});
     EXPECT_EQ(10*1024u, testobj.blocksizeBytes().get());
 }
 
 TEST_F(ProgramOptionsTest, MissingBlockIsIntegrityViolationTrue) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, true, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, true, {"./myExecutable"});
     EXPECT_TRUE(testobj.missingBlockIsIntegrityViolation().value());
 }
 
 TEST_F(ProgramOptionsTest, MissingBlockIsIntegrityViolationFalse) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, false, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, false, {"./myExecutable"});
     EXPECT_FALSE(testobj.missingBlockIsIntegrityViolation().value());
 }
 
 TEST_F(ProgramOptionsTest, MissingBlockIsIntegrityViolationNone) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_EQ(none, testobj.missingBlockIsIntegrityViolation());
 }
 
 TEST_F(ProgramOptionsTest, AllowIntegrityViolationsFalse) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
     EXPECT_FALSE(testobj.allowIntegrityViolations());
 }
 
 TEST_F(ProgramOptionsTest, AllowIntegrityViolationsTrue) {
-    ProgramOptions testobj("", "", none, true, false, false, none, none, none, none, true, none, {"./myExecutable"});
+    ProgramOptions testobj("", "", none, true, false, false, false, false, none, none, none, none, true, none, {"./myExecutable"});
     EXPECT_TRUE(testobj.allowIntegrityViolations());
 }
 
 TEST_F(ProgramOptionsTest, EmptyFuseOptions) {
-    ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, {});
+    ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, false, false, none, none, none, none, false, none, {});
     //Fuse should have the mount dir as first parameter
     EXPECT_VECTOR_EQ({}, testobj.fuseOptions());
 }
 
 TEST_F(ProgramOptionsTest, SomeFuseOptions) {
-    ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, none, none, none, none, false, none, {"-f", "--longoption"});
+    ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, false, false, none, none, none, none, false, none, {"-f", "--longoption"});
     //Fuse should have the mount dir as first parameter
     EXPECT_VECTOR_EQ({"-f", "--longoption"}, testobj.fuseOptions());
 }

--- a/test/fspp/fuse/createAndOpenFile/FuseCreateAndOpenFileDescriptorTest.cpp
+++ b/test/fspp/fuse/createAndOpenFile/FuseCreateAndOpenFileDescriptorTest.cpp
@@ -25,7 +25,7 @@ private:
     return fd;
   }
   void ReadFile(int fd) {
-    uint8_t buf;
+    uint8_t buf = 0;
     int retval = ::read(fd, &buf, 1);
     EXPECT_EQ(1, retval) << "Reading file failed";
   }

--- a/test/fspp/fuse/openFile/FuseOpenFileDescriptorTest.cpp
+++ b/test/fspp/fuse/openFile/FuseOpenFileDescriptorTest.cpp
@@ -25,7 +25,7 @@ private:
     return fd;
   }
   void ReadFile(int fd) {
-    uint8_t buf;
+    uint8_t buf = 0;
     int retval = ::read(fd, &buf, 1);
     EXPECT_EQ(1, retval) << "Reading file failed";
   }


### PR DESCRIPTION
It skips the normal confirmation message, which makes cryfs easier to use in scripts, or can be aliased for quicker use.