### PR TITLE
ci: drop --release axis from check matrix to fit GitHub's 256 limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,13 @@ jobs:
         crate: ["blobstore", "blockstore", "check", "cli-utils", "concurrent-store", "cryfs-config", "cryfs-cli", "cryfs-filesystem", "cryfs-runner", "cryfs-version", "crypto", "e2e-perf-tests", "cryfs-fsblobstore", "rustfs", "tempproject", "utils"]
         targets: ["", "--tests", "--examples", "--benches"]
         features: ["", "--no-default-features", "--all-features"]
-        profile: ["", "--release"]
+        # TODO Re-add at least some release-profile coverage for this job.
+        # The full profile axis (debug vs release) was 16 × 4 × 3 × 2 = 384
+        # configurations, which exceeds GitHub Actions' 256-configuration
+        # matrix cap and caused the entire job to fail at matrix-resolution
+        # time. Either find a way to fit release back in (split into a
+        # second job, drop a less-valuable axis, exclude some
+        # crate/target/feature combinations) or accept debug-only here.
     steps:
       - name: Free Disk Space (Ubuntu)
         if: ${{ runner.os == 'Linux' }}
@@ -74,7 +80,7 @@ jobs:
           default: true
       - name: cargo check
         working-directory: ./crates/${{ matrix.crate }}
-        run: cargo check ${{ matrix.profile }} ${{ matrix.features }} ${{matrix.targets}}
+        run: cargo check ${{ matrix.features }} ${{matrix.targets}}
   # clippy_check:
   #   name: Linter (clippy)
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
The `crates_individually_testable` job's matrix was 16 crates × 4 targets × 3 features × 2 profiles = 384 configurations, which exceeds GitHub Actions' hard cap of 256. The whole job was failing at matrix-resolution time with:

```
Error: Strategy for job 'crates_individually_testable' produced 384
configurations which exceeds the maximum of 256 configurations
```

Drop the profile axis. The remaining 192 (debug-only) configurations still catch the per-crate / per-feature / per-target compile errors this job exists to validate; release-mode would catch the same set of issues at higher compile cost.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6)_