### PR TITLE
Don't resolve symlinks in base dir path

### DIFF
--- a/src/cryfs/impl/localstate/BasedirMetadata.cpp
+++ b/src/cryfs/impl/localstate/BasedirMetadata.cpp
@@ -44,7 +44,7 @@ void _save(const bf::path &metadataFilePath, const ptree& data) {
 }
 
 string jsonPathForBasedir(const bf::path &basedir) {
-  return bf::canonical(basedir).string() + ".filesystemId";
+  return bf::absolute(basedir).lexically_normal().string() + ".filesystemId";
 }
 
 }


### PR DESCRIPTION
Solve https://github.com/hardcore-sushi/DroidFS/issues/281.

Related discussion: #472

Might weaken security if some users open volumes via symbolic links, but this will improve compatibility with strict access controls policies such as implemented using SELinux on Android.