### PR TITLE
minor: shebang python -> python3

### DIFF
--- a/src/gitversion/getversion.py
+++ b/src/gitversion/getversion.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import versioneer
 

--- a/src/gitversion/setup.py
+++ b/src/gitversion/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup
 import versioneer


### PR DESCRIPTION
Align with https://github.com/cryfs/cryfs/pull/413

Macs and some distros no longer have `python` available by default.