### PR TITLE
Use CryptoPP::SecureWipeBuffer for secure memory zeroing in UnswappableAllocator

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,13 @@
+Version 1.0.4 (unreleased)
+---------------
+* Fixed: UnswappableAllocator used std::memset to zero sensitive memory (e.g. encryption keys) on
+  deallocation, which the compiler could optimize away as a dead store. Now uses
+  CryptoPP::SecureWipeBuffer, which is guaranteed not to be elided. Note that this is not a
+  vulnerability in CryFS's threat model, since keys lingering in memory do not allow a cloud storage
+  provider to break the encryption. However, it is still good practice to zero key material as early
+  as possible to reduce exposure in case of memory disclosure through other vectors.
+
+
 Version 1.0.3
 ---------------
 * No changes, just needed to re-create the GitHub release to be able to add asset files to it

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,8 +4,9 @@ Version 1.0.4 (unreleased)
   deallocation, which the compiler could optimize away as a dead store. Now uses
   CryptoPP::SecureWipeBuffer, which is guaranteed not to be elided. Note that this is not a
   vulnerability in CryFS's threat model, since keys lingering in memory do not allow a cloud storage
-  provider to break the encryption. However, it is still good practice to zero key material as early
-  as possible to reduce exposure in case of memory disclosure through other vectors.
+  provider to break the encryption. It would only matter in scenarios where the local machine is
+  already compromised (e.g. memory disclosure exploits), which is outside CryFS's threat model.
+  However, it is still good practice to zero key material as early as possible.
 
 
 Version 1.0.3

--- a/src/cpp-utils/system/memory_nonwindows.cpp
+++ b/src/cpp-utils/system/memory_nonwindows.cpp
@@ -3,8 +3,8 @@
 #include "memory.h"
 #include <sys/mman.h>
 #include <errno.h>
-#include <string.h>
 #include <stdexcept>
+#include <vendor_cryptopp/misc.h>
 #include <cpp-utils/logging/logging.h>
 
 using namespace cpputils::logging;
@@ -27,9 +27,9 @@ void UnswappableAllocator::free(void* data, size_t size) {
     }
 
     // overwrite the memory with zeroes before we free it.
-    // explicit_bzero is guaranteed not to be optimized away by the compiler,
+    // SecureWipeBuffer is guaranteed not to be optimized away by the compiler,
     // unlike std::memset which can be removed as a dead store.
-    explicit_bzero(data, size);
+    CryptoPP::SecureWipeBuffer(static_cast<CryptoPP::byte*>(data), size);
 
     DefaultAllocator().free(data, size);
 }

--- a/src/cpp-utils/system/memory_nonwindows.cpp
+++ b/src/cpp-utils/system/memory_nonwindows.cpp
@@ -3,6 +3,7 @@
 #include "memory.h"
 #include <sys/mman.h>
 #include <errno.h>
+#include <string.h>
 #include <stdexcept>
 #include <cpp-utils/logging/logging.h>
 
@@ -25,8 +26,10 @@ void UnswappableAllocator::free(void* data, size_t size) {
         LOG(WARN, "Error calling munlock. Errno: {}", errno);
     }
 
-    // overwrite the memory with zeroes before we free it
-    std::memset(data, 0, size);
+    // overwrite the memory with zeroes before we free it.
+    // explicit_bzero is guaranteed not to be optimized away by the compiler,
+    // unlike std::memset which can be removed as a dead store.
+    explicit_bzero(data, size);
 
     DefaultAllocator().free(data, size);
 }

--- a/src/cpp-utils/system/memory_windows.cpp
+++ b/src/cpp-utils/system/memory_windows.cpp
@@ -29,8 +29,10 @@ void* UnswappableAllocator::allocate(size_t size) {
 }
 
 void UnswappableAllocator::free(void* data, size_t size) {
-	// overwrite the memory with zeroes before we free it
-	std::memset(data, 0, size);
+	// overwrite the memory with zeroes before we free it.
+	// SecureZeroMemory is guaranteed not to be optimized away by the compiler,
+	// unlike std::memset which can be removed as a dead store.
+	SecureZeroMemory(data, size);
 
 	// unlock allocated pages from RAM
 	BOOL success = ::VirtualUnlock(data, size);

--- a/src/cpp-utils/system/memory_windows.cpp
+++ b/src/cpp-utils/system/memory_windows.cpp
@@ -3,6 +3,7 @@
 #include "memory.h"
 #include <Windows.h>
 #include <stdexcept>
+#include <vendor_cryptopp/misc.h>
 #include <cpp-utils/logging/logging.h>
 
 using namespace cpputils::logging;
@@ -30,9 +31,9 @@ void* UnswappableAllocator::allocate(size_t size) {
 
 void UnswappableAllocator::free(void* data, size_t size) {
 	// overwrite the memory with zeroes before we free it.
-	// SecureZeroMemory is guaranteed not to be optimized away by the compiler,
+	// SecureWipeBuffer is guaranteed not to be optimized away by the compiler,
 	// unlike std::memset which can be removed as a dead store.
-	SecureZeroMemory(data, size);
+	CryptoPP::SecureWipeBuffer(static_cast<CryptoPP::byte*>(data), size);
 
 	// unlock allocated pages from RAM
 	BOOL success = ::VirtualUnlock(data, size);


### PR DESCRIPTION
Summary
UnswappableAllocator::free() used std::memset to zero encryption keys before deallocation, but the compiler is allowed to optimize this away as a dead store since the memory is freed immediately after
Replaced with CryptoPP::SecureWipeBuffer, which uses inline assembly with memory clobbers on x86 and volatile intrinsics on ARM to guarantee the zeroing cannot be elided
Uses the already-vendored Crypto++ library, so this is a single cross-platform fix with no new dependencies
Threat model note
This is not a vulnerability in CryFS's threat model. CryFS protects against a cloud storage provider reading your data — keys lingering in process memory don't help with that. This would only matter if the local machine is already compromised (e.g. memory disclosure exploits), which is outside scope. Still, zeroing key material early is good hygiene.