### PR TITLE
Apply rustfmt to two files left unformatted by recent commits

### DIFF
--- a/crates/blockstore/src/low_level/implementations/integrity/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/integrity/mod.rs
@@ -644,10 +644,7 @@ mod specialized_tests {
         fn new() -> Self {
             Self {
                 underlying: SyncDrop::new(SharedBlockStore::new(InMemoryBlockStore::new())),
-                integrity_file_dir: tempfile::Builder::new()
-                    .prefix("test")
-                    .tempdir()
-                    .unwrap(),
+                integrity_file_dir: tempfile::Builder::new().prefix("test").tempdir().unwrap(),
                 integrity_violation_triggered: Arc::new(Mutex::new(None)),
             }
         }

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -17,8 +17,8 @@ pub mod peekable;
 pub mod periodic_task;
 pub mod progress;
 pub mod stream;
-pub mod tmpfile;
 pub mod threadpool;
+pub mod tmpfile;
 
 #[cfg(any(test, feature = "testutils"))]
 pub mod testutils;


### PR DESCRIPTION
`cargo fmt --check` currently fails on main with diffs in:

- `crates/blockstore/src/low_level/implementations/integrity/mod.rs:644` — a `tempfile::Builder::new().prefix(...).tempdir().unwrap()` chain that fits on one line is wrapped across four.
- `crates/utils/src/lib.rs:17` — `pub mod tmpfile;` declared before `pub mod threadpool;`; rustfmt wants alphabetical order.

Both look like they slipped in along with the recent tempdir → tempfile swap.

The CI `Code Formatter (rustfmt)` job didn't catch this because `mbrobbel/rustfmt-check@0.5.0` tries to post the formatting diff as a GitHub check annotation, and the workflow's `permissions: contents: read` doesn't grant the `checks: write` it needs. The action fails with `Resource not accessible by integration` instead of surfacing the diff. That's worth fixing separately, but the immediate need is just to make `cargo fmt --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6)_