### PR TITLE
Use EncryptionKey class consistently for all encryption key handling

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,10 +1,11 @@
 Version 1.0.4 (unreleased)
 ---------------
-* Improved protection and zeroing of encryption key material in memory. Note that this is not a
-  vulnerability in CryFS's threat model, since keys lingering in memory do not allow a cloud storage
-  provider to break the encryption. It would only matter in scenarios where the local machine is
-  already compromised (e.g. memory disclosure exploits), which is outside CryFS's threat model.
-  However, it is still good practice to protect and zero key material as early as possible.
+* Improved protection and zeroing of encryption key material in CryFS process memory while the
+  file system is mounted. Note that this is not a vulnerability in CryFS's threat model, since keys
+  lingering in memory do not allow a cloud storage provider to break the encryption. It would only
+  matter in scenarios where the local machine is already compromised (e.g. memory disclosure
+  exploits), which is outside CryFS's threat model. However, it is still good practice to protect
+  and zero key material as early as possible.
   - Fixed: UnswappableAllocator used std::memset to zero sensitive memory on deallocation, which the
     compiler could optimize away as a dead store. Now uses CryptoPP::SecureWipeBuffer, which is
     guaranteed not to be elided.

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -10,9 +10,10 @@ Version 1.0.4 (unreleased)
     compiler could optimize away as a dead store. Now uses CryptoPP::SecureWipeBuffer, which is
     guaranteed not to be elided.
   - Use the EncryptionKey class (which locks memory with mlock and zeroes on free) consistently
-    throughout the codebase. Previously, encryption keys were converted to plain std::string for
-    storage and passing through the configuration layer, bypassing the memory protections. Keys are
-    now only converted to/from hex strings at serialization boundaries (config file I/O).
+    throughout the codebase. Previously, encryption keys already used this class in most places,
+    but there were a few exceptions (e.g. config file handling) where keys were converted to plain
+    std::string, bypassing the memory protections. Keys are now only converted to/from hex strings
+    at serialization boundaries (config file I/O).
 
 
 Version 1.0.3

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,12 +1,17 @@
 Version 1.0.4 (unreleased)
 ---------------
-* Fixed: UnswappableAllocator used std::memset to zero sensitive memory (e.g. encryption keys) on
-  deallocation, which the compiler could optimize away as a dead store. Now uses
-  CryptoPP::SecureWipeBuffer, which is guaranteed not to be elided. Note that this is not a
+* Improved protection and zeroing of encryption key material in memory. Note that this is not a
   vulnerability in CryFS's threat model, since keys lingering in memory do not allow a cloud storage
   provider to break the encryption. It would only matter in scenarios where the local machine is
   already compromised (e.g. memory disclosure exploits), which is outside CryFS's threat model.
-  However, it is still good practice to zero key material as early as possible.
+  However, it is still good practice to protect and zero key material as early as possible.
+  - Fixed: UnswappableAllocator used std::memset to zero sensitive memory on deallocation, which the
+    compiler could optimize away as a dead store. Now uses CryptoPP::SecureWipeBuffer, which is
+    guaranteed not to be elided.
+  - Use the EncryptionKey class (which locks memory with mlock and zeroes on free) consistently
+    throughout the codebase. Previously, encryption keys were converted to plain std::string for
+    storage and passing through the configuration layer, bypassing the memory protections. Keys are
+    now only converted to/from hex strings at serialization boundaries (config file I/O).
 
 
 Version 1.0.3

--- a/src/cpp-utils/crypto/hash/Hash.cpp
+++ b/src/cpp-utils/crypto/hash/Hash.cpp
@@ -7,10 +7,10 @@ using CryptoPP::SHA512;
 namespace cpputils {
 namespace hash {
 
-Hash hash(const void* data, size_t size, Salt salt) {
+Hash hash(const Data& data, Salt salt) {
   SHA512 hasher; // NOLINT (workaround for clang-warning in libcrypto++)
   hasher.Update(static_cast<const CryptoPP::byte*>(salt.data()), Salt::BINARY_LENGTH);
-  hasher.Update(static_cast<const CryptoPP::byte*>(data), size);
+  hasher.Update(static_cast<const CryptoPP::byte*>(data.data()), data.size());
 
   Digest digest = Digest::Null();
   hasher.Final(static_cast<CryptoPP::byte*>(digest.data()));
@@ -19,10 +19,6 @@ Hash hash(const void* data, size_t size, Salt salt) {
       digest,
       salt
   };
-}
-
-Hash hash(const Data& data, Salt salt) {
-  return hash(data.data(), data.size(), salt);
 }
 
 Salt generateSalt() {

--- a/src/cpp-utils/crypto/hash/Hash.cpp
+++ b/src/cpp-utils/crypto/hash/Hash.cpp
@@ -7,10 +7,10 @@ using CryptoPP::SHA512;
 namespace cpputils {
 namespace hash {
 
-Hash hash(const Data& data, Salt salt) {
+Hash hash(const void* data, size_t size, Salt salt) {
   SHA512 hasher; // NOLINT (workaround for clang-warning in libcrypto++)
   hasher.Update(static_cast<const CryptoPP::byte*>(salt.data()), Salt::BINARY_LENGTH);
-  hasher.Update(static_cast<const CryptoPP::byte*>(data.data()), data.size());
+  hasher.Update(static_cast<const CryptoPP::byte*>(data), size);
 
   Digest digest = Digest::Null();
   hasher.Final(static_cast<CryptoPP::byte*>(digest.data()));
@@ -19,6 +19,10 @@ Hash hash(const Data& data, Salt salt) {
       digest,
       salt
   };
+}
+
+Hash hash(const Data& data, Salt salt) {
+  return hash(data.data(), data.size(), salt);
 }
 
 Salt generateSalt() {

--- a/src/cpp-utils/crypto/hash/Hash.h
+++ b/src/cpp-utils/crypto/hash/Hash.h
@@ -18,7 +18,6 @@ struct Hash final {
 
 
 Salt generateSalt();
-Hash hash(const void* data, size_t size, Salt salt);
 Hash hash(const cpputils::Data& data, Salt salt);
 
 

--- a/src/cpp-utils/crypto/hash/Hash.h
+++ b/src/cpp-utils/crypto/hash/Hash.h
@@ -18,6 +18,7 @@ struct Hash final {
 
 
 Salt generateSalt();
+Hash hash(const void* data, size_t size, Salt salt);
 Hash hash(const cpputils::Data& data, Salt salt);
 
 

--- a/src/cpp-utils/crypto/symmetric/EncryptionKey.h
+++ b/src/cpp-utils/crypto/symmetric/EncryptionKey.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <cpp-utils/system/memory.h>
 #include <cpp-utils/random/RandomGenerator.h>
+#include <cpp-utils/crypto/hash/Hash.h>
 
 namespace cpputils {
 
@@ -87,6 +88,10 @@ public:
         auto result = std::make_shared<Data>(numTaken, make_unique_ref<UnswappableAllocator>());
         std::memcpy(result->data(), _keyData->data(), numTaken);
         return EncryptionKey(std::move(result));
+    }
+
+    cpputils::hash::Hash hash(cpputils::hash::Salt salt) const {
+        return cpputils::hash::hash(*_keyData, salt);
     }
 
     EncryptionKey drop(size_t numDropped) const {

--- a/src/cpp-utils/system/memory_windows.cpp
+++ b/src/cpp-utils/system/memory_windows.cpp
@@ -13,7 +13,13 @@ namespace cpputils {
 void* UnswappableAllocator::allocate(size_t size) {
 	// VirtualAlloc allocates memory in full pages. This is needed, because VirtualUnlock unlocks full pages
 	// and might otherwise unlock unrelated memory of other allocations.
-    
+
+	// VirtualAlloc fails with ERROR_INVALID_PARAMETER for size=0.
+	// Match DefaultAllocator behavior and allocate 1 byte instead.
+	if (size == 0) {
+		size = 1;
+	}
+
 	// allocate pages
 	void* data = ::VirtualAlloc(nullptr, size, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
 	if (nullptr == data) {

--- a/src/cpp-utils/system/memory_windows.cpp
+++ b/src/cpp-utils/system/memory_windows.cpp
@@ -36,6 +36,12 @@ void* UnswappableAllocator::allocate(size_t size) {
 }
 
 void UnswappableAllocator::free(void* data, size_t size) {
+	// Match the size adjustment in allocate() so that VirtualUnlock
+	// receives the same size that was passed to VirtualLock.
+	if (size == 0) {
+		size = 1;
+	}
+
 	// overwrite the memory with zeroes before we free it.
 	// SecureWipeBuffer is guaranteed not to be optimized away by the compiler,
 	// unlike std::memset which can be removed as a dead store.

--- a/src/cryfs/impl/config/CryCipher.cpp
+++ b/src/cryfs/impl/config/CryCipher.cpp
@@ -38,12 +38,12 @@ public:
         return _warning;
     }
 
-    unique_ref<BlockStore2> createEncryptedBlockstore(unique_ref<BlockStore2> baseBlockStore, const string &encKey) const override {
-        return make_unique_ref<EncryptedBlockStore2<Cipher>>(std::move(baseBlockStore), Cipher::EncryptionKey::FromString(encKey));
+    unique_ref<BlockStore2> createEncryptedBlockstore(unique_ref<BlockStore2> baseBlockStore, const cpputils::EncryptionKey &encKey) const override {
+        return make_unique_ref<EncryptedBlockStore2<Cipher>>(std::move(baseBlockStore), encKey);
     }
 
-    string createKey(cpputils::RandomGenerator *randomGenerator) const override {
-        return Cipher::EncryptionKey::CreateKey(randomGenerator, Cipher::KEYSIZE).ToString();
+    cpputils::EncryptionKey createKey(cpputils::RandomGenerator *randomGenerator) const override {
+        return Cipher::EncryptionKey::CreateKey(randomGenerator, Cipher::KEYSIZE);
     }
 
     unique_ref<InnerEncryptor> createInnerConfigEncryptor(const EncryptionKey& key) const override {

--- a/src/cryfs/impl/config/CryCipher.h
+++ b/src/cryfs/impl/config/CryCipher.h
@@ -39,8 +39,8 @@ public:
 
     virtual std::string cipherName() const = 0;
     virtual const boost::optional<std::string> &warning() const = 0;
-    virtual cpputils::unique_ref<blockstore::BlockStore2> createEncryptedBlockstore(cpputils::unique_ref<blockstore::BlockStore2> baseBlockStore, const std::string &encKey) const = 0;
-    virtual std::string createKey(cpputils::RandomGenerator *randomGenerator) const = 0;
+    virtual cpputils::unique_ref<blockstore::BlockStore2> createEncryptedBlockstore(cpputils::unique_ref<blockstore::BlockStore2> baseBlockStore, const cpputils::EncryptionKey &encKey) const = 0;
+    virtual cpputils::EncryptionKey createKey(cpputils::RandomGenerator *randomGenerator) const = 0;
     virtual cpputils::unique_ref<InnerEncryptor> createInnerConfigEncryptor(const cpputils::EncryptionKey &key) const = 0;
 };
 

--- a/src/cryfs/impl/config/CryConfig.cpp
+++ b/src/cryfs/impl/config/CryConfig.cpp
@@ -22,7 +22,7 @@ constexpr const char* CryConfig::FilesystemFormatVersion;
 
 CryConfig::CryConfig()
 : _rootBlob("")
-, _encKey("")
+, _encKey(cpputils::EncryptionKey::Null(0))
 , _cipher("")
 , _version("")
 , _createdWithVersion("")
@@ -46,7 +46,7 @@ CryConfig CryConfig::load(const Data &data) {
 
   CryConfig cfg;
   cfg._rootBlob = pt.get<string>("cryfs.rootblob");
-  cfg._encKey = pt.get<string>("cryfs.key");
+  cfg._encKey = cpputils::EncryptionKey::FromString(pt.get<string>("cryfs.key"));
   cfg._cipher = pt.get<string>("cryfs.cipher");
   cfg._version = pt.get<string>("cryfs.version", "0.8"); // CryFS 0.8 didn't specify this field, so if the field doesn't exist, it's 0.8.
   cfg._createdWithVersion = pt.get<string>("cryfs.createdWithVersion", cfg._version); // In CryFS <= 0.9.2, we didn't have this field, but also didn't update cryfs.version, so we can use this field instead.
@@ -72,7 +72,7 @@ Data CryConfig::save() const {
   ptree pt;
 
   pt.put<string>("cryfs.rootblob", _rootBlob);
-  pt.put<string>("cryfs.key", _encKey);
+  pt.put<string>("cryfs.key", _encKey.ToString());
   pt.put<string>("cryfs.cipher", _cipher);
   pt.put<string>("cryfs.version", _version);
   pt.put<string>("cryfs.createdWithVersion", _createdWithVersion);
@@ -100,11 +100,11 @@ void CryConfig::SetRootBlob(std::string value) {
   _rootBlob = std::move(value);
 }
 
-const string &CryConfig::EncryptionKey() const {
+const cpputils::EncryptionKey &CryConfig::EncryptionKey() const {
   return _encKey;
 }
 
-void CryConfig::SetEncryptionKey(std::string value) {
+void CryConfig::SetEncryptionKey(cpputils::EncryptionKey value) {
   _encKey = std::move(value);
 }
 

--- a/src/cryfs/impl/config/CryConfig.h
+++ b/src/cryfs/impl/config/CryConfig.h
@@ -7,6 +7,7 @@
 #include <cpp-utils/data/Data.h>
 #include <iostream>
 #include <cpp-utils/data/FixedSizeData.h>
+#include <cpp-utils/crypto/symmetric/EncryptionKey.h>
 
 namespace cryfs {
 
@@ -22,8 +23,8 @@ public:
   const std::string &RootBlob() const;
   void SetRootBlob(std::string value);
 
-  const std::string &EncryptionKey() const;
-  void SetEncryptionKey(std::string value);
+  const cpputils::EncryptionKey &EncryptionKey() const;
+  void SetEncryptionKey(cpputils::EncryptionKey value);
 
   const std::string &Cipher() const;
   void SetCipher(std::string value);
@@ -68,7 +69,7 @@ public:
 
 private:
   std::string _rootBlob;
-  std::string _encKey;
+  cpputils::EncryptionKey _encKey;
   std::string _cipher;
   std::string _version;
   std::string _createdWithVersion;

--- a/src/cryfs/impl/config/CryConfigCreator.cpp
+++ b/src/cryfs/impl/config/CryConfigCreator.cpp
@@ -29,7 +29,7 @@ namespace cryfs {
         config.SetRootBlob(_generateRootBlobId());
         config.SetFilesystemId(_generateFilesystemID());
         auto encryptionKey = _generateEncKey(config.Cipher());
-        auto localState = LocalStateMetadata::loadOrGenerate(_localStateDir.forFilesystemId(config.FilesystemId()), cpputils::Data::FromString(encryptionKey), allowReplacedFilesystem);
+        auto localState = LocalStateMetadata::loadOrGenerate(_localStateDir.forFilesystemId(config.FilesystemId()), encryptionKey, allowReplacedFilesystem);
         const uint32_t myClientId = localState.myClientId();
         config.SetEncryptionKey(std::move(encryptionKey));
         config.SetExclusiveClientId(_generateExclusiveClientId(missingBlockIsIntegrityViolationFromCommandLine, myClientId));
@@ -72,7 +72,7 @@ namespace cryfs {
         }
     }
 
-    string CryConfigCreator::_generateEncKey(const std::string &cipher) {
+    cpputils::EncryptionKey CryConfigCreator::_generateEncKey(const std::string &cipher) {
         _console->print("\nGenerating secure encryption key. This can take some time...");
         auto key = CryCiphers::find(cipher).createKey(_encryptionKeyGenerator);
         _console->print("done\n");

--- a/src/cryfs/impl/config/CryConfigCreator.h
+++ b/src/cryfs/impl/config/CryConfigCreator.h
@@ -23,7 +23,7 @@ namespace cryfs {
         ConfigCreateResult create(const boost::optional<std::string> &cipherFromCommandLine, const boost::optional<uint32_t> &blocksizeBytesFromCommandLine, const boost::optional<bool> &missingBlockIsIntegrityViolationFromCommandLine, bool allowReplacedFilesystem);
     private:
         std::string _generateCipher(const boost::optional<std::string> &cipherFromCommandLine);
-        std::string _generateEncKey(const std::string &cipher);
+        cpputils::EncryptionKey _generateEncKey(const std::string &cipher);
         std::string _generateRootBlobId();
         uint32_t _generateBlocksizeBytes(const boost::optional<uint32_t> &blocksizeBytesFromCommandLine);
         CryConfig::FilesystemID _generateFilesystemID();

--- a/src/cryfs/impl/config/CryConfigLoader.cpp
+++ b/src/cryfs/impl/config/CryConfigLoader.cpp
@@ -57,7 +57,7 @@ either<CryConfigFile::LoadError, CryConfigLoader::ConfigLoadResult> CryConfigLoa
     }
   }
   _checkCipher(*config.right()->config());
-  auto localState = LocalStateMetadata::loadOrGenerate(_localStateDir.forFilesystemId(config.right()->config()->FilesystemId()), cpputils::Data::FromString(config.right()->config()->EncryptionKey()), allowReplacedFilesystem);
+  auto localState = LocalStateMetadata::loadOrGenerate(_localStateDir.forFilesystemId(config.right()->config()->FilesystemId()), config.right()->config()->EncryptionKey(), allowReplacedFilesystem);
   const uint32_t myClientId = localState.myClientId();
   _checkMissingBlocksAreIntegrityViolations(config.right().get(), myClientId);
   return ConfigLoadResult {std::move(oldConfig), std::move(config.right()), myClientId};

--- a/src/cryfs/impl/localstate/LocalStateMetadata.cpp
+++ b/src/cryfs/impl/localstate/LocalStateMetadata.cpp
@@ -18,7 +18,6 @@ using std::ostream;
 using std::string;
 using blockstore::integrity::KnownBlockVersions;
 using cpputils::hash::Hash;
-using cpputils::Data;
 using cpputils::Random;
 namespace bf = boost::filesystem;
 using namespace cpputils::logging;

--- a/src/cryfs/impl/localstate/LocalStateMetadata.cpp
+++ b/src/cryfs/impl/localstate/LocalStateMetadata.cpp
@@ -36,7 +36,7 @@ LocalStateMetadata LocalStateMetadata::loadOrGenerate(const bf::path &statePath,
     return generate_(metadataFile, encryptionKey);
   }
 
-  if (!allowReplacedFilesystem && loaded->_encryptionKeyHash.digest != cpputils::hash::hash(encryptionKey.data(), encryptionKey.binaryLength(), loaded->_encryptionKeyHash.salt).digest) {
+  if (!allowReplacedFilesystem && loaded->_encryptionKeyHash.digest != encryptionKey.hash(loaded->_encryptionKeyHash.salt).digest) {
     throw CryfsException("The filesystem encryption key differs from the last time we loaded this filesystem. Did an attacker replace the file system?", ErrorCode::EncryptionKeyChanged);
   }
   return *loaded;
@@ -93,7 +93,7 @@ LocalStateMetadata LocalStateMetadata::generate_(const bf::path &metadataFilePat
   }
 #endif
 
-  LocalStateMetadata result(myClientId, cpputils::hash::hash(encryptionKey.data(), encryptionKey.binaryLength(), cpputils::hash::generateSalt()));
+  LocalStateMetadata result(myClientId, encryptionKey.hash(cpputils::hash::generateSalt()));
   result.save_(metadataFilePath);
   return result;
 }

--- a/src/cryfs/impl/localstate/LocalStateMetadata.cpp
+++ b/src/cryfs/impl/localstate/LocalStateMetadata.cpp
@@ -5,6 +5,8 @@
 #include <boost/filesystem.hpp>
 #include <blockstore/implementations/integrity/KnownBlockVersions.h>
 #include <cryfs/impl/CryfsException.h>
+#include <cpp-utils/system/memory.h>
+#include <cstring>
 
 using boost::optional;
 using boost::none;
@@ -25,10 +27,18 @@ using namespace cpputils::logging;
 
 namespace cryfs {
 
+namespace {
+Data _encryptionKeyToData(const cpputils::EncryptionKey& key) {
+  Data result(key.binaryLength(), cpputils::make_unique_ref<cpputils::UnswappableAllocator>());
+  std::memcpy(result.data(), key.data(), key.binaryLength());
+  return result;
+}
+}
+
 LocalStateMetadata::LocalStateMetadata(uint32_t myClientId, Hash encryptionKeyHash)
 : _myClientId(myClientId), _encryptionKeyHash(encryptionKeyHash) {}
 
-LocalStateMetadata LocalStateMetadata::loadOrGenerate(const bf::path &statePath, const Data& encryptionKey, bool allowReplacedFilesystem) {
+LocalStateMetadata LocalStateMetadata::loadOrGenerate(const bf::path &statePath, const cpputils::EncryptionKey& encryptionKey, bool allowReplacedFilesystem) {
   auto metadataFile = statePath / "metadata";
   auto loaded = load_(metadataFile);
   if (loaded == none) {
@@ -36,7 +46,8 @@ LocalStateMetadata LocalStateMetadata::loadOrGenerate(const bf::path &statePath,
     return generate_(metadataFile, encryptionKey);
   }
 
-  if (!allowReplacedFilesystem && loaded->_encryptionKeyHash.digest != cpputils::hash::hash(encryptionKey, loaded->_encryptionKeyHash.salt).digest) {
+  auto keyData = _encryptionKeyToData(encryptionKey);
+  if (!allowReplacedFilesystem && loaded->_encryptionKeyHash.digest != cpputils::hash::hash(keyData, loaded->_encryptionKeyHash.salt).digest) {
     throw CryfsException("The filesystem encryption key differs from the last time we loaded this filesystem. Did an attacker replace the file system?", ErrorCode::EncryptionKeyChanged);
   }
   return *loaded;
@@ -83,7 +94,7 @@ optional<uint32_t> _tryLoadClientIdFromLegacyFile(const bf::path &metadataFilePa
 #endif
 }
 
-LocalStateMetadata LocalStateMetadata::generate_(const bf::path &metadataFilePath, const Data& encryptionKey) {
+LocalStateMetadata LocalStateMetadata::generate_(const bf::path &metadataFilePath, const cpputils::EncryptionKey& encryptionKey) {
   uint32_t myClientId = generateClientId_();
 #ifndef CRYFS_NO_COMPATIBILITY
   // In the old format, this was stored in a "myClientId" file. If that file exists, load it from there.
@@ -93,7 +104,8 @@ LocalStateMetadata LocalStateMetadata::generate_(const bf::path &metadataFilePat
   }
 #endif
 
-  LocalStateMetadata result(myClientId, cpputils::hash::hash(encryptionKey, cpputils::hash::generateSalt()));
+  auto keyData = _encryptionKeyToData(encryptionKey);
+  LocalStateMetadata result(myClientId, cpputils::hash::hash(keyData, cpputils::hash::generateSalt()));
   result.save_(metadataFilePath);
   return result;
 }

--- a/src/cryfs/impl/localstate/LocalStateMetadata.cpp
+++ b/src/cryfs/impl/localstate/LocalStateMetadata.cpp
@@ -5,8 +5,6 @@
 #include <boost/filesystem.hpp>
 #include <blockstore/implementations/integrity/KnownBlockVersions.h>
 #include <cryfs/impl/CryfsException.h>
-#include <cpp-utils/system/memory.h>
-#include <cstring>
 
 using boost::optional;
 using boost::none;
@@ -27,14 +25,6 @@ using namespace cpputils::logging;
 
 namespace cryfs {
 
-namespace {
-Data _encryptionKeyToData(const cpputils::EncryptionKey& key) {
-  Data result(key.binaryLength(), cpputils::make_unique_ref<cpputils::UnswappableAllocator>());
-  std::memcpy(result.data(), key.data(), key.binaryLength());
-  return result;
-}
-}
-
 LocalStateMetadata::LocalStateMetadata(uint32_t myClientId, Hash encryptionKeyHash)
 : _myClientId(myClientId), _encryptionKeyHash(encryptionKeyHash) {}
 
@@ -46,8 +36,7 @@ LocalStateMetadata LocalStateMetadata::loadOrGenerate(const bf::path &statePath,
     return generate_(metadataFile, encryptionKey);
   }
 
-  auto keyData = _encryptionKeyToData(encryptionKey);
-  if (!allowReplacedFilesystem && loaded->_encryptionKeyHash.digest != cpputils::hash::hash(keyData, loaded->_encryptionKeyHash.salt).digest) {
+  if (!allowReplacedFilesystem && loaded->_encryptionKeyHash.digest != cpputils::hash::hash(encryptionKey.data(), encryptionKey.binaryLength(), loaded->_encryptionKeyHash.salt).digest) {
     throw CryfsException("The filesystem encryption key differs from the last time we loaded this filesystem. Did an attacker replace the file system?", ErrorCode::EncryptionKeyChanged);
   }
   return *loaded;
@@ -104,8 +93,7 @@ LocalStateMetadata LocalStateMetadata::generate_(const bf::path &metadataFilePat
   }
 #endif
 
-  auto keyData = _encryptionKeyToData(encryptionKey);
-  LocalStateMetadata result(myClientId, cpputils::hash::hash(keyData, cpputils::hash::generateSalt()));
+  LocalStateMetadata result(myClientId, cpputils::hash::hash(encryptionKey.data(), encryptionKey.binaryLength(), cpputils::hash::generateSalt()));
   result.save_(metadataFilePath);
   return result;
 }

--- a/src/cryfs/impl/localstate/LocalStateMetadata.h
+++ b/src/cryfs/impl/localstate/LocalStateMetadata.h
@@ -6,13 +6,14 @@
 #include <boost/optional.hpp>
 #include <iostream>
 #include <cpp-utils/crypto/hash/Hash.h>
+#include <cpp-utils/crypto/symmetric/EncryptionKey.h>
 
 namespace cryfs {
 
 class LocalStateMetadata final {
 public:
 
-  static LocalStateMetadata loadOrGenerate(const boost::filesystem::path &statePath, const cpputils::Data& encryptionKey, bool allowReplacedFilesystem);
+  static LocalStateMetadata loadOrGenerate(const boost::filesystem::path &statePath, const cpputils::EncryptionKey& encryptionKey, bool allowReplacedFilesystem);
 
   uint32_t myClientId() const;
 
@@ -22,7 +23,7 @@ private:
 
   static boost::optional<LocalStateMetadata> load_(const boost::filesystem::path &metadataFilePath);
   static LocalStateMetadata deserialize_(std::istream& stream);
-  static LocalStateMetadata generate_(const boost::filesystem::path &metadataFilePath, const cpputils::Data& encryptionKey);
+  static LocalStateMetadata generate_(const boost::filesystem::path &metadataFilePath, const cpputils::EncryptionKey& encryptionKey);
   void save_(const boost::filesystem::path &metadataFilePath) const;
   void serialize_(std::ostream& stream) const;
 

--- a/test/cpp-utils/system/MemoryTest.cpp
+++ b/test/cpp-utils/system/MemoryTest.cpp
@@ -16,3 +16,9 @@ TEST(MemoryTest, LockingLargeMemoryDoesntCrash) {
     void *data = allocator.allocate(10240);
     allocator.free(data, 10240);
 }
+
+TEST(MemoryTest, LockingZeroMemoryDoesntCrash) {
+    UnswappableAllocator allocator;
+    void *data = allocator.allocate(0);
+    allocator.free(data, 0);
+}

--- a/test/cryfs-cli/CliTest_IntegrityCheck.cpp
+++ b/test/cryfs-cli/CliTest_IntegrityCheck.cpp
@@ -78,7 +78,7 @@ public:
   void modifyFilesystemKey() {
     FakeCryKeyProvider keyProvider;
     auto configFile = CryConfigFile::load(basedir / "cryfs.config", &keyProvider, CryConfigFile::Access::ReadWrite).right_opt().value();
-    configFile->config()->SetEncryptionKey("0123456789ABCDEF0123456789ABCDEF");
+    configFile->config()->SetEncryptionKey(cpputils::EncryptionKey::FromString("0123456789ABCDEF0123456789ABCDEF"));
     configFile->save();
   }
 };

--- a/test/cryfs/impl/config/CryCipherTest.cpp
+++ b/test/cryfs/impl/config/CryCipherTest.cpp
@@ -37,19 +37,19 @@ public:
     void EXPECT_CREATES_CORRECT_ENCRYPTED_BLOCKSTORE(const string &cipherName) {
         const auto &actualCipher = CryCiphers::find(cipherName);
         Data dataFixture = DataFixture::generate(1024);
-        const string encKey = ExpectedCipher::EncryptionKey::CreateKey(Random::Csprng(), ExpectedCipher::KEYSIZE).ToString();
+        const EncryptionKey encKey = ExpectedCipher::EncryptionKey::CreateKey(Random::Csprng(), ExpectedCipher::KEYSIZE);
         EXPECT_ENCRYPTS_WITH_ACTUAL_BLOCKSTORE_DECRYPTS_CORRECTLY_WITH_EXPECTED_BLOCKSTORE_<ExpectedCipher>(actualCipher, encKey, std::move(dataFixture));
     }
 
     template<class ExpectedCipher>
-    void EXPECT_ENCRYPTS_WITH_ACTUAL_BLOCKSTORE_DECRYPTS_CORRECTLY_WITH_EXPECTED_BLOCKSTORE_(const CryCipher &actualCipher, const std::string &encKey, Data dataFixture) {
+    void EXPECT_ENCRYPTS_WITH_ACTUAL_BLOCKSTORE_DECRYPTS_CORRECTLY_WITH_EXPECTED_BLOCKSTORE_(const CryCipher &actualCipher, const EncryptionKey &encKey, Data dataFixture) {
         const blockstore::BlockId blockId = blockstore::BlockId::Random();
         Data encrypted = _encryptUsingEncryptedBlockStoreWithCipher(actualCipher, encKey, blockId, dataFixture.copy());
         const Data decrypted = _decryptUsingEncryptedBlockStoreWithCipher<ExpectedCipher>(encKey, blockId, std::move(encrypted));
         EXPECT_EQ(dataFixture, decrypted);
     }
 
-    Data _encryptUsingEncryptedBlockStoreWithCipher(const CryCipher &cipher, const std::string &encKey, const blockstore::BlockId &blockId, Data data) {
+    Data _encryptUsingEncryptedBlockStoreWithCipher(const CryCipher &cipher, const EncryptionKey &encKey, const blockstore::BlockId &blockId, Data data) {
         unique_ref<InMemoryBlockStore2> _baseStore = make_unique_ref<InMemoryBlockStore2>();
         InMemoryBlockStore2 *baseStore = _baseStore.get();
         unique_ref<BlockStore2> encryptedStore = cipher.createEncryptedBlockstore(std::move(_baseStore), encKey);
@@ -59,11 +59,11 @@ public:
     }
 
     template<class Cipher>
-    Data _decryptUsingEncryptedBlockStoreWithCipher(const std::string &encKey, const blockstore::BlockId &blockId, Data data) {
+    Data _decryptUsingEncryptedBlockStoreWithCipher(const EncryptionKey &encKey, const blockstore::BlockId &blockId, Data data) {
         unique_ref<InMemoryBlockStore2> baseStore = make_unique_ref<InMemoryBlockStore2>();
         const bool created = baseStore->tryCreate(blockId, data);
         EXPECT_TRUE(created);
-        EncryptedBlockStore2<Cipher> encryptedStore(std::move(baseStore), Cipher::EncryptionKey::FromString(encKey));
+        EncryptedBlockStore2<Cipher> encryptedStore(std::move(baseStore), encKey);
         return _loadBlock(&encryptedStore, blockId);
     }
 
@@ -119,13 +119,13 @@ TEST_F(CryCipherTest, ThereIsACipherWithIntegrityWarning) {
 }
 
 TEST_F(CryCipherTest, EncryptionKeyHasCorrectSize_448) {
-    EXPECT_EQ(Mars448_GCM::STRING_KEYSIZE, CryCiphers::find("mars-448-gcm").createKey(Random::Csprng()).size());
+    EXPECT_EQ(Mars448_GCM::STRING_KEYSIZE, CryCiphers::find("mars-448-gcm").createKey(Random::Csprng()).stringLength());
 }
 
 TEST_F(CryCipherTest, EncryptionKeyHasCorrectSize_256) {
-    EXPECT_EQ(AES256_GCM::STRING_KEYSIZE, CryCiphers::find("aes-256-gcm").createKey(Random::Csprng()).size());
+    EXPECT_EQ(AES256_GCM::STRING_KEYSIZE, CryCiphers::find("aes-256-gcm").createKey(Random::Csprng()).stringLength());
 }
 
 TEST_F(CryCipherTest, EncryptionKeyHasCorrectSize_128) {
-    EXPECT_EQ(AES128_GCM::STRING_KEYSIZE, CryCiphers::find("aes-128-gcm").createKey(Random::Csprng()).size());
+    EXPECT_EQ(AES128_GCM::STRING_KEYSIZE, CryCiphers::find("aes-128-gcm").createKey(Random::Csprng()).stringLength());
 }

--- a/test/cryfs/impl/config/CryConfigCreatorTest.cpp
+++ b/test/cryfs/impl/config/CryConfigCreatorTest.cpp
@@ -159,7 +159,8 @@ TEST_F(CryConfigCreatorTest, ChoosesValidEncryptionKey_448) {
     IGNORE_ASK_FOR_MISSINGBLOCKISINTEGRITYVIOLATION();
     EXPECT_ASK_FOR_CIPHER().WillOnce(ChooseCipher("mars-448-gcm"));
     const CryConfig config = creator.create(none, none, none, false).config;
-    cpputils::Mars448_GCM::EncryptionKey::FromString(config.EncryptionKey()); // This crashes if invalid
+    // Verify key has the correct size for Mars-448-GCM
+    EXPECT_EQ(cpputils::Mars448_GCM::KEYSIZE, config.EncryptionKey().binaryLength());
 }
 
 TEST_F(CryConfigCreatorTest, ChoosesValidEncryptionKey_256) {
@@ -167,7 +168,8 @@ TEST_F(CryConfigCreatorTest, ChoosesValidEncryptionKey_256) {
     IGNORE_ASK_FOR_MISSINGBLOCKISINTEGRITYVIOLATION();
     EXPECT_ASK_FOR_CIPHER().WillOnce(ChooseCipher("aes-256-gcm"));
     const CryConfig config = creator.create(none, none, none, false).config;
-    cpputils::AES256_GCM::EncryptionKey::FromString(config.EncryptionKey()); // This crashes if invalid
+    // Verify key has the correct size for AES-256-GCM
+    EXPECT_EQ(cpputils::AES256_GCM::KEYSIZE, config.EncryptionKey().binaryLength());
 }
 
 TEST_F(CryConfigCreatorTest, ChoosesValidEncryptionKey_128) {
@@ -175,7 +177,8 @@ TEST_F(CryConfigCreatorTest, ChoosesValidEncryptionKey_128) {
     IGNORE_ASK_FOR_MISSINGBLOCKISINTEGRITYVIOLATION();
     EXPECT_ASK_FOR_CIPHER().WillOnce(ChooseCipher("aes-128-gcm"));
     const CryConfig config = creator.create(none, none, none, false).config;
-    cpputils::AES128_GCM::EncryptionKey::FromString(config.EncryptionKey()); // This crashes if invalid
+    // Verify key has the correct size for AES-128-GCM
+    EXPECT_EQ(cpputils::AES128_GCM::KEYSIZE, config.EncryptionKey().binaryLength());
 }
 
 TEST_F(CryConfigCreatorTest, DoesNotAskForAnythingIfEverythingIsSpecified) {

--- a/test/cryfs/impl/config/CryConfigFileTest.cpp
+++ b/test/cryfs/impl/config/CryConfigFileTest.cpp
@@ -93,23 +93,23 @@ TEST_F(CryConfigFileTest, RootBlob_SaveAndLoad) {
 
 TEST_F(CryConfigFileTest, EncryptionKey_Init) {
     unique_ref<CryConfigFile> created = CreateAndLoadEmpty();
-    EXPECT_EQ("", created->config()->EncryptionKey());
+    EXPECT_EQ("", created->config()->EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigFileTest, EncryptionKey_CreateAndLoad) {
     CryConfig cfg = Config();
-    cfg.SetEncryptionKey("encryptionkey");
+    cfg.SetEncryptionKey(cpputils::EncryptionKey::FromString("AABB0011223344"));
     Create(std::move(cfg));
     unique_ref<CryConfigFile> loaded = std::move(Load().value());
-    EXPECT_EQ("encryptionkey", loaded->config()->EncryptionKey());
+    EXPECT_EQ("AABB0011223344", loaded->config()->EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigFileTest, EncryptionKey_SaveAndLoad) {
     unique_ref<CryConfigFile> created = CreateAndLoadEmpty();
-    created->config()->SetEncryptionKey("encryptionkey");
+    created->config()->SetEncryptionKey(cpputils::EncryptionKey::FromString("AABB0011223344"));
     created->save();
     unique_ref<CryConfigFile> loaded = std::move(Load().value());
-    EXPECT_EQ("encryptionkey", loaded->config()->EncryptionKey());
+    EXPECT_EQ("AABB0011223344", loaded->config()->EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigFileTest, Cipher_Init) {

--- a/test/cryfs/impl/config/CryConfigLoaderTest.cpp
+++ b/test/cryfs/impl/config/CryConfigLoaderTest.cpp
@@ -137,7 +137,7 @@ public:
 
     void ChangeEncryptionKey(const string &encKey, const string& password = "mypassword") {
         auto cfg = CryConfigFile::load(file.path(), keyProvider(password).get(), CryConfigFile::Access::ReadWrite).right();
-        cfg->config()->SetEncryptionKey(encKey);
+        cfg->config()->SetEncryptionKey(cpputils::EncryptionKey::FromString(encKey));
         cfg->save();
     }
 
@@ -247,7 +247,7 @@ TEST_F(CryConfigLoaderTest, RootBlob_Create) {
 TEST_F(CryConfigLoaderTest, EncryptionKey_Load) {
     CreateWithEncryptionKey("3B4682CF22F3CA199E385729B9F3CA19D325229E385729B9443CA19D325229E3");
     auto loaded = LoadOrCreate().right();
-    EXPECT_EQ("3B4682CF22F3CA199E385729B9F3CA19D325229E385729B9443CA19D325229E3", loaded->config()->EncryptionKey());
+    EXPECT_EQ("3B4682CF22F3CA199E385729B9F3CA19D325229E385729B9443CA19D325229E3", loaded->config()->EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigLoaderTest, EncryptionKey_Load_whenKeyChanged_thenFails) {
@@ -261,7 +261,8 @@ TEST_F(CryConfigLoaderTest, EncryptionKey_Load_whenKeyChanged_thenFails) {
 
 TEST_F(CryConfigLoaderTest, EncryptionKey_Create) {
     auto created = Create();
-    cpputils::AES256_GCM::EncryptionKey::FromString(created->config()->EncryptionKey()); // This crashes if key is invalid
+    // Verify key has the correct size for AES-256-GCM
+    EXPECT_EQ(cpputils::AES256_GCM::KEYSIZE, created->config()->EncryptionKey().binaryLength());
 }
 
 TEST_F(CryConfigLoaderTest, Cipher_Load) {

--- a/test/cryfs/impl/config/CryConfigTest.cpp
+++ b/test/cryfs/impl/config/CryConfigTest.cpp
@@ -48,30 +48,30 @@ TEST_F(CryConfigTest, RootBlob_AfterSaveAndLoad) {
 }
 
 TEST_F(CryConfigTest, EncryptionKey_Init) {
-    EXPECT_EQ("", cfg.EncryptionKey());
+    EXPECT_EQ("", cfg.EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigTest, EncryptionKey) {
-    cfg.SetEncryptionKey("enckey");
-    EXPECT_EQ("enckey", cfg.EncryptionKey());
+    cfg.SetEncryptionKey(cpputils::EncryptionKey::FromString("AABB01"));
+    EXPECT_EQ("AABB01", cfg.EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigTest, EncryptionKey_AfterMove) {
-    cfg.SetEncryptionKey("enckey");
+    cfg.SetEncryptionKey(cpputils::EncryptionKey::FromString("AABB01"));
     const CryConfig moved = std::move(cfg);
-    EXPECT_EQ("enckey", moved.EncryptionKey());
+    EXPECT_EQ("AABB01", moved.EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigTest, EncryptionKey_AfterCopy) {
-    cfg.SetEncryptionKey("enckey");
+    cfg.SetEncryptionKey(cpputils::EncryptionKey::FromString("AABB01"));
     const CryConfig copy = cfg;
-    EXPECT_EQ("enckey", copy.EncryptionKey());
+    EXPECT_EQ("AABB01", copy.EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigTest, EncryptionKey_AfterSaveAndLoad) {
-    cfg.SetEncryptionKey("enckey");
+    cfg.SetEncryptionKey(cpputils::EncryptionKey::FromString("AABB01"));
     const CryConfig loaded = SaveAndLoad(std::move(cfg));
-    EXPECT_EQ("enckey", loaded.EncryptionKey());
+    EXPECT_EQ("AABB01", loaded.EncryptionKey().ToString());
 }
 
 TEST_F(CryConfigTest, Cipher_Init) {

--- a/test/cryfs/impl/filesystem/testutils/CryTestBase.h
+++ b/test/cryfs/impl/filesystem/testutils/CryTestBase.h
@@ -29,7 +29,7 @@ public:
     std::shared_ptr<cryfs::CryConfigFile> configFile() {
         cryfs::CryConfig config;
         config.SetCipher("aes-256-gcm");
-        config.SetEncryptionKey(cpputils::AES256_GCM::EncryptionKey::CreateKey(cpputils::Random::Csprng(), cpputils::AES256_GCM::KEYSIZE).ToString());
+        config.SetEncryptionKey(cpputils::AES256_GCM::EncryptionKey::CreateKey(cpputils::Random::Csprng(), cpputils::AES256_GCM::KEYSIZE));
         config.SetBlocksizeBytes(10240);
         cryfs::CryPresetPasswordBasedKeyProvider keyProvider("mypassword", cpputils::make_unique_ref<cpputils::SCrypt>(cpputils::SCrypt::TestSettings));
         return cryfs::CryConfigFile::create(_configFile.path(), std::move(config), &keyProvider);

--- a/test/cryfs/impl/localstate/LocalStateMetadataTest.cpp
+++ b/test/cryfs/impl/localstate/LocalStateMetadataTest.cpp
@@ -3,13 +3,26 @@
 #include <cryfs/impl/localstate/LocalStateMetadata.h>
 #include <cpp-utils/tempfile/TempDir.h>
 #include <fstream>
-#include <cpp-utils/data/DataFixture.h>
+#include <cpp-utils/crypto/symmetric/EncryptionKey.h>
+#include <cpp-utils/random/Random.h>
 
 using cpputils::TempDir;
-using cpputils::Data;
+using cpputils::EncryptionKey;
 using cryfs::LocalStateMetadata;
-using cpputils::DataFixture;
 using std::ofstream;
+
+namespace {
+EncryptionKey generateKey(unsigned int seed) {
+    // Generate a deterministic key by repeating the seed byte
+    std::string hex;
+    for (size_t i = 0; i < 32; ++i) {
+        char buf[3];
+        snprintf(buf, sizeof(buf), "%02X", (seed + i) & 0xFF);
+        hex += buf;
+    }
+    return EncryptionKey::FromString(hex);
+}
+}
 
 class LocalStateMetadataTest : public ::testing::Test {
 public:
@@ -18,14 +31,14 @@ public:
 };
 
 TEST_F(LocalStateMetadataTest, myClientId_ValueIsConsistent) {
-    const LocalStateMetadata metadata1 = LocalStateMetadata::loadOrGenerate(stateDir.path(), Data(0), false);
-    const LocalStateMetadata metadata2 = LocalStateMetadata::loadOrGenerate(stateDir.path(), Data(0), false);
+    const LocalStateMetadata metadata1 = LocalStateMetadata::loadOrGenerate(stateDir.path(), EncryptionKey::Null(0), false);
+    const LocalStateMetadata metadata2 = LocalStateMetadata::loadOrGenerate(stateDir.path(), EncryptionKey::Null(0), false);
     EXPECT_EQ(metadata1.myClientId(), metadata2.myClientId());
 }
 
 TEST_F(LocalStateMetadataTest, myClientId_ValueIsRandomForNewClient) {
-    const LocalStateMetadata metadata1 = LocalStateMetadata::loadOrGenerate(stateDir.path(), Data(0), false);
-    const LocalStateMetadata metadata2 = LocalStateMetadata::loadOrGenerate(stateDir2.path(), Data(0), false);
+    const LocalStateMetadata metadata1 = LocalStateMetadata::loadOrGenerate(stateDir.path(), EncryptionKey::Null(0), false);
+    const LocalStateMetadata metadata2 = LocalStateMetadata::loadOrGenerate(stateDir2.path(), EncryptionKey::Null(0), false);
     EXPECT_NE(metadata1.myClientId(), metadata2.myClientId());
 }
 
@@ -35,20 +48,21 @@ TEST_F(LocalStateMetadataTest, myClientId_TakesLegacyValueIfSpecified) {
   file << 12345u;
   file.close();
 
-  const LocalStateMetadata metadata = LocalStateMetadata::loadOrGenerate(stateDir.path(), Data(0), false);
+  const LocalStateMetadata metadata = LocalStateMetadata::loadOrGenerate(stateDir.path(), EncryptionKey::Null(0), false);
   EXPECT_EQ(12345u, metadata.myClientId());
 }
 #endif
 
 TEST_F(LocalStateMetadataTest, encryptionKeyHash_whenLoadingWithSameKey_thenDoesntCrash) {
-  LocalStateMetadata::loadOrGenerate(stateDir.path(), DataFixture::generate(1024), false);
-  LocalStateMetadata::loadOrGenerate(stateDir.path(), DataFixture::generate(1024), false);
+  const auto key = generateKey(1);
+  LocalStateMetadata::loadOrGenerate(stateDir.path(), key, false);
+  LocalStateMetadata::loadOrGenerate(stateDir.path(), key, false);
 }
 
 TEST_F(LocalStateMetadataTest, encryptionKeyHash_whenLoadingWithDifferentKey_thenCrashes) {
-  LocalStateMetadata::loadOrGenerate(stateDir.path(), DataFixture::generate(1024, 1), false);
+  LocalStateMetadata::loadOrGenerate(stateDir.path(), generateKey(1), false);
   EXPECT_THROW(
-    LocalStateMetadata::loadOrGenerate(stateDir.path(), DataFixture::generate(1024, 2), false),
+    LocalStateMetadata::loadOrGenerate(stateDir.path(), generateKey(2), false),
     std::runtime_error
   );
 }

--- a/test/cryfs/impl/localstate/LocalStateMetadataTest.cpp
+++ b/test/cryfs/impl/localstate/LocalStateMetadataTest.cpp
@@ -4,23 +4,17 @@
 #include <cpp-utils/tempfile/TempDir.h>
 #include <fstream>
 #include <cpp-utils/crypto/symmetric/EncryptionKey.h>
-#include <cpp-utils/random/Random.h>
+#include <cpp-utils/data/DataFixture.h>
 
 using cpputils::TempDir;
 using cpputils::EncryptionKey;
+using cpputils::DataFixture;
 using cryfs::LocalStateMetadata;
 using std::ofstream;
 
 namespace {
-EncryptionKey generateKey(unsigned int seed) {
-    // Generate a deterministic key by repeating the seed byte
-    std::string hex;
-    for (size_t i = 0; i < 32; ++i) {
-        char buf[3];
-        snprintf(buf, sizeof(buf), "%02X", (seed + i) & 0xFF);
-        hex += buf;
-    }
-    return EncryptionKey::FromString(hex);
+EncryptionKey generateKey(size_t size, unsigned int seed = 1) {
+    return EncryptionKey::FromString(DataFixture::generate(size, seed).ToString());
 }
 }
 
@@ -54,15 +48,15 @@ TEST_F(LocalStateMetadataTest, myClientId_TakesLegacyValueIfSpecified) {
 #endif
 
 TEST_F(LocalStateMetadataTest, encryptionKeyHash_whenLoadingWithSameKey_thenDoesntCrash) {
-  const auto key = generateKey(1);
+  const auto key = generateKey(1024);
   LocalStateMetadata::loadOrGenerate(stateDir.path(), key, false);
   LocalStateMetadata::loadOrGenerate(stateDir.path(), key, false);
 }
 
 TEST_F(LocalStateMetadataTest, encryptionKeyHash_whenLoadingWithDifferentKey_thenCrashes) {
-  LocalStateMetadata::loadOrGenerate(stateDir.path(), generateKey(1), false);
+  LocalStateMetadata::loadOrGenerate(stateDir.path(), generateKey(1024, 1), false);
   EXPECT_THROW(
-    LocalStateMetadata::loadOrGenerate(stateDir.path(), generateKey(2), false),
+    LocalStateMetadata::loadOrGenerate(stateDir.path(), generateKey(1024, 2), false),
     std::runtime_error
   );
 }


### PR DESCRIPTION
Summary
The EncryptionKey class provides memory protection (mlock) and secure zeroing on free via UnswappableAllocator, but encryption keys were being converted to plain std::string in a few places (e.g. config file handling), bypassing these protections.
Changed CryConfig::_encKey from std::string to cpputils::EncryptionKey and updated all call sites (CryCipher, CryConfigCreator, CryConfigLoader, LocalStateMetadata) to pass EncryptionKey objects directly. Keys are now only converted to/from hex strings at serialization boundaries (config file I/O).
Added an EncryptionKey::hash(Salt) method so callers can hash key material without exposing internals.
Context
This is not a vulnerability in CryFS's threat model — keys lingering in unprotected process memory would only matter if the local machine is already compromised (e.g. memory disclosure exploits), which is outside the scope of what CryFS defends against (protecting data at rest on cloud storage). However, it is good practice to minimize the window during which key material sits in unprotected memory.