### PR TITLE
Add buffer size validation to CryFS header checks

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -14,6 +14,12 @@ Version 1.0.4 (unreleased)
     but there were a few exceptions (e.g. config file handling) where keys were converted to plain
     std::string, bypassing the memory protections. Keys are now only converted to/from hex strings
     at serialization boundaries (config file I/O).
+* Fixed: Undefined behavior in OnDiskBlockStore2 when loading a block file smaller than the format
+  version header. The header validation functions (_isAcceptedCryfsHeader, _isOtherCryfsHeader)
+  called std::memcmp without first checking that the data buffer was large enough, causing a
+  heap buffer over-read. In practice, this would occur if a block file on disk was truncated or
+  corrupted, and the memcmp would simply fail to match — but it is still undefined behavior that
+  should be avoided. Added bounds checks before the memcmp calls.
 
 
 Version 1.0.3

--- a/src/blockstore/implementations/ondisk/OnDiskBlockStore2.cpp
+++ b/src/blockstore/implementations/ondisk/OnDiskBlockStore2.cpp
@@ -37,10 +37,16 @@ Data OnDiskBlockStore2::_checkAndRemoveHeader(const Data &data) {
 }
 
 bool OnDiskBlockStore2::_isAcceptedCryfsHeader(const Data &data) {
+  if (data.size() < formatVersionHeaderSize()) {
+    return false;
+  }
   return 0 == std::memcmp(data.data(), FORMAT_VERSION_HEADER.c_str(), formatVersionHeaderSize());
 }
 
 bool OnDiskBlockStore2::_isOtherCryfsHeader(const Data &data) {
+  if (data.size() < FORMAT_VERSION_HEADER_PREFIX.size()) {
+    return false;
+  }
   return 0 == std::memcmp(data.data(), FORMAT_VERSION_HEADER_PREFIX.c_str(), FORMAT_VERSION_HEADER_PREFIX.size());
 }
 

--- a/test/blockstore/implementations/ondisk/OnDiskBlockStoreTest_Specific.cpp
+++ b/test/blockstore/implementations/ondisk/OnDiskBlockStoreTest_Specific.cpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <fstream>
+#include <string_view>
 
 using ::testing::Test;
 
@@ -88,15 +89,15 @@ TEST_F(OnDiskBlockStoreTest, LoadingBlockWithEmptyFile_ThrowsError) {
 
 TEST_F(OnDiskBlockStoreTest, LoadingBlockWithUndersizedFile_ThrowsError) {
   const BlockId blockId = BlockId::FromString("AB0123456789ABCDEF0123456789AB01");
-  const char shortData[] = "cryfs";
-  writeRawBlockFile(blockId, shortData, sizeof(shortData) - 1);
+  constexpr std::string_view shortData = "cryfs";
+  writeRawBlockFile(blockId, shortData.data(), shortData.size());
   EXPECT_THROW(blockStore.load(blockId), std::runtime_error);
 }
 
 TEST_F(OnDiskBlockStoreTest, LoadingBlockWithSizeBetweenPrefixAndFullHeader_ThrowsError) {
   // Data larger than FORMAT_VERSION_HEADER_PREFIX but smaller than full header
   const BlockId blockId = BlockId::FromString("AB0123456789ABCDEF0123456789AB01");
-  const char partialHeader[] = "cryfs;block;";
-  writeRawBlockFile(blockId, partialHeader, sizeof(partialHeader) - 1);
+  constexpr std::string_view partialHeader = "cryfs;block;";
+  writeRawBlockFile(blockId, partialHeader.data(), partialHeader.size());
   EXPECT_THROW(blockStore.load(blockId), std::runtime_error);
 }

--- a/test/blockstore/implementations/ondisk/OnDiskBlockStoreTest_Specific.cpp
+++ b/test/blockstore/implementations/ondisk/OnDiskBlockStoreTest_Specific.cpp
@@ -1,14 +1,17 @@
 #include <gtest/gtest.h>
 #include "blockstore/implementations/ondisk/OnDiskBlockStore2.h"
 #include <cpp-utils/tempfile/TempDir.h>
+#include <boost/filesystem.hpp>
 
 #include <cstddef>
+#include <fstream>
 
 using ::testing::Test;
 
 using cpputils::TempDir;
 using cpputils::Data;
 using std::ifstream;
+using std::ofstream;
 using blockstore::BlockId;
 
 using namespace blockstore::ondisk;
@@ -30,6 +33,15 @@ public:
     ifstream stream((baseDir.path() / blockId.ToString().substr(0,3) / blockId.ToString().substr(3)).c_str());
     stream.seekg(0, stream.end);
     return stream.tellg();
+  }
+
+  void writeRawBlockFile(const BlockId &blockId, const void *data, size_t size) {
+    std::string idStr = blockId.ToString();
+    auto dir = baseDir.path() / idStr.substr(0, 3);
+    boost::filesystem::create_directories(dir);
+    auto filepath = dir / idStr.substr(3);
+    ofstream file(filepath.string().c_str(), std::ios::binary | std::ios::trunc);
+    file.write(static_cast<const char*>(data), static_cast<std::streamsize>(size));
   }
 };
 
@@ -66,4 +78,25 @@ TEST_F(OnDiskBlockStoreTest, NumBlocksIsCorrectAfterAddingTwoBlocksWithSameKeyPr
   EXPECT_TRUE(blockStore.tryCreate(key1, cpputils::Data(0)));
   EXPECT_TRUE(blockStore.tryCreate(key2, cpputils::Data(0)));
   EXPECT_EQ(2u, blockStore.numBlocks());
+}
+
+TEST_F(OnDiskBlockStoreTest, LoadingBlockWithEmptyFile_ThrowsError) {
+  const BlockId blockId = BlockId::FromString("AB0123456789ABCDEF0123456789AB01");
+  writeRawBlockFile(blockId, "", 0);
+  EXPECT_THROW(blockStore.load(blockId), std::runtime_error);
+}
+
+TEST_F(OnDiskBlockStoreTest, LoadingBlockWithUndersizedFile_ThrowsError) {
+  const BlockId blockId = BlockId::FromString("AB0123456789ABCDEF0123456789AB01");
+  const char shortData[] = "cryfs";
+  writeRawBlockFile(blockId, shortData, sizeof(shortData) - 1);
+  EXPECT_THROW(blockStore.load(blockId), std::runtime_error);
+}
+
+TEST_F(OnDiskBlockStoreTest, LoadingBlockWithSizeBetweenPrefixAndFullHeader_ThrowsError) {
+  // Data larger than FORMAT_VERSION_HEADER_PREFIX but smaller than full header
+  const BlockId blockId = BlockId::FromString("AB0123456789ABCDEF0123456789AB01");
+  const char partialHeader[] = "cryfs;block;";
+  writeRawBlockFile(blockId, partialHeader, sizeof(partialHeader) - 1);
+  EXPECT_THROW(blockStore.load(blockId), std::runtime_error);
 }

--- a/test/blockstore/implementations/ondisk/OnDiskBlockStoreTest_Specific.cpp
+++ b/test/blockstore/implementations/ondisk/OnDiskBlockStoreTest_Specific.cpp
@@ -36,7 +36,7 @@ public:
   }
 
   void writeRawBlockFile(const BlockId &blockId, const void *data, size_t size) {
-    std::string idStr = blockId.ToString();
+    std::string const idStr = blockId.ToString();
     auto dir = baseDir.path() / idStr.substr(0, 3);
     boost::filesystem::create_directories(dir);
     auto filepath = dir / idStr.substr(3);


### PR DESCRIPTION
## Summary
This PR adds critical buffer size validation to the CryFS header detection methods to prevent potential buffer over-read vulnerabilities when processing undersized block files.

## Key Changes
- **OnDiskBlockStore2.cpp**: Added size checks before `memcmp` operations in `_isAcceptedCryfsHeader()` and `_isOtherCryfsHeader()` to ensure the data buffer is large enough before comparing against header constants
- **OnDiskBlockStoreTest_Specific.cpp**: Added comprehensive test coverage including:
  - New `writeRawBlockFile()` helper method to create test block files with arbitrary content
  - Test for loading empty block files
  - Test for loading undersized block files
  - Test for loading files with partial headers (between prefix and full header size)

## Implementation Details
The validation checks ensure that:
1. `_isAcceptedCryfsHeader()` verifies data size is at least `formatVersionHeaderSize()` before comparing
2. `_isOtherCryfsHeader()` verifies data size is at least `FORMAT_VERSION_HEADER_PREFIX.size()` before comparing

These guards prevent undefined behavior when `memcmp` is called on buffers smaller than the comparison length, which could occur when loading corrupted or malformed block files from disk.