### PR TITLE
ci: cancel superseded runs via concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
   - push
   - pull_request
 
+# Cancel in-progress runs on the same ref when a new commit is pushed,
+# so a fix-up push doesn't have to wait behind the superseded run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
When a new commit lands on a ref (branch or PR), the previous in-flight CI run on that ref keeps going to completion alongside the new one, even though its results no longer matter. With a 72-job test matrix that takes ~50 min per Linux job and longer on macOS, stacking a few fix-up pushes during review piles up dozens of stale jobs and starves the new run of runner slots.

Add a `concurrency` block that auto-cancels in-progress runs in the same ref's group when a new run starts. Push and pull_request events land in distinct groups because `github.ref` differs (`refs/heads/...` vs `refs/pull/<N>/merge`), so a push and the matching PR run on the same commit don't cancel each other.

Reference: <https://docs.github.com/en/actions/using-jobs/using-concurrency>

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6)_