### PR TITLE
ci: skip slow integration tests in coverage to fit 6h job limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,11 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
-        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        # --lib --bins skips integration tests. The slow cli-utils integration
+        # tests spawn child cargo builds via tempproject; the child binaries
+        # aren't instrumented so they contribute no coverage data anyway, but
+        # they push the run past GitHub's hard 6h job limit.
+        run: cargo llvm-cov --all-features --workspace --lib --bins --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
The Code Coverage job hits GitHub Actions' hard 6h timeout. The dominant cost is the `cli-utils` integration test suite, whose tests spawn child cargo builds via `tempproject`. Each child build has to compile `cryfs-cli-utils` + many transitive dependencies in a fresh target dir; multiplied across ~200 such tests under llvm-cov instrumentation, it runs past 6h.

Add `--lib --bins` so coverage only runs lib and bin unit tests, not the `tests/` integration suites. The coverage data lost to this is minimal: the child binaries spawned by those integration tests aren't instrumented to begin with, so they contribute no coverage information about `cryfs-cli-utils` source either way.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6)_