### PR TITLE
src/fspp/fuse/Fuse.h: add <memory.h> include for std::shared_ptr

### DIFF
--- a/src/fspp/fuse/Fuse.h
+++ b/src/fspp/fuse/Fuse.h
@@ -11,6 +11,7 @@
 #include <boost/optional.hpp>
 #include <cpp-utils/macros.h>
 #include <atomic>
+#include <memory>
 #include "stat_compatibility.h"
 #include <fspp/fs_interface/Context.h>
 


### PR DESCRIPTION
Needed to fix build with Boost 1.77 (some indirect inclusion
got lost).

Noticed in Gentoo.

Signed-off-by: Sam James <sam@gentoo.org>