### PR TITLE
Don't limit install on Release/Debug/RelWithDebInfo CONFIGURATIONS

### DIFF
--- a/src/cryfs-cli/CMakeLists.txt
+++ b/src/cryfs-cli/CMakeLists.txt
@@ -27,6 +27,5 @@ target_enable_style_warnings(${PROJECT_NAME}_bin)
 target_activate_cpp14(${PROJECT_NAME}_bin)
 
 install(TARGETS ${PROJECT_NAME}_bin
-        CONFIGURATIONS Debug Release RelWithDebInfo
         DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/src/cryfs-unmount/CMakeLists.txt
+++ b/src/cryfs-unmount/CMakeLists.txt
@@ -20,6 +20,5 @@ target_enable_style_warnings(${PROJECT_NAME}_bin)
 target_activate_cpp14(${PROJECT_NAME}_bin)
 
 install(TARGETS ${PROJECT_NAME}_bin
-		CONFIGURATIONS Debug Release RelWithDebInfo
-		DESTINATION ${CMAKE_INSTALL_BINDIR}
+        DESTINATION ${CMAKE_INSTALL_BINDIR}
 )


### PR DESCRIPTION
Upstreaming a patch from downstream Gentoo. We use a custom build type ("Gentoo"), so this is needed to install in that case.