### PR TITLE
rustfs: account for umask in mkdir test_mode assertion

### DIFF
--- a/crates/rustfs/src/tests/mkdir.rs
+++ b/crates/rustfs/src/tests/mkdir.rs
@@ -173,8 +173,11 @@ mod arguments {
             test_mkdir(
                 &path,
                 async move |driver| driver.mkdir(&path, mode_arg).await,
-                move |_, _req, _parent_ino, _name, mode, _umask| {
-                    assert_eq!(expected_mode_return, mode);
+                move |_, _req, _parent_ino, _name, mode, umask| {
+                    // The kernel applies the calling process's umask to mode before passing
+                    // it to the FUSE handler, so we compare against the post-umask value.
+                    let expected_after_umask = expected_mode_return & !Mode::from(umask);
+                    assert_eq!(expected_after_umask, mode);
                     mkdir_return_ok(mode)
                 },
             )


### PR DESCRIPTION
The kernel applies the calling process's umask to mode before passing the mkdir request to the FUSE handler, so the handler receives mode already masked. The test was comparing the raw input mode against the masked mode received by the handler, which fails when umask is non-zero (every CI runner runs with umask 0o22).

The failure on CI looked like:

```
---- tests::mkdir::arguments::mode::test_mode::case_3::path_1_path____some_component___ stdout ----
...
thread '...' panicked at crates/rustfs/src/tests/mkdir.rs:177:21:
assertion `left == right` failed
  left: Mode(0o40764)
 right: Mode(0o40744)
```

(`0o40764` was the raw expected mode with the dir-flag bit; `0o40744` is what the kernel handed us after applying umask `0o22`.)

This PR ANDs the expected value with `!umask` before comparing. Cases that don't have group-write set in the expected mode (case_1, case_2) were already passing because masking 0 by 0o22 is still 0.

Verified locally with `cargo +nightly test -p cryfs-rustfs --lib -- tests::mkdir::arguments::mode::test_mode` (all 8 cases pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6)_