### PR TITLE
cryfs: add inital support for system-based packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ require_clang_version(7.0)
 option(BUILD_TESTING "build test cases" OFF)
 option(CRYFS_UPDATE_CHECKS "let cryfs check for updates and security vulnerabilities" ON)
 option(DISABLE_OPENMP "allow building without OpenMP libraries. This will cause performance degradations." OFF)
+option(USE_SYSTEM_LIBS "build with system libs instead of bundled libs" OFF)
 
 # The following options are helpful for development and/or CI
 option(USE_WERROR "build with -Werror flag")
@@ -41,7 +42,20 @@ endif()
 
 include(cmake-utils/Dependencies.cmake)
 
-add_subdirectory(vendor EXCLUDE_FROM_ALL)
+if(USE_SYSTEM_LIBS)
+    include(FindPkgConfig)
+    pkg_check_modules(CRYPTOPP REQUIRED libcryptopp>=8.2)
+    if(BUILD_TESTING)
+        find_package(GTest CONFIG REQUIRED)
+        set(GOOGLETEST_LIBS GTest::gtest GTest::gmock)
+    endif()
+
+    add_definitions(-DUSE_SYSTEM_LIBS)
+else()
+    add_subdirectory(vendor EXCLUDE_FROM_ALL)
+    set(GOOGLETEST_LIBS googletest)
+endif()
+
 add_subdirectory(src)
 add_subdirectory(doc)
 add_subdirectory(test)

--- a/src/blockstore/implementations/compressing/compressors/Gzip.cpp
+++ b/src/blockstore/implementations/compressing/compressors/Gzip.cpp
@@ -1,5 +1,9 @@
 #include "Gzip.h"
-#include <vendor_cryptopp/gzip.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/gzip.h>
+#else
+    #include <vendor_cryptopp/gzip.h>
+#endif
 
 using cpputils::Data;
 

--- a/src/cpp-utils/crypto/hash/Hash.cpp
+++ b/src/cpp-utils/crypto/hash/Hash.cpp
@@ -1,6 +1,10 @@
 #include "Hash.h"
 #include <cpp-utils/random/Random.h>
-#include <vendor_cryptopp/sha.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/sha.h>
+#else
+    #include <vendor_cryptopp/sha.h>
+#endif
 
 using CryptoPP::SHA512;
 

--- a/src/cpp-utils/crypto/kdf/Scrypt.cpp
+++ b/src/cpp-utils/crypto/kdf/Scrypt.cpp
@@ -1,5 +1,9 @@
 #include "Scrypt.h"
-#include <vendor_cryptopp/scrypt.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/scrypt.h>
+#else
+    #include <vendor_cryptopp/scrypt.h>
+#endif
 
 using std::string;
 

--- a/src/cpp-utils/crypto/symmetric/CFB_Cipher.h
+++ b/src/cpp-utils/crypto/symmetric/CFB_Cipher.h
@@ -6,7 +6,11 @@
 #include "../../data/Data.h"
 #include "../../random/Random.h"
 #include <boost/optional.hpp>
-#include <vendor_cryptopp/modes.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/modes.h>
+#else
+    #include <vendor_cryptopp/modes.h>
+#endif
 #include "Cipher.h"
 #include "EncryptionKey.h"
 

--- a/src/cpp-utils/crypto/symmetric/GCM_Cipher.h
+++ b/src/cpp-utils/crypto/symmetric/GCM_Cipher.h
@@ -3,13 +3,16 @@
 #define MESSMER_CPPUTILS_CRYPTO_SYMMETRIC_GCMCIPHER_H_
 
 #include "AEAD_Cipher.h"
-#include <vendor_cryptopp/gcm.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/gcm.h>
+#else
+    #include <vendor_cryptopp/gcm.h>
+#endif
 
 namespace cpputils {
 
 template<typename BlockCipher, unsigned int KeySize>
 using GCM_Cipher = AEADCipher<CryptoPP::GCM<BlockCipher, CryptoPP::GCM_64K_Tables>, KeySize, BlockCipher::BLOCKSIZE, 16>;
-    
 }
 
 #endif

--- a/src/cpp-utils/crypto/symmetric/ciphers.h
+++ b/src/cpp-utils/crypto/symmetric/ciphers.h
@@ -2,12 +2,21 @@
 #ifndef MESSMER_CPPUTILS_CRYPTO_SYMMETRIC_CIPHERS_H_
 #define MESSMER_CPPUTILS_CRYPTO_SYMMETRIC_CIPHERS_H_
 
-#include <vendor_cryptopp/aes.h>
-#include <vendor_cryptopp/twofish.h>
-#include <vendor_cryptopp/serpent.h>
-#include <vendor_cryptopp/cast.h>
-#include <vendor_cryptopp/mars.h>
-#include <vendor_cryptopp/chachapoly.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/aes.h>
+    #include <cryptopp/twofish.h>
+    #include <cryptopp/serpent.h>
+    #include <cryptopp/cast.h>
+    #include <cryptopp/mars.h>
+    #include <cryptopp/chachapoly.h>
+#else
+    #include <vendor_cryptopp/aes.h>
+    #include <vendor_cryptopp/twofish.h>
+    #include <vendor_cryptopp/serpent.h>
+    #include <vendor_cryptopp/cast.h>
+    #include <vendor_cryptopp/mars.h>
+    #include <vendor_cryptopp/chachapoly.h>
+#endif
 #include "GCM_Cipher.h"
 #include "CFB_Cipher.h"
 

--- a/src/cpp-utils/data/Data.cpp
+++ b/src/cpp-utils/data/Data.cpp
@@ -1,6 +1,10 @@
 #include "Data.h"
 #include <stdexcept>
-#include <vendor_cryptopp/hex.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/hex.h>
+#else
+    #include <vendor_cryptopp/hex.h>
+#endif
 
 using std::istream;
 using std::ofstream;

--- a/src/cpp-utils/data/FixedSizeData.h
+++ b/src/cpp-utils/data/FixedSizeData.h
@@ -2,7 +2,11 @@
 #ifndef MESSMER_CPPUTILS_DATA_FIXEDSIZEDATA_H_
 #define MESSMER_CPPUTILS_DATA_FIXEDSIZEDATA_H_
 
-#include <vendor_cryptopp/hex.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/hex.h>
+#else
+    #include <vendor_cryptopp/hex.h>
+#endif
 #include <string>
 #include <array>
 #include <cstring>

--- a/src/cpp-utils/random/OSRandomGenerator.h
+++ b/src/cpp-utils/random/OSRandomGenerator.h
@@ -3,7 +3,11 @@
 #define MESSMER_CPPUTILS_RANDOM_OSRANDOMGENERATOR_H
 
 #include "RandomGenerator.h"
-#include <vendor_cryptopp/osrng.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/osrng.h>
+#else
+    #include <vendor_cryptopp/osrng.h>
+#endif
 
 namespace cpputils {
     class OSRandomGenerator final : public RandomGenerator {

--- a/src/cpp-utils/random/RandomGeneratorThread.h
+++ b/src/cpp-utils/random/RandomGeneratorThread.h
@@ -4,7 +4,11 @@
 
 #include "../thread/LoopThread.h"
 #include "ThreadsafeRandomDataBuffer.h"
-#include <vendor_cryptopp/osrng.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/osrng.h>
+#else
+    #include <vendor_cryptopp/osrng.h>
+#endif
 
 namespace cpputils {
     //TODO Test

--- a/src/cryfs/impl/localstate/BasedirMetadata.cpp
+++ b/src/cryfs/impl/localstate/BasedirMetadata.cpp
@@ -1,7 +1,11 @@
 #include "BasedirMetadata.h"
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/json_parser.hpp>
-#include <vendor_cryptopp/sha.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/sha.h>
+#else
+    #include <vendor_cryptopp/sha.h>
+#endif
 #include <boost/filesystem/operations.hpp>
 #include "LocalStateDir.h"
 #include <cpp-utils/logging/logging.h>

--- a/test/blobstore/CMakeLists.txt
+++ b/test/blobstore/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SOURCES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} my-gtest-main blobstore)
+target_link_libraries(${PROJECT_NAME} my-gtest-main ${GOOGLETEST_LIBS} blobstore)
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 
 target_enable_style_warnings(${PROJECT_NAME})

--- a/test/blockstore/CMakeLists.txt
+++ b/test/blockstore/CMakeLists.txt
@@ -42,7 +42,7 @@ set(SOURCES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} my-gtest-main blockstore)
+target_link_libraries(${PROJECT_NAME} my-gtest-main ${GOOGLETEST_LIBS} blockstore)
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 
 target_enable_style_warnings(${PROJECT_NAME})

--- a/test/cpp-utils/CMakeLists.txt
+++ b/test/cpp-utils/CMakeLists.txt
@@ -71,7 +71,7 @@ target_activate_cpp14(${PROJECT_NAME}_exit_signal)
 target_link_libraries(${PROJECT_NAME}_exit_signal cpp-utils)
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} my-gtest-main cpp-utils)
+target_link_libraries(${PROJECT_NAME} my-gtest-main ${GOOGLETEST_LIBS} cpp-utils)
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_exit_status ${PROJECT_NAME}_exit_signal)
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 

--- a/test/cryfs-cli/CMakeLists.txt
+++ b/test/cryfs-cli/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SOURCES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} my-gtest-main cryfs-cli_lib cryfs-unmount_lib fspp-fuse)
+target_link_libraries(${PROJECT_NAME} my-gtest-main ${GOOGLETEST_LIBS} cryfs-cli cryfs-unmount fspp-fuse)
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 
 target_enable_style_warnings(${PROJECT_NAME})

--- a/test/cryfs/CMakeLists.txt
+++ b/test/cryfs/CMakeLists.txt
@@ -26,7 +26,7 @@ set(SOURCES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} my-gtest-main cryfs)
+target_link_libraries(${PROJECT_NAME} my-gtest-main ${GOOGLETEST_LIBS} cryfs)
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 
 target_enable_style_warnings(${PROJECT_NAME})

--- a/test/cryfs/impl/config/CompatibilityTest.cpp
+++ b/test/cryfs/impl/config/CompatibilityTest.cpp
@@ -2,7 +2,11 @@
 #include <vector>
 #include <boost/filesystem.hpp>
 #include <cpp-utils/data/Data.h>
-#include <vendor_cryptopp/hex.h>
+#if defined(USE_SYSTEM_LIBS)
+    #include <cryptopp/hex.h>
+#else
+    #include <vendor_cryptopp/hex.h>
+#endif
 #include <cpp-utils/crypto/symmetric/ciphers.h>
 #include <cpp-utils/tempfile/TempFile.h>
 #include <cryfs/impl/config/CryConfigFile.h>

--- a/test/fspp/CMakeLists.txt
+++ b/test/fspp/CMakeLists.txt
@@ -103,7 +103,7 @@ set(SOURCES
         testutils/OpenFileHandle.cpp testutils/OpenFileHandle.h)
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} my-gtest-main fspp-interface fspp-fuse)
+target_link_libraries(${PROJECT_NAME} my-gtest-main ${GOOGLETEST_LIBS} fspp-interface fspp-fuse)
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 
 target_enable_style_warnings(${PROJECT_NAME})

--- a/test/gitversion/CMakeLists.txt
+++ b/test/gitversion/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SOURCES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} my-gtest-main gitversion)
+target_link_libraries(${PROJECT_NAME} my-gtest-main ${GOOGLETEST_LIBS} gitversion)
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 
 target_enable_style_warnings(${PROJECT_NAME})

--- a/test/my-gtest-main/CMakeLists.txt
+++ b/test/my-gtest-main/CMakeLists.txt
@@ -5,7 +5,7 @@ set(SOURCES
 )
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES})
-target_link_libraries(${PROJECT_NAME} PUBLIC CryfsDependencies_gtest cpp-utils)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${GOOGLETEST_LIBS} cpp-utils)
 target_add_boost(${PROJECT_NAME} filesystem system)
 target_include_directories(${PROJECT_NAME} PUBLIC .)
 

--- a/test/parallelaccessstore/CMakeLists.txt
+++ b/test/parallelaccessstore/CMakeLists.txt
@@ -6,7 +6,7 @@ set(SOURCES
 )
 
 add_executable(${PROJECT_NAME} ${SOURCES})
-target_link_libraries(${PROJECT_NAME} my-gtest-main parallelaccessstore)
+target_link_libraries(${PROJECT_NAME} my-gtest-main ${GOOGLETEST_LIBS} parallelaccessstore)
 add_test(${PROJECT_NAME} ${PROJECT_NAME})
 
 target_enable_style_warnings(${PROJECT_NAME})


### PR DESCRIPTION
On gentoo we tend to prefer unvendored packages over vendored ones.
That patch provide an initial release for unvendored packages (this applies to other OSes as well).

That patch is not my direct work and instead is based on the one made by Parona:
https://github.com/gentoo/gentoo/commit/4283061

Signed-off-by: Marco Scardovi <mscardovi95@gmail.com>
