### PR TITLE
Rename PseudoRandomPool to CsprngPool for clarity

### DIFF
--- a/src/blockstore/utils/IdWrapper.h
+++ b/src/blockstore/utils/IdWrapper.h
@@ -51,7 +51,7 @@ inline IdWrapper<Tag>::IdWrapper(const IdData& id): id_(id) {}
 
 template<class Tag>
 inline IdWrapper<Tag> IdWrapper<Tag>::Random() {
-    return IdWrapper(cpputils::Random::PseudoRandom()->getFixedSize<BINARY_LENGTH>());
+    return IdWrapper(cpputils::Random::Csprng()->getFixedSize<BINARY_LENGTH>());
 }
 
 template<class Tag>

--- a/src/cpp-utils/CMakeLists.txt
+++ b/src/cpp-utils/CMakeLists.txt
@@ -32,7 +32,7 @@ set(SOURCES
         random/Random.cpp
         random/RandomGeneratorThread.cpp
         random/OSRandomGenerator.cpp
-        random/PseudoRandomPool.cpp
+        random/CsprngPool.cpp
         random/RandomDataBuffer.cpp
         random/RandomGenerator.cpp
         lock/LockPool.cpp

--- a/src/cpp-utils/crypto/RandomPadding.cpp
+++ b/src/cpp-utils/crypto/RandomPadding.cpp
@@ -12,7 +12,7 @@ namespace cpputils {
         if (size >= targetSize - sizeof(size)) {
             throw std::runtime_error("Data too large. We should increase padding target size.");
         }
-        Data randomData = Random::PseudoRandom()->get(targetSize-sizeof(size)-size);
+        Data randomData = Random::Csprng()->get(targetSize-sizeof(size)-size);
         ASSERT(sizeof(size) + size + randomData.size() == targetSize, "Calculated size of randomData incorrectly");
         Data result(targetSize);
         serialize<uint32_t>(result.data(), size);

--- a/src/cpp-utils/crypto/hash/Hash.cpp
+++ b/src/cpp-utils/crypto/hash/Hash.cpp
@@ -22,7 +22,7 @@ Hash hash(const Data& data, Salt salt) {
 }
 
 Salt generateSalt() {
-  return Random::PseudoRandom()->getFixedSize<8>();
+  return Random::Csprng()->getFixedSize<8>();
 }
 
 }

--- a/src/cpp-utils/crypto/kdf/Scrypt.cpp
+++ b/src/cpp-utils/crypto/kdf/Scrypt.cpp
@@ -27,7 +27,7 @@ EncryptionKey _derive(size_t keySize, const std::string& password, const SCryptP
 }
 
 SCryptParameters _createNewSCryptParameters(const SCryptSettings& settings) {
-    return SCryptParameters(Random::PseudoRandom()->get(settings.SALT_LEN), settings.N, settings.r, settings.p);
+    return SCryptParameters(Random::Csprng()->get(settings.SALT_LEN), settings.N, settings.r, settings.p);
 }
 }
 

--- a/src/cpp-utils/crypto/symmetric/AEAD_Cipher.h
+++ b/src/cpp-utils/crypto/symmetric/AEAD_Cipher.h
@@ -43,7 +43,7 @@ template<class CryptoPPCipher, unsigned int KEYSIZE_, unsigned int IV_SIZE_, uns
 Data AEADCipher<CryptoPPCipher, KEYSIZE_, IV_SIZE_, TAG_SIZE_>::encrypt(const CryptoPP::byte *plaintext, unsigned int plaintextSize, const EncryptionKey &encKey) {
     ASSERT(encKey.binaryLength() == AEADCipher::KEYSIZE, "Wrong key size");
 
-    FixedSizeData<IV_SIZE> iv = Random::PseudoRandom()->getFixedSize<IV_SIZE>();
+    FixedSizeData<IV_SIZE> iv = Random::Csprng()->getFixedSize<IV_SIZE>();
     typename CryptoPPCipher::Encryption encryption;
     encryption.SetKeyWithIV(static_cast<const CryptoPP::byte*>(encKey.data()), encKey.binaryLength(), iv.data(), IV_SIZE);
     Data ciphertext(ciphertextSize(plaintextSize));

--- a/src/cpp-utils/crypto/symmetric/CFB_Cipher.h
+++ b/src/cpp-utils/crypto/symmetric/CFB_Cipher.h
@@ -44,7 +44,7 @@ template<typename BlockCipher, unsigned int KeySize>
 Data CFB_Cipher<BlockCipher, KeySize>::encrypt(const CryptoPP::byte *plaintext, unsigned int plaintextSize, const EncryptionKey &encKey) {
   ASSERT(encKey.binaryLength() == KeySize, "Wrong key size");
 
-  FixedSizeData<IV_SIZE> iv = Random::PseudoRandom()->getFixedSize<IV_SIZE>();
+  FixedSizeData<IV_SIZE> iv = Random::Csprng()->getFixedSize<IV_SIZE>();
   auto encryption = typename CryptoPP::CFB_Mode<BlockCipher>::Encryption(static_cast<const CryptoPP::byte*>(encKey.data()), encKey.binaryLength(), iv.data());
   Data ciphertext(ciphertextSize(plaintextSize));
   iv.ToBinary(ciphertext.data());

--- a/src/cpp-utils/random/CsprngPool.cpp
+++ b/src/cpp-utils/random/CsprngPool.cpp
@@ -1,0 +1,6 @@
+#include "CsprngPool.h"
+
+namespace cpputils {
+    constexpr size_t CsprngPool::MIN_BUFFER_SIZE;
+    constexpr size_t CsprngPool::MAX_BUFFER_SIZE;
+}

--- a/src/cpp-utils/random/CsprngPool.h
+++ b/src/cpp-utils/random/CsprngPool.h
@@ -1,6 +1,6 @@
 #pragma once
-#ifndef MESSMER_CPPUTILS_RANDOM_PSEUDORANDOMPOOL_H
-#define MESSMER_CPPUTILS_RANDOM_PSEUDORANDOMPOOL_H
+#ifndef MESSMER_CPPUTILS_RANDOM_CSPRNGPOOL_H
+#define MESSMER_CPPUTILS_RANDOM_CSPRNGPOOL_H
 
 #include "RandomGenerator.h"
 #include "RandomGeneratorThread.h"
@@ -11,9 +11,9 @@
 
 namespace cpputils {
     //TODO Test
-    class PseudoRandomPool final : public RandomGenerator {
+    class CsprngPool final : public RandomGenerator {
     public:
-        PseudoRandomPool();
+        CsprngPool();
 
     protected:
         void _get(void *target, size_t bytes) override;
@@ -24,15 +24,15 @@ namespace cpputils {
 
         ThreadsafeRandomDataBuffer _buffer;
         RandomGeneratorThread _refillThread;
-        DISALLOW_COPY_AND_ASSIGN(PseudoRandomPool);
+        DISALLOW_COPY_AND_ASSIGN(CsprngPool);
     };
 
 
-    inline void PseudoRandomPool::_get(void *target, size_t bytes) {
+    inline void CsprngPool::_get(void *target, size_t bytes) {
         _buffer.get(target, bytes);
     }
 
-    inline PseudoRandomPool::PseudoRandomPool(): _buffer(), _refillThread(&_buffer, MIN_BUFFER_SIZE, MAX_BUFFER_SIZE) {
+    inline CsprngPool::CsprngPool(): _buffer(), _refillThread(&_buffer, MIN_BUFFER_SIZE, MAX_BUFFER_SIZE) {
         _refillThread.start();
     }
 }

--- a/src/cpp-utils/random/PseudoRandomPool.cpp
+++ b/src/cpp-utils/random/PseudoRandomPool.cpp
@@ -1,6 +1,0 @@
-#include "PseudoRandomPool.h"
-
-namespace cpputils {
-    constexpr size_t PseudoRandomPool::MIN_BUFFER_SIZE;
-    constexpr size_t PseudoRandomPool::MAX_BUFFER_SIZE;
-}

--- a/src/cpp-utils/random/Random.h
+++ b/src/cpp-utils/random/Random.h
@@ -2,7 +2,7 @@
 #ifndef MESSMER_CPPUTILS_RANDOM_RANDOM_H
 #define MESSMER_CPPUTILS_RANDOM_RANDOM_H
 
-#include "PseudoRandomPool.h"
+#include "CsprngPool.h"
 #include "OSRandomGenerator.h"
 #include "../data/FixedSizeData.h"
 #include "../data/Data.h"
@@ -11,9 +11,9 @@
 namespace cpputils {
     class Random final {
     public:
-        static PseudoRandomPool *PseudoRandom() {
+        static CsprngPool *Csprng() {
             const std::unique_lock <std::mutex> lock(_mutex);
-            static PseudoRandomPool random;
+            static CsprngPool random;
             return &random;
         }
 

--- a/src/cryfs/impl/config/CryConfig.cpp
+++ b/src/cryfs/impl/config/CryConfig.cpp
@@ -60,7 +60,7 @@ CryConfig CryConfig::load(const Data &data) {
 
   optional<string> filesystemIdOpt = pt.get_optional<string>("cryfs.filesystemId");
   if (filesystemIdOpt == none) {
-    cfg._filesystemId = Random::PseudoRandom()->getFixedSize<FilesystemID::BINARY_LENGTH>();
+    cfg._filesystemId = Random::Csprng()->getFixedSize<FilesystemID::BINARY_LENGTH>();
   } else {
     cfg._filesystemId = FilesystemID::FromString(*filesystemIdOpt);
   }

--- a/src/cryfs/impl/config/CryConfigCreator.cpp
+++ b/src/cryfs/impl/config/CryConfigCreator.cpp
@@ -85,6 +85,6 @@ namespace cryfs {
     }
 
     CryConfig::FilesystemID CryConfigCreator::_generateFilesystemID() {
-        return Random::PseudoRandom()->getFixedSize<CryConfig::FilesystemID::BINARY_LENGTH>();
+        return Random::Csprng()->getFixedSize<CryConfig::FilesystemID::BINARY_LENGTH>();
     }
 }

--- a/src/cryfs/impl/localstate/LocalStateMetadata.cpp
+++ b/src/cryfs/impl/localstate/LocalStateMetadata.cpp
@@ -61,7 +61,7 @@ uint32_t generateClientId_() {
   uint32_t result = KnownBlockVersions::CLIENT_ID_FOR_DELETED_BLOCK;
   // Safety check - CLIENT_ID_FOR_DELETED_BLOCK shouldn't be used by any valid client.
   while(result == KnownBlockVersions::CLIENT_ID_FOR_DELETED_BLOCK) {
-    result = cpputils::deserialize<uint32_t>(Random::PseudoRandom()->getFixedSize<sizeof(uint32_t)>().data());
+    result = cpputils::deserialize<uint32_t>(Random::Csprng()->getFixedSize<sizeof(uint32_t)>().data());
   }
   return result;
 }

--- a/test/cryfs-cli/testutils/CliTest.h
+++ b/test/cryfs-cli/testutils/CliTest.h
@@ -50,7 +50,7 @@ public:
         for (const std::string& arg : args) {
             _args.emplace_back(arg.c_str());
         }
-        auto *keyGenerator = cpputils::Random::PseudoRandom();
+        auto *keyGenerator = cpputils::Random::Csprng();
         ON_CALL(*console, askPassword(testing::StrEq("Password: "))).WillByDefault(testing::Return("pass"));
         ON_CALL(*console, askPassword(testing::StrEq("Confirm Password: "))).WillByDefault(testing::Return("pass"));
         // Run Cryfs

--- a/test/cryfs/impl/config/CryCipherTest.cpp
+++ b/test/cryfs/impl/config/CryCipherTest.cpp
@@ -37,7 +37,7 @@ public:
     void EXPECT_CREATES_CORRECT_ENCRYPTED_BLOCKSTORE(const string &cipherName) {
         const auto &actualCipher = CryCiphers::find(cipherName);
         Data dataFixture = DataFixture::generate(1024);
-        const string encKey = ExpectedCipher::EncryptionKey::CreateKey(Random::PseudoRandom(), ExpectedCipher::KEYSIZE).ToString();
+        const string encKey = ExpectedCipher::EncryptionKey::CreateKey(Random::Csprng(), ExpectedCipher::KEYSIZE).ToString();
         EXPECT_ENCRYPTS_WITH_ACTUAL_BLOCKSTORE_DECRYPTS_CORRECTLY_WITH_EXPECTED_BLOCKSTORE_<ExpectedCipher>(actualCipher, encKey, std::move(dataFixture));
     }
 
@@ -119,13 +119,13 @@ TEST_F(CryCipherTest, ThereIsACipherWithIntegrityWarning) {
 }
 
 TEST_F(CryCipherTest, EncryptionKeyHasCorrectSize_448) {
-    EXPECT_EQ(Mars448_GCM::STRING_KEYSIZE, CryCiphers::find("mars-448-gcm").createKey(Random::PseudoRandom()).size());
+    EXPECT_EQ(Mars448_GCM::STRING_KEYSIZE, CryCiphers::find("mars-448-gcm").createKey(Random::Csprng()).size());
 }
 
 TEST_F(CryCipherTest, EncryptionKeyHasCorrectSize_256) {
-    EXPECT_EQ(AES256_GCM::STRING_KEYSIZE, CryCiphers::find("aes-256-gcm").createKey(Random::PseudoRandom()).size());
+    EXPECT_EQ(AES256_GCM::STRING_KEYSIZE, CryCiphers::find("aes-256-gcm").createKey(Random::Csprng()).size());
 }
 
 TEST_F(CryCipherTest, EncryptionKeyHasCorrectSize_128) {
-    EXPECT_EQ(AES128_GCM::STRING_KEYSIZE, CryCiphers::find("aes-128-gcm").createKey(Random::PseudoRandom()).size());
+    EXPECT_EQ(AES128_GCM::STRING_KEYSIZE, CryCiphers::find("aes-128-gcm").createKey(Random::Csprng()).size());
 }

--- a/test/cryfs/impl/config/CryConfigCreatorTest.cpp
+++ b/test/cryfs/impl/config/CryConfigCreatorTest.cpp
@@ -45,8 +45,8 @@ public:
     CryConfigCreatorTest()
             : console(make_shared<NiceMock<MockConsole>>()),
               tempLocalStateDir(), localStateDir(tempLocalStateDir.path()),
-              creator(console, cpputils::Random::PseudoRandom(), localStateDir),
-              noninteractiveCreator(make_shared<NoninteractiveConsole>(console), cpputils::Random::PseudoRandom(), localStateDir) {
+              creator(console, cpputils::Random::Csprng(), localStateDir),
+              noninteractiveCreator(make_shared<NoninteractiveConsole>(console), cpputils::Random::Csprng(), localStateDir) {
         EXPECT_CALL(*console, ask(HasSubstr("block cipher"), testing::_)).WillRepeatedly(ChooseAnyCipher());
         EXPECT_CALL(*console, ask(HasSubstr("block size"), testing::_)).WillRepeatedly(Return(0));
     }

--- a/test/cryfs/impl/config/CryConfigLoaderTest.cpp
+++ b/test/cryfs/impl/config/CryConfigLoaderTest.cpp
@@ -75,7 +75,7 @@ public:
 
     CryConfigLoader loader(const string &password, bool noninteractive, const optional<string> &cipher = none) {
         auto _console = noninteractive ? shared_ptr<Console>(make_shared<NoninteractiveConsole>(console)) : shared_ptr<Console>(console);
-        return CryConfigLoader(_console, cpputils::Random::PseudoRandom(), keyProvider(password), localStateDir, cipher, none, none);
+        return CryConfigLoader(_console, cpputils::Random::Csprng(), keyProvider(password), localStateDir, cipher, none, none);
     }
 
     unique_ref<CryConfigFile> Create(const string &password = "mypassword", const optional<string> &cipher = none, bool noninteractive = false) {

--- a/test/cryfs/impl/filesystem/CryFsTest.cpp
+++ b/test/cryfs/impl/filesystem/CryFsTest.cpp
@@ -43,7 +43,7 @@ public:
 
   shared_ptr<CryConfigFile> loadOrCreateConfig() {
     auto keyProvider = make_unique_ref<CryPresetPasswordBasedKeyProvider>("mypassword", make_unique_ref<SCrypt>(SCrypt::TestSettings));
-    return CryConfigLoader(make_shared<NoninteractiveConsole>(mockConsole()), Random::PseudoRandom(), std::move(keyProvider), localStateDir, none, none, none).loadOrCreate(config.path(), false, false).right().configFile;
+    return CryConfigLoader(make_shared<NoninteractiveConsole>(mockConsole()), Random::Csprng(), std::move(keyProvider), localStateDir, none, none, none).loadOrCreate(config.path(), false, false).right().configFile;
   }
 
   unique_ref<OnDiskBlockStore2> blockStore() {

--- a/test/cryfs/impl/filesystem/FileSystemTest.cpp
+++ b/test/cryfs/impl/filesystem/FileSystemTest.cpp
@@ -39,7 +39,7 @@ public:
     auto blockStore = cpputils::make_unique_ref<InMemoryBlockStore2>();
     auto _console = make_shared<NoninteractiveConsole>(mockConsole());
     auto keyProvider = make_unique_ref<CryPresetPasswordBasedKeyProvider>("mypassword", make_unique_ref<SCrypt>(SCrypt::TestSettings));
-    auto config = CryConfigLoader(_console, Random::PseudoRandom(), std::move(keyProvider), localStateDir, none, none, none)
+    auto config = CryConfigLoader(_console, Random::Csprng(), std::move(keyProvider), localStateDir, none, none, none)
             .loadOrCreate(configFile.path(), false, false).right();
     return make_unique_ref<CryDevice>(std::move(config.configFile), std::move(blockStore), localStateDir, config.myClientId, false, false, failOnIntegrityViolation());
   }

--- a/test/cryfs/impl/filesystem/testutils/CryTestBase.h
+++ b/test/cryfs/impl/filesystem/testutils/CryTestBase.h
@@ -29,7 +29,7 @@ public:
     std::shared_ptr<cryfs::CryConfigFile> configFile() {
         cryfs::CryConfig config;
         config.SetCipher("aes-256-gcm");
-        config.SetEncryptionKey(cpputils::AES256_GCM::EncryptionKey::CreateKey(cpputils::Random::PseudoRandom(), cpputils::AES256_GCM::KEYSIZE).ToString());
+        config.SetEncryptionKey(cpputils::AES256_GCM::EncryptionKey::CreateKey(cpputils::Random::Csprng(), cpputils::AES256_GCM::KEYSIZE).ToString());
         config.SetBlocksizeBytes(10240);
         cryfs::CryPresetPasswordBasedKeyProvider keyProvider("mypassword", cpputils::make_unique_ref<cpputils::SCrypt>(cpputils::SCrypt::TestSettings));
         return cryfs::CryConfigFile::create(_configFile.path(), std::move(config), &keyProvider);


### PR DESCRIPTION
The PseudoRandomPool class has a misleading name. Despite the name suggesting a weak pseudo-random number generator (like rand() or Mersenne Twister), the implementation actually uses CryptoPP::AutoSeededRandomPool which is a cryptographically secure PRNG (CSPRNG) seeded from OS entropy.

This commit renames the class to CsprngPool and the accessor method from Random::PseudoRandom() to Random::Csprng() to accurately reflect that this random generator is cryptographically secure and suitable for security-sensitive operations.

Changes:
- Rename PseudoRandomPool class to CsprngPool
- Rename PseudoRandomPool.h/cpp files to CsprngPool.h/cpp
- Update Random::PseudoRandom() accessor to Random::Csprng()
- Update all usages throughout the codebase and tests
- Update CMakeLists.txt with renamed files

https://claude.ai/code/session_01C6igJ5LJeQYRPzLBTv91j6