### PR TITLE
Include stdexcept when using logic_error

### DIFF
--- a/src/cpp-utils/thread/LeftRight.h
+++ b/src/cpp-utils/thread/LeftRight.h
@@ -4,6 +4,7 @@
 #include <thread>
 #include <cpp-utils/macros.h>
 #include <array>
+#include <stdexcept>
 
 namespace cpputils {
 


### PR DESCRIPTION
Build of cryfs on Fedora Rawhide fails with this error:

    FAILED: src/cpp-utils/CMakeFiles/cpp-utils.dir/thread/LeftRight.cpp.o 
    /usr/bin/g++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CHRONO_DYN_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_FILESYSTEM_DYN_LINK -DBOOST_FILESYSTEM_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_STACKTRACE_ADDR2LINE_LOCATION=/usr/bin/addr2line -DBOOST_STACKTRACE_USE_ADDR2LINE -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_VERSION=4 -DFMT_SHARED -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -I/builddir/build/BUILD/cryfs-0.11.3/src -I/builddir/build/BUILD/cryfs-0.11.3/vendor/cryptopp/vendor_cryptopp -isystem /builddir/build/BUILD/cryfs-0.11.3/vendor/cryptopp -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -DNDEBUG -std=gnu++14 -fPIC -Wall -Wextra -Wold-style-cast -Wcast-align -Wno-maybe-uninitialized -fopenmp -MD -MT src/cpp-utils/CMakeFiles/cpp-utils.dir/thread/LeftRight.cpp.o -MF src/cpp-utils/CMakeFiles/cpp-utils.dir/thread/LeftRight.cpp.o.d -o src/cpp-utils/CMakeFiles/cpp-utils.dir/thread/LeftRight.cpp.o -c /builddir/build/BUILD/cryfs-0.11.3/src/cpp-utils/thread/LeftRight.cpp
    In file included from /builddir/build/BUILD/cryfs-0.11.3/src/cpp-utils/thread/LeftRight.cpp:1:
    /builddir/build/BUILD/cryfs-0.11.3/src/cpp-utils/thread/LeftRight.h: In member function 'auto cpputils::LeftRight<T>::read(F&&) const':
    /builddir/build/BUILD/cryfs-0.11.3/src/cpp-utils/thread/LeftRight.h:54:24: error: 'logic_error' is not a member of 'std'
       54 |             throw std::logic_error("Issued LeftRight::read() after the destructor started running");
          |                        ^~~~~~~~~~~
    /builddir/build/BUILD/cryfs-0.11.3/src/cpp-utils/thread/LeftRight.h:7:1: note: 'std::logic_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?
        6 | #include <array>
      +++ |+#include <stdexcept>
        7 | 
    /builddir/build/BUILD/cryfs-0.11.3/src/cpp-utils/thread/LeftRight.h: In member function 'auto cpputils::LeftRight<T>::write(F&&)':
    /builddir/build/BUILD/cryfs-0.11.3/src/cpp-utils/thread/LeftRight.h:67:24: error: 'logic_error' is not a member of 'std'
       67 |             throw std::logic_error("Issued LeftRight::read() after the destructor started running");
          |                        ^~~~~~~~~~~
    /builddir/build/BUILD/cryfs-0.11.3/src/cpp-utils/thread/LeftRight.h:67:24: note: 'std::logic_error' is defined in header '<stdexcept>'; did you forget to '#include <stdexcept>'?

I don't know what exactly triggered this, whether it's a newer gcc or some change in the includes in cryfs or what, but it's broken, and this fixes it.