### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   - push
   - pull_request


### PR DESCRIPTION
Potential fix for [https://github.com/cryfs/cryfs/security/code-scanning/5](https://github.com/cryfs/cryfs/security/code-scanning/5)

In general, the problem is fixed by explicitly specifying a `permissions:` block to restrict the `GITHUB_TOKEN` to the minimum scopes required. This can be done at the workflow root (applies to all jobs) or per job (overrides the root). Since none of the shown jobs need to write to the repository or PRs, and they only need to read the repository contents, we can safely set `contents: read` as the global default.

The best fix here, without changing existing functionality, is to add a workflow-level `permissions:` block right after the `name:` field, setting `contents: read`. This will apply to every job (`test`, `crates_individually_testable`, `code_format`, `dead_doc_links`, `coverage`, etc.) and reduce the `GITHUB_TOKEN` to read-only for repository contents, which is sufficient for `actions/checkout` and any other read-only operation. No other scopes (like `pull-requests: write` or `checks: write`) are used by the shown steps, so we don’t need to add them. No additional imports, methods, or definitions are needed, since this is purely a YAML configuration change.

Concretely: in `.github/workflows/ci.yml`, insert

```yaml
permissions:
  contents: read
```

after line 1 (`name: CI`) and before the `on:` block. No other lines need to be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
