### PR TITLE
runner: fix daemon_survives_parent_exit pid-read race

### DIFF
--- a/crates/cryfs-runner/tests/daemon_survives_parent_exit.rs
+++ b/crates/cryfs-runner/tests/daemon_survives_parent_exit.rs
@@ -114,21 +114,25 @@ fn daemon_survives_parent_exit() {
             // Wait for the daemon to publish its PID. The daemon is a
             // grandchild of this test, not a direct child, so we discover it
             // via the PID file rather than waitpid.
+            //
+            // Poll on parseable content rather than just file existence:
+            // `std::fs::write` (used by the daemon) creates the file before
+            // it writes, so a naive `pid_path.exists()` check can win the
+            // race and read an empty file. macOS exposes this race more
+            // often than Linux.
             let pid_deadline = Instant::now() + Duration::from_secs(5);
-            while !pid_path.exists() {
+            let daemon_pid = loop {
+                if let Ok(contents) = std::fs::read_to_string(&pid_path) {
+                    if let Ok(pid) = contents.trim().parse::<i32>() {
+                        break Pid::from_raw(pid);
+                    }
+                }
                 assert!(
                     Instant::now() < pid_deadline,
-                    "daemon did not write PID file within 5s",
+                    "daemon did not publish a parseable PID within 5s",
                 );
                 thread::sleep(Duration::from_millis(20));
-            }
-            let daemon_pid = Pid::from_raw(
-                std::fs::read_to_string(&pid_path)
-                    .expect("read pid file")
-                    .trim()
-                    .parse::<i32>()
-                    .expect("parse pid"),
-            );
+            };
             // Installed *before* any assertion below, so the daemon gets
             // killed even if a check panics.
             let _guard = DaemonGuard(daemon_pid);


### PR DESCRIPTION
The `daemon_survives_parent_exit` integration test polls `pid_path.exists()` and then reads + parses the file, but `std::fs::write` (used by the daemon's `daemon_main`) creates the file *before* writing its contents. The polling loop can win the race, observe `exists() == true`, then read an empty file and panic with:

```
thread 'daemon_survives_parent_exit' panicked at
crates/cryfs-runner/tests/daemon_survives_parent_exit.rs:130:22:
parse pid: ParseIntError { kind: Empty }
```

macOS surfaces this more often than Linux (caught it on a recent CI run), but it's a race on both platforms.

Fix: poll on parseable content instead of just file existence — retry the read+parse until both succeed, or the 5-second deadline elapses.

The sentinel-file polling that comes a few lines below has the same shape but is naturally robust (it compares two reads for inequality, so racing into an initially-empty file still works — the second read will pick up the real tick value), so it doesn't need this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6)_