### PR TITLE
Support the latest FUSE on macOS

### DIFF
--- a/.github/workflows/actions/osx_setup/action.yaml
+++ b/.github/workflows/actions/osx_setup/action.yaml
@@ -10,7 +10,7 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        brew install ninja osxfuse libomp ${{inputs.compiler_homebrew_package}}
+        brew install ninja macfuse libomp ${{inputs.compiler_homebrew_package}}
         pip3 install conan
         conan profile new default --detect
         conan profile update settings.compiler.libcxx=libstdc++11 default

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CryFS is distributed via Homebrew and MacPorts.
 
 If you use Homebrew:
 
-    brew cask install osxfuse
+    brew install osxfuse
     brew install cryfs
 
 If you use MacPorts (not available for OSX 10.15 at the moment):
@@ -74,7 +74,7 @@ Requirements
   - Conan package manager
   - libcurl4 (including development headers)
   - SSL development libraries (including development headers, e.g. libssl-dev)
-  - libFUSE version >= 2.8.6 (including development headers), on Mac OS X instead install osxfuse from https://osxfuse.github.io/
+  - libFUSE version >= 2.8.6 (including development headers), on Mac OS X instead install macFUSE from https://osxfuse.github.io/
   - Python >= 3.5
   - OpenMP
 
@@ -133,13 +133,13 @@ On most systems, CMake should find the libraries automatically. However, that do
 
     Pass in the library path with
 
-        cmake .. -DFUSE_LIB_PATH=/path/to/fuse/or/osxfuse
+        cmake .. -DFUSE_LIB_PATH=/path/to/fuse/or/macFUSE
 
 2. **Fuse/Osxfuse headers not found**
 
     Pass in the include path with
 
-        cmake .. -DCMAKE_CXX_FLAGS="-I/path/to/fuse/or/osxfuse/headers"
+        cmake .. -DCMAKE_CXX_FLAGS="-I/path/to/fuse/or/macFUSE/headers"
 
 3. **Openssl headers not found**
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Requirements
   - Git (for getting the source code)
   - GCC version >= 7 or Clang >= 7
   - CMake version >= 3.10
+  - pkg-config (on Unix)
   - Conan package manager
   - libcurl4 (including development headers)
   - SSL development libraries (including development headers, e.g. libssl-dev)
@@ -81,15 +82,15 @@ Requirements
 You can use the following commands to install these requirements
 
         # Ubuntu
-        $ sudo apt install git g++ cmake make libcurl4-openssl-dev libssl-dev libfuse-dev python python3-pip
+        $ sudo apt install git g++ cmake make pkg-config libcurl4-openssl-dev libssl-dev libfuse-dev python python3-pip
         $ sudo pip3 install conan
 
         # Fedora
-        $ sudo dnf install git gcc-c++ cmake make libcurl-devel openssl-devel fuse-devel python python3-pip
+        $ sudo dnf install git gcc-c++ cmake make pkgconf libcurl-devel openssl-devel fuse-devel python python3-pip
         $ sudo pip3 install conan
 
         # Macintosh
-        $ brew install cmake openssl libomp
+        $ brew install cmake pkg-config openssl libomp
         $ sudo pip3 install conan
 
 Build & Install
@@ -129,17 +130,17 @@ Troubleshooting
 
 On most systems, CMake should find the libraries automatically. However, that doesn't always work.
 
-1. **Fuse/Osxfuse library not found**
+1. **Fuse library not found**
 
     Pass in the library path with
 
-        cmake .. -DFUSE_LIB_PATH=/path/to/fuse/or/macFUSE
+        PKG_CONFIG_PATH=/path-to-fuse-or-macFUSE/lib/pkgconfig cmake ..
 
-2. **Fuse/Osxfuse headers not found**
+2. **Fuse headers not found**
 
     Pass in the include path with
 
-        cmake .. -DCMAKE_CXX_FLAGS="-I/path/to/fuse/or/macFUSE/headers"
+        PKG_CONFIG_PATH=/path-to-fuse-or-macFUSE/lib/pkgconfig cmake ..
 
 3. **Openssl headers not found**
 

--- a/cmake-utils/utils.cmake
+++ b/cmake-utils/utils.cmake
@@ -130,33 +130,6 @@ function(require_clang_version VERSION)
     endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endfunction(require_clang_version)
 
-##################################################
-# Find the location of a library and return its full path in OUTPUT_VARIABLE.
-# If PATH_VARIABLE points to a defined variable, then the library will only be searched in this path.
-# If PATH_VARIABLE points to a undefined variable, default system locations will be searched.
-#
-# Uses (the following will search for fuse in system locations by default, and if the user passes -DFUSE_LIB_PATH to cmake, it will only search in this path.
-#  find_library_with_path(MYLIBRARY fuse FUSE_LIB_PATH)
-#  target_link_library(target ${MYLIBRARY})
-##################################################
-function(find_library_with_path OUTPUT_VARIABLE LIBRARY_NAME PATH_VARIABLE)
-    if(${PATH_VARIABLE})
-        find_library(${OUTPUT_VARIABLE} ${LIBRARY_NAME} PATHS ${${PATH_VARIABLE}} NO_DEFAULT_PATH)
-        if (${OUTPUT_VARIABLE} MATCHES NOTFOUND)
-            message(FATAL_ERROR "Didn't find ${LIBRARY_NAME} in path specified by the ${PATH_VARIABLE} parameter (${${PATH_VARIABLE}}). Pass in the correct path or remove the parameter to try common system locations.")
-        else(${OUTPUT_VARIABLE} MATCHES NOTFOUND)
-            message(STATUS "Found ${LIBRARY_NAME} in user-defined path ${${PATH_VARIABLE}}")
-        endif(${OUTPUT_VARIABLE} MATCHES NOTFOUND)
-    else(${PATH_VARIABLE})
-        find_library(${OUTPUT_VARIABLE} ${LIBRARY_NAME})
-        if (${OUTPUT_VARIABLE} MATCHES NOTFOUND)
-            message(FATAL_ERROR "Didn't find ${LIBRARY_NAME} library. If ${LIBRARY_NAME} is installed, try passing in the library location with -D${PATH_VARIABLE}=/path/to/${LIBRARY_NAME}/lib.")
-        else(${OUTPUT_VARIABLE} MATCHES NOTFOUND)
-            message(STATUS "Found ${LIBRARY_NAME} in system location")
-        endif(${OUTPUT_VARIABLE} MATCHES NOTFOUND)
-    endif(${PATH_VARIABLE})
-endfunction(find_library_with_path)
-
 include(cmake-utils/TargetArch.cmake)
 function(get_target_architecture output_var)
 	target_architecture(local_output_var)

--- a/src/fspp/fuse/CMakeLists.txt
+++ b/src/fspp/fuse/CMakeLists.txt
@@ -35,13 +35,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     DESTINATION "${CMAKE_INSTALL_BINDIR}"
   )
 
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set(CMAKE_FIND_FRAMEWORK LAST)
-  find_library_with_path(FUSE "osxfuse" FUSE_LIB_PATH)
-  target_link_libraries(${PROJECT_NAME} PUBLIC ${FUSE})
-  target_include_directories(${PROJECT_NAME} PUBLIC /usr/local/include/osxfuse/)
-else() # Linux
+else() # Linux and macOS
   find_library_with_path(FUSE "fuse" FUSE_LIB_PATH)
+  target_include_directories(${PROJECT_NAME} PUBLIC "${FUSE_LIB_PATH}/include")
   target_link_libraries(${PROJECT_NAME} PUBLIC ${FUSE})
 endif()
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(CMAKE_FIND_FRAMEWORK LAST)
+endif()

--- a/src/fspp/fuse/CMakeLists.txt
+++ b/src/fspp/fuse/CMakeLists.txt
@@ -36,9 +36,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   )
 
 else() # Linux and macOS
-  find_library_with_path(FUSE "fuse" FUSE_LIB_PATH)
-  target_include_directories(${PROJECT_NAME} PUBLIC "${FUSE_LIB_PATH}/include")
-  target_link_libraries(${PROJECT_NAME} PUBLIC ${FUSE})
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(Fuse REQUIRED IMPORTED_TARGET fuse)
+  target_link_libraries(${PROJECT_NAME} PUBLIC PkgConfig::Fuse)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/src/fspp/fuse/Fuse.cpp
+++ b/src/fspp/fuse/Fuse.cpp
@@ -435,7 +435,7 @@ vector<char *> Fuse::_build_argv(const bf::path &mountdir, const vector<string> 
   // Make volume name default to mountdir on macOS
   _add_fuse_option_if_not_exists(&argv, "volname", mountdir.filename().string());
 #endif
-  // TODO Also set read/write size for osxfuse. The options there are called differently.
+  // TODO Also set read/write size for macFUSE. The options there are called differently.
   // large_read not necessary because reads are large anyhow. This option is only important for 2.4.
   //argv.push_back(_create_c_string("-o"));
   //argv.push_back(_create_c_string("large_read"));

--- a/src/fspp/impl/FilesystemImpl.cpp
+++ b/src/fspp/impl/FilesystemImpl.cpp
@@ -325,7 +325,7 @@ void FilesystemImpl::statfs(struct ::statvfs *fsstat) {
   fsstat->f_namemax = stat.max_filename_length;
 
   //f_frsize, f_favail, f_fsid and f_flag are ignored in fuse, see http://fuse.sourcearchive.com/documentation/2.7.0/structfuse__operations_4e765e29122e7b6b533dc99849a52655.html#4e765e29122e7b6b533dc99849a52655
-  fsstat->f_frsize = fsstat->f_bsize; // even though this is supposed to be ignored, osxfuse needs it.
+  fsstat->f_frsize = fsstat->f_bsize; // even though this is supposed to be ignored, macFUSE needs it.
 }
 
 void FilesystemImpl::createSymlink(const bf::path &to, const bf::path &from, ::uid_t uid, ::gid_t gid) {

--- a/test/fspp/testutils/FuseThread.cpp
+++ b/test/fspp/testutils/FuseThread.cpp
@@ -23,7 +23,7 @@ void FuseThread::start(const bf::path &mountDir, const vector<string> &fuseOptio
   //Wait until it is running (busy waiting is simple and doesn't hurt much here)
   while(!_fuse->running()) {}
 #ifdef __APPLE__
-  // On Mac OS X, _fuse->running() returns true too early, because osxfuse calls init() when it's not ready yet. Give it a bit time.
+  // On Mac OS X, _fuse->running() returns true too early, because macFUSE calls init() when it's not ready yet. Give it a bit time.
   std::this_thread::sleep_for(std::chrono::milliseconds(200));
 #endif
 }


### PR DESCRIPTION
This drops osxfuse support in favor of macFUSE. macFUSE is a newer version of osxfuse that supports the latest release of macOS, and is a rebranded version of the same project.
