### PR TITLE
Add documentation and tests to cryfs-version crate

### DIFF
--- a/crates/cryfs-version/src/lib.rs
+++ b/crates/cryfs-version/src/lib.rs
@@ -1,5 +1,38 @@
 #![forbid(unsafe_code)]
-// TODO #![deny(missing_docs)]
+// Note: Can't use #![deny(missing_docs)] because git2version::init_proxy_lib!()
+// generates an undocumented GITINFO constant. Using warn instead.
+#![warn(missing_docs)]
+
+//! Version management for CryFS with git tag integration.
+//!
+//! This crate provides semantic version handling with compile-time verification
+//! that the version in `Cargo.toml` matches the git tag. This ensures version
+//! consistency between the package metadata and version control.
+//!
+//! # Key Types
+//!
+//! - [`Version`]: A semantic version with major, minor, patch, and optional prerelease components.
+//! - [`VersionInfo`]: Combines a [`Version`] with optional git metadata (commit hash, tag info).
+//!
+//! # Macros
+//!
+//! - [`package_version!`]: Returns a [`VersionInfo`] with the package version and git metadata.
+//!   Asserts at compile time that the Cargo.toml version matches the git tag.
+//! - [`cargo_version!`]: Returns a [`Version`] from `Cargo.toml` without git metadata.
+//! - [`assert_cargo_version_equals_git_version!`]: Compile-time assertion that versions match.
+//!
+//! # Example
+//!
+//! ```ignore
+//! // Get the full version info including git metadata
+//! let version_info = cryfs_version::package_version!();
+//! println!("Version: {}", version_info);
+//! // Output: "1.2.3" or "1.2.3+5.gabcdef" (if commits since tag)
+//!
+//! // Get just the Cargo.toml version
+//! let version = cryfs_version::cargo_version!();
+//! assert_eq!(version.major, 1);
+//! ```
 
 git2version::init_proxy_lib!();
 
@@ -8,6 +41,25 @@ pub use version::Version;
 mod version_info;
 pub use version_info::VersionInfo;
 
+/// Returns a [`VersionInfo`] containing the package version and git metadata.
+///
+/// This macro reads the version from `Cargo.toml` and combines it with git
+/// information (commit hash, tag, commits since tag). It performs a compile-time
+/// assertion that the `Cargo.toml` version matches the git tag, ensuring version
+/// consistency.
+///
+/// # Panics
+///
+/// Causes a compile-time error if the `Cargo.toml` version does not match
+/// the current git tag (when building from a tagged commit).
+///
+/// # Example
+///
+/// ```ignore
+/// let info = cryfs_version::package_version!();
+/// println!("Running version {}", info);
+/// // Prints: "1.2.3" or "1.2.3+5.gabcdef.modified"
+/// ```
 #[macro_export]
 macro_rules! package_version {
     () => {{
@@ -32,6 +84,24 @@ macro_rules! package_version {
     }};
 }
 
+/// Returns a [`Version`] parsed from the calling crate's `Cargo.toml`.
+///
+/// This macro reads the `CARGO_PKG_VERSION_*` environment variables at compile
+/// time to construct a [`Version`]. It does not include git metadata.
+///
+/// Use this when you only need the version number without git information,
+/// or when you want to avoid the version consistency check performed by
+/// [`package_version!`].
+///
+/// # Example
+///
+/// ```ignore
+/// let version = cryfs_version::cargo_version!();
+/// println!("Version {}.{}.{}", version.major, version.minor, version.patch);
+/// if let Some(pre) = version.prerelease {
+///     println!("Prerelease: {}", pre);
+/// }
+/// ```
 #[macro_export]
 macro_rules! cargo_version {
     () => {{
@@ -63,6 +133,27 @@ macro_rules! cargo_version {
     }};
 }
 
+/// Asserts at compile time that the `Cargo.toml` version matches the git tag.
+///
+/// This macro creates a module with a const assertion that verifies version
+/// consistency. If the versions do not match, compilation fails with an error
+/// message indicating the mismatch.
+///
+/// This is automatically called by [`package_version!`], but can be used
+/// independently if you want to enforce version consistency without retrieving
+/// the version info.
+///
+/// # Panics
+///
+/// Causes a compile-time error if the `Cargo.toml` version does not match
+/// the current git tag (when building from a tagged commit).
+///
+/// # Example
+///
+/// ```ignore
+/// // Place at module level to enforce version consistency
+/// cryfs_version::assert_cargo_version_equals_git_version!();
+/// ```
 #[macro_export]
 macro_rules! assert_cargo_version_equals_git_version {
     () => {

--- a/crates/cryfs-version/src/version_info.rs
+++ b/crates/cryfs-version/src/version_info.rs
@@ -7,6 +7,33 @@ use std::{
 use super::version::Version;
 use git2version::GitInfo;
 
+/// Version information including optional git metadata.
+///
+/// This struct combines a semantic [`Version`] with optional git information
+/// such as the commit hash, tag, and number of commits since the tag. It provides
+/// a complete picture of the build version, useful for displaying in CLI tools
+/// or logging.
+///
+/// # Display Format
+///
+/// When formatted for display, `VersionInfo` produces strings like:
+/// - `1.2.3` - stable release exactly on a tag
+/// - `1.2.3-alpha` - prerelease exactly on a tag
+/// - `1.2.3+5.gabcdef` - 5 commits after tag, commit hash abcdef
+/// - `1.2.3+5.gabcdef.modified` - same, with uncommitted modifications
+/// - `1.2.3+modified` - on tag but with uncommitted modifications
+///
+/// # Type Parameters
+///
+/// - `'b`, `'c`: Lifetimes for git info string references
+/// - `P`: The string type for the version prerelease (typically `&str` or `String`)
+///
+/// # Example
+///
+/// ```ignore
+/// let info = cryfs_version::package_version!();
+/// println!("Running CryFS {}", info);
+/// ```
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound(deserialize = "'de: 'b + 'c, P: Deserialize<'de>"))]
 pub struct VersionInfo<'b, 'c, P>
@@ -18,6 +45,21 @@ where
 }
 
 impl<'a, 'b, 'c> VersionInfo<'b, 'c, &'a str> {
+    /// Creates a new `VersionInfo` with version consistency validation.
+    ///
+    /// If git information is provided and includes a tag, this constructor
+    /// validates that the provided version matches the git tag version.
+    /// A mismatch causes a compile-time panic when used in const contexts.
+    ///
+    /// # Arguments
+    ///
+    /// * `version` - The semantic version from Cargo.toml
+    /// * `gitinfo` - Optional git metadata (commit hash, tag info)
+    ///
+    /// # Panics
+    ///
+    /// Panics at compile time if the version does not match the git tag version.
+    /// This ensures version consistency between Cargo.toml and git tags.
     #[track_caller]
     pub const fn new(version: Version<&'a str>, gitinfo: Option<GitInfo<'b, 'c>>) -> Self {
         if let Some(gitinfo) = gitinfo {
@@ -50,15 +92,49 @@ impl<'b, 'c, P> VersionInfo<'b, 'c, P>
 where
     P: Borrow<str>,
 {
+    /// Asserts that the Cargo.toml version equals the git tag version.
+    ///
+    /// This is a no-op method that returns `self`, as the assertion is already
+    /// performed in the [`Self::new`] constructor. It exists for use in const
+    /// contexts where method chaining is needed for the assertion side effect.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// const INFO: VersionInfo<&str> = VersionInfo::new(version, gitinfo)
+    ///     .assert_cargo_version_equals_git_version();
+    /// ```
     pub const fn assert_cargo_version_equals_git_version(self) -> Self {
         // Nothing to do because we already assert this in the constructor
         self
     }
 
+    /// Returns a reference to the semantic version.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let info = cryfs_version::package_version!();
+    /// let version = info.version();
+    /// println!("Major version: {}", version.major);
+    /// ```
     pub const fn version(&self) -> &Version<P> {
         &self.version
     }
 
+    /// Returns the git metadata, if available.
+    ///
+    /// Returns `None` if the build was not from a git repository or if
+    /// git information was not available at build time.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let info = cryfs_version::package_version!();
+    /// if let Some(gitinfo) = info.gitinfo() {
+    ///     println!("Commit: {}", gitinfo.commit_id);
+    /// }
+    /// ```
     pub const fn gitinfo(&self) -> Option<GitInfo<'b, 'c>> {
         self.gitinfo
     }
@@ -307,6 +383,137 @@ mod tests {
             };
             assert_eq!("1.2.3-alpha+modified", format!("{}", version));
             assert_eq!("1.2.3-alpha+modified", format!("{:?}", version));
+        }
+    }
+
+    mod accessors {
+        use super::*;
+
+        #[test]
+        fn version_returns_correct_version() {
+            let info: VersionInfo<&str> = VersionInfo {
+                version: Version {
+                    major: 1,
+                    minor: 2,
+                    patch: 3,
+                    prerelease: Some("alpha"),
+                },
+                gitinfo: None,
+            };
+            let version = info.version();
+            assert_eq!(1, version.major);
+            assert_eq!(2, version.minor);
+            assert_eq!(3, version.patch);
+            assert_eq!(Some("alpha"), version.prerelease);
+        }
+
+        #[test]
+        fn gitinfo_returns_none_when_absent() {
+            let info: VersionInfo<&str> = VersionInfo {
+                version: Version {
+                    major: 1,
+                    minor: 2,
+                    patch: 3,
+                    prerelease: None,
+                },
+                gitinfo: None,
+            };
+            assert!(info.gitinfo().is_none());
+        }
+
+        #[test]
+        fn gitinfo_returns_some_when_present() {
+            let info: VersionInfo<&str> = VersionInfo {
+                version: Version {
+                    major: 1,
+                    minor: 2,
+                    patch: 3,
+                    prerelease: None,
+                },
+                gitinfo: Some(GitInfo {
+                    tag_info: Some(TagInfo {
+                        tag: "1.2.3",
+                        commits_since_tag: 5,
+                    }),
+                    commit_id: "abc123",
+                    modified: true,
+                }),
+            };
+            let gitinfo = info.gitinfo().unwrap();
+            assert_eq!("abc123", gitinfo.commit_id);
+            assert!(gitinfo.modified);
+            assert_eq!(5, gitinfo.tag_info.unwrap().commits_since_tag);
+        }
+    }
+
+    mod serde {
+        use super::*;
+
+        #[test]
+        fn roundtrip_no_gitinfo() {
+            let original: VersionInfo<&str> = VersionInfo {
+                version: Version {
+                    major: 1,
+                    minor: 2,
+                    patch: 3,
+                    prerelease: Some("alpha"),
+                },
+                gitinfo: None,
+            };
+            let serialized = serde_json::to_string(&original).unwrap();
+            let deserialized: VersionInfo<String> = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(original.version().major, deserialized.version().major);
+            assert_eq!(original.version().minor, deserialized.version().minor);
+            assert_eq!(original.version().patch, deserialized.version().patch);
+            assert_eq!(
+                original.version().prerelease,
+                deserialized.version().prerelease.as_deref()
+            );
+            assert!(deserialized.gitinfo().is_none());
+        }
+
+        #[test]
+        fn roundtrip_with_gitinfo() {
+            let original: VersionInfo<&str> = VersionInfo {
+                version: Version {
+                    major: 2,
+                    minor: 0,
+                    patch: 0,
+                    prerelease: None,
+                },
+                gitinfo: Some(GitInfo {
+                    tag_info: Some(TagInfo {
+                        tag: "2.0.0",
+                        commits_since_tag: 10,
+                    }),
+                    commit_id: "deadbeef",
+                    modified: false,
+                }),
+            };
+            let serialized = serde_json::to_string(&original).unwrap();
+            let deserialized: VersionInfo<String> = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(original.version().major, deserialized.version().major);
+
+            let original_gitinfo = original.gitinfo().unwrap();
+            let deserialized_gitinfo = deserialized.gitinfo().unwrap();
+            assert_eq!(original_gitinfo.commit_id, deserialized_gitinfo.commit_id);
+            assert_eq!(original_gitinfo.modified, deserialized_gitinfo.modified);
+        }
+
+        #[test]
+        fn json_format_no_gitinfo() {
+            let info: VersionInfo<&str> = VersionInfo {
+                version: Version {
+                    major: 1,
+                    minor: 0,
+                    patch: 0,
+                    prerelease: None,
+                },
+                gitinfo: None,
+            };
+            let serialized = serde_json::to_string(&info).unwrap();
+            assert!(serialized.contains("\"major\":1"));
+            assert!(serialized.contains("\"gitinfo\":null"));
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add comprehensive documentation comments to all public types, methods, and macros in the `cryfs-version` crate
- Enable `#![warn(missing_docs)]` lint to enforce documentation going forward
- Add 20 new tests for serde serialization and ownership conversion methods

## Changes

### Documentation
- Added crate-level `//!` documentation explaining the crate's purpose and usage
- Documented `Version<P>` struct and all its methods (`parse`, `parse_const`, `eq_const`, `to_owned`, `into_owned`, `to_borrowed`)
- Documented `VersionInfo` struct and all its methods (`new`, `version`, `gitinfo`, `assert_cargo_version_equals_git_version`)
- Documented `ParseVersionError` error type
- Documented all 3 macros: `package_version!`, `cargo_version!`, `assert_cargo_version_equals_git_version!`

### Tests Added
- `version.rs`: 14 new tests
  - 5 serde round-trip tests
  - 9 ownership conversion tests (`to_owned`, `into_owned`, `to_borrowed`)
- `version_info.rs`: 6 new tests
  - 3 serde round-trip tests
  - 3 accessor method tests (`version()`, `gitinfo()`)

### Lint
- Enabled `#![warn(missing_docs)]` (cannot use `deny` because `git2version::init_proxy_lib!()` generates an undocumented constant)

## Test plan
- [x] `cargo test -p cryfs-version` - All 48 tests pass
- [x] `cargo doc -p cryfs-version --no-deps` - Documentation builds successfully
- [x] Doc tests pass (8 pass, 8 ignored for macro context requirements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)