### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ CryFS is distributed via Homebrew and MacPorts.
 
 If you use Homebrew:
 
-    brew cask install osxfuse
+    brew install --cask osxfuse
     brew install cryfs
 
 If you use MacPorts (not available for OSX 10.15 at the moment):


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524