### PR TITLE
utils: fix unstable_name_collisions warnings in extension trait tests

### DIFF
--- a/crates/utils/src/containers.rs
+++ b/crates/utils/src/containers.rs
@@ -95,7 +95,7 @@ mod tests {
         fn test_try_insert_new_key_succeeds() {
             let mut map: HashMap<i32, &str> = HashMap::new();
 
-            let result = map.try_insert(1, "one");
+            let result = HashMapExt::try_insert(&mut map, 1, "one");
 
             assert!(result.is_ok());
             assert_eq!(Some(&"one"), map.get(&1));
@@ -105,7 +105,7 @@ mod tests {
         fn test_try_insert_returns_mutable_reference() {
             let mut map: HashMap<i32, String> = HashMap::new();
 
-            let value_ref = map.try_insert(1, String::from("one")).unwrap();
+            let value_ref = HashMapExt::try_insert(&mut map, 1, String::from("one")).unwrap();
             value_ref.push_str(" modified");
 
             assert_eq!(Some(&String::from("one modified")), map.get(&1));
@@ -116,7 +116,7 @@ mod tests {
             let mut map: HashMap<i32, &str> = HashMap::new();
             map.insert(1, "one");
 
-            let result = map.try_insert(1, "uno");
+            let result = HashMapExt::try_insert(&mut map, 1, "uno");
 
             assert!(result.is_err());
             // Original value should be unchanged
@@ -128,7 +128,7 @@ mod tests {
             let mut map: HashMap<i32, &str> = HashMap::new();
             map.insert(1, "one");
 
-            let err = map.try_insert(1, "uno").unwrap_err();
+            let err = HashMapExt::try_insert(&mut map, 1, "uno").unwrap_err();
 
             assert_eq!(&1, err.entry.key());
             assert_eq!(&"one", err.entry.get());
@@ -140,7 +140,7 @@ mod tests {
             let mut map: HashMap<i32, &str> = HashMap::new();
             map.insert(1, "one");
 
-            let err = map.try_insert(1, "uno").unwrap_err();
+            let err = HashMapExt::try_insert(&mut map, 1, "uno").unwrap_err();
             let display = format!("{}", err);
 
             assert!(display.contains("1"));

--- a/crates/utils/src/peekable.rs
+++ b/crates/utils/src/peekable.rs
@@ -44,22 +44,22 @@ mod tests {
     #[test]
     fn test_is_empty_on_empty_iterator() {
         let mut iter = std::iter::empty::<i32>().peekable();
-        assert!(iter.is_empty());
+        assert!(PeekableExt::is_empty(&mut iter));
     }
 
     #[test]
     fn test_is_empty_on_nonempty_iterator() {
         let mut iter = [1, 2, 3].into_iter().peekable();
-        assert!(!iter.is_empty());
+        assert!(!PeekableExt::is_empty(&mut iter));
     }
 
     #[test]
     fn test_is_empty_after_consuming_all_items() {
         let mut iter = [1].into_iter().peekable();
-        assert!(!iter.is_empty());
+        assert!(!PeekableExt::is_empty(&mut iter));
 
         iter.next();
-        assert!(iter.is_empty());
+        assert!(PeekableExt::is_empty(&mut iter));
     }
 
     #[test]
@@ -67,8 +67,8 @@ mod tests {
         let mut iter = [1, 2].into_iter().peekable();
 
         // Check twice - should still have elements
-        assert!(!iter.is_empty());
-        assert!(!iter.is_empty());
+        assert!(!PeekableExt::is_empty(&mut iter));
+        assert!(!PeekableExt::is_empty(&mut iter));
 
         // First element should still be available
         assert_eq!(Some(1), iter.next());


### PR DESCRIPTION
HashMapExt::try_insert and PeekableExt::is_empty shadow methods that
may be stabilized in std, which produced 11 future-incompatibility
warnings from the test modules. Switch the test call sites to fully
qualified syntax, matching the convention already used by production
callers (e.g. handle_forest/node.rs).