### PR TITLE
ci: drop --all-features from llvm-cov coverage run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,14 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        # Don't pass --all-features. The cryfs-e2e-perf-tests crate's
+        # `benchmark` feature switches its perf_test_macro to a
+        # criterion-benchmark form that doesn't compile under
+        # `cargo build --tests` (which is what llvm-cov drives), only
+        # under `cargo bench`. With --all-features the coverage job
+        # fails to compile e2e-perf-tests; without it, every crate
+        # uses its default features and llvm-cov can finish.
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
`cargo llvm-cov` was running with `--all-features`, which enables the `benchmark` feature on `cryfs-e2e-perf-tests`. That feature switches its `perf_test_macro` to a criterion-benchmark form that compiles under `cargo bench` but not under `cargo build --tests` (which is what llvm-cov drives), so the coverage job fails to compile that crate before any coverage data can be collected.

Drop `--all-features` from the coverage run. With each crate using its default features only, `e2e-perf-tests` compiles cleanly. As a side benefit, this should noticeably shorten coverage's runtime — running under `--all-features` instrumentation has been pushing the job toward GitHub Actions' 6h job-time cap.

Verified locally: `cargo +nightly check --workspace --tests` builds clean.

---

(Updated per review feedback: original version excluded `cryfs-e2e-perf-tests` while keeping `--all-features`; this version drops `--all-features` instead, addressing both the compile error and the runtime cost in one change.)