### PR TITLE
Track main@origin bookmark in devcontainer jujutsu setup

### DIFF
--- a/.devcontainer/setup_jj.sh
+++ b/.devcontainer/setup_jj.sh
@@ -29,6 +29,7 @@ EOF
 # Initialize jujutsu in colocated mode for the workspace
 cd /workspaces/cryfs
 jj git init --colocate
+jj bookmark track main@origin
 
 # Sync git user configuration to jujutsu
 git_name=$(git config --get user.name 2>/dev/null || true)


### PR DESCRIPTION
## Summary

Add `jj bookmark track main@origin` to the devcontainer setup script so that the remote main branch is automatically tracked when the devcontainer is created.

## Changes

- Added `jj bookmark track main@origin` after `jj git init --colocate` in `.devcontainer/setup_jj.sh`

## Motivation

This enables operations like `jj rebase -d main@origin` to work seamlessly without requiring manual bookmark tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)