### PR TITLE
Add instructions for arch-based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This only works for Ubuntu 17.04 and later, and Debian Stretch and later.
 You can also use CryFS on older versions of these distributions by following the **Building from source** instructions below.
 
     sudo apt install cryfs
+    
+The following should work on Arch and Arch-based distros:
+    
+    sudo pacman -S cryfs
 
 Additionally, the following would work for any Linux distro with the Nix package manager:
 


### PR DESCRIPTION
Added instructions for using pacman on arch-based distros. If it doesn't make enough sense please feel free to apply any changes.