### PR TITLE
Fix building with Boost 1.88

### DIFF
--- a/src/cpp-utils/process/subprocess.cpp
+++ b/src/cpp-utils/process/subprocess.cpp
@@ -1,7 +1,18 @@
 #include "subprocess.h"
 #include <array>
 #include <boost/asio.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION < 108800
 #include <boost/process.hpp>
+#else
+#define BOOST_PROCESS_VERSION 1
+#include <boost/process/v1/args.hpp>
+#include <boost/process/v1/async_pipe.hpp>
+#include <boost/process/v1/child.hpp>
+#include <boost/process/v1/exe.hpp>
+#include <boost/process/v1/io.hpp>
+#include <boost/process/v1/search_path.hpp>
+#endif
 #include <cerrno>
 #include <cstddef>
 #include <cstdio>


### PR DESCRIPTION
Boost.Process 1.88.0 has made v2 the default - https://github.com/boostorg/process/commit/2ccd97cd48c5468b0609a488b59253efaa381711

This change at least allows building with v1 in 1.88.0:
* `BOOST_PROCESS_VERSION` allows using `boost::process` namespace - https://github.com/boostorg/process/blob/boost-1.88.0/include/boost/process/v1/detail/config.hpp#L28-L29
* I couldn't find a single header for all of v1 (`boost/process/v1.hpp` was deleted) so included each used

---

Mainly a stopgap measure. Should probably switch to v2 as I am guessing v1 will be dropped in a future release.