### PR TITLE
ci: replace deprecated actions-rs/* with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,10 @@ jobs:
       - name: Install Dependencies (MacOS)
         if: ${{ runner.os == 'macOS' }}
         run: brew install pkg-config macfuse
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-          default: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: ${{ matrix.command }}
-          args: ${{ matrix.features }} ${{ matrix.profile }}
+      - run: cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }}
   crates_individually_testable:
     # This job tests that each crate can be built and tested individually.
     # We don't actually run any tests because those are being run as part of other CI jobs already.
@@ -68,10 +64,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Dependencies
         run: sudo apt-get install -y fuse3 libfuse3-dev
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: cargo check
         working-directory: ./crates/${{ matrix.crate }}
         run: cargo check ${{ matrix.profile }} ${{ matrix.features }} ${{matrix.targets}}
@@ -98,11 +91,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
-          default: true
       - uses: mbrobbel/rustfmt-check@0.5.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -122,10 +113,7 @@ jobs:
     - uses: actions/checkout@v6
     - name: Install Dependencies
       run: sudo apt-get install -y fuse3 libfuse3-dev
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        default: true
+    - uses: dtolnay/rust-toolchain@stable
     - run: RUSTDOCFLAGS="-Dwarnings" cargo doc
   coverage:
     name: Code Coverage
@@ -135,10 +123,7 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         uses: jlumbroso/free-disk-space@v1.3.1
       - uses: actions/checkout@v6
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
       # Setup inspired by instructions at https://github.com/taiki-e/cargo-llvm-cov/blob/9b93f70f4c5a06d6ee221d3537067bc8d3f5b7c6/README.md
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install Dependencies (MacOS)
         if: ${{ runner.os == 'macOS' }}
         run: brew install pkg-config macfuse
-      - uses: dtolnay/rust-toolchain@master
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
           toolchain: ${{ matrix.toolchain }}
       - run: cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }}
@@ -64,7 +64,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install Dependencies
         run: sudo apt-get install -y fuse3 libfuse3-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
       - name: cargo check
         working-directory: ./crates/${{ matrix.crate }}
         run: cargo check ${{ matrix.profile }} ${{ matrix.features }} ${{matrix.targets}}
@@ -91,8 +93,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
         with:
+          toolchain: stable
           components: rustfmt
       - uses: mbrobbel/rustfmt-check@0.5.0
         with:
@@ -113,7 +116,9 @@ jobs:
     - uses: actions/checkout@v6
     - name: Install Dependencies
       run: sudo apt-get install -y fuse3 libfuse3-dev
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      with:
+        toolchain: stable
     - run: RUSTDOCFLAGS="-Dwarnings" cargo doc
   coverage:
     name: Code Coverage
@@ -123,7 +128,9 @@ jobs:
         if: ${{ runner.os == 'Linux' }}
         uses: jlumbroso/free-disk-space@v1.3.1
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        with:
+          toolchain: stable
       # Setup inspired by instructions at https://github.com/taiki-e/cargo-llvm-cov/blob/9b93f70f4c5a06d6ee221d3537067bc8d3f5b7c6/README.md
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
The `actions-rs/toolchain` and `actions-rs/cargo` actions are unmaintained (last release in 2020) and run on the deprecated Node.js 20 runtime, which GitHub plans to disable. Switch to the maintained `dtolnay/rust-toolchain` action and run cargo via a plain `run:` step.

No matrix or behavior change — the dtolnay action installs the same toolchain and the plain `run` step invokes cargo identically. Side benefit: cargo's stdout/stderr stream directly instead of being buffered through the actions-rs/cargo wrapper (which itself uses the deprecated `set-output` workflow command).

The two `actions-rs/*` references that remain in the file are inside the commented-out `clippy_check` job and don't run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6)_