### PR TITLE
ci: fix crate name in check matrix (fsblobstore, not cryfs-fsblobstore)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crate: ["blobstore", "blockstore", "check", "cli-utils", "concurrent-store", "cryfs-config", "cryfs-cli", "cryfs-filesystem", "cryfs-runner", "cryfs-version", "crypto", "e2e-perf-tests", "cryfs-fsblobstore", "rustfs", "tempproject", "utils"]
+        crate: ["blobstore", "blockstore", "check", "cli-utils", "concurrent-store", "cryfs-config", "cryfs-cli", "cryfs-filesystem", "cryfs-runner", "cryfs-version", "crypto", "e2e-perf-tests", "fsblobstore", "rustfs", "tempproject", "utils"]
         targets: ["", "--tests", "--examples", "--benches"]
         features: ["", "--no-default-features", "--all-features"]
         profile: ["", "--release"]


### PR DESCRIPTION
The directory under `crates/` is `fsblobstore`, not `cryfs-fsblobstore`, so the `check (cryfs-fsblobstore, ...)` jobs in the `crates_individually_testable` matrix all fail to start with:

```
An error occurred trying to start process '/usr/bin/bash' with
working directory '/home/runner/work/cryfs/cryfs/./crates/cryfs-fsblobstore'.
No such file or directory
```

This entry has been broken since the check matrix was added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6)_