### PR TITLE
ci: fix macOS jobs — skip FUSE-mounting + DNS-dependent tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,16 @@ jobs:
         #      the FUSE session/mountpoint plumbing could be stubbed.
         run: |
           if [[ "${{ runner.os }}" == "macOS" ]]; then
-            cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }} -- --skip tests::mkdir:: --skip tests::utils::fuser_runner::
+            # Also skip http_client::test_get_valid_{http,https}: they hit
+            # http://example.com / https://example.com over the real network,
+            # so they fail whenever the runner's DNS resolver hiccups
+            # (observed on macos-15-intel: getaddrinfo returned EAI_NONAME
+            # for example.com mid-job even though DNS had worked at job
+            # start — macOS runners have a history of flaky resolver
+            # behavior, e.g. actions/runner-images#12562, #8649). They're
+            # reqwest smoke tests, not cryfs unit tests, and still run on
+            # Linux CI and locally.
+            cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }} -- --skip tests::mkdir:: --skip tests::utils::fuser_runner:: --skip version::http_client::tests::reqwest_http_client::test_get_valid_
           else
             cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }}
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,18 @@ jobs:
       - name: cargo ${{ matrix.command }}
         shell: bash
         # On GitHub-hosted macOS runners we have to skip the cryfs-rustfs
-        # tests under `tests::mkdir::`: they mount real FUSE sessions via
-        # fuser → macFUSE, and the runner image won't approve macFUSE's
-        # kernel extension (https://github.com/actions/runner-images/issues/4731),
-        # so the mount() syscall hangs forever and the job runs out the
-        # 6h clock. The tests still work on a local macOS where the
-        # operator has approved the kext, so we deliberately don't
-        # cfg-gate them out at compile time — only this CI invocation
-        # skips them. Keep the filter in sync with the test module paths
-        # under crates/rustfs/src/tests/.
+        # tests that mount real FUSE sessions via fuser → macFUSE: the
+        # runner image won't approve macFUSE's kernel extension
+        # (https://github.com/actions/runner-images/issues/4731), so the
+        # mount() syscall hangs forever and the job runs out the 6h clock.
+        # That's all tests under crates/rustfs/src/tests/ — currently the
+        # `tests::mkdir::` module and the fuser_runner self-tests in
+        # `tests::utils::fuser_runner::`. The tests still work on a local
+        # macOS where the operator has approved the kext, so we
+        # deliberately don't cfg-gate them out at compile time — only this
+        # CI invocation skips them. The --skip filters match by substring;
+        # keep them in sync with the test module paths under
+        # crates/rustfs/src/tests/.
         #
         # TODO Find a way to run these tests on GitHub-hosted macOS too:
         #   1. Switch to fuse-t (https://www.fuse-t.org/) — userspace
@@ -75,7 +78,7 @@ jobs:
         #      the FUSE session/mountpoint plumbing could be stubbed.
         run: |
           if [[ "${{ runner.os }}" == "macOS" ]]; then
-            cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }} -- --skip tests::mkdir::
+            cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }} -- --skip tests::mkdir:: --skip tests::utils::fuser_runner::
           else
             cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }}
           fi


### PR DESCRIPTION
## Summary

This PR makes **all macOS CI jobs pass** — they previously hung until the 6h execution cap. It contains the two remaining skip-filter fixes that were validated on the diagnostic branch (PR #538), where the **full 48-job macOS matrix (macos-14 / macos-15 / macos-15-intel / macos-26 × debug/release × default/no-default-features × stable/nightly/1.95) finished fully GREEN**: https://github.com/cryfs/cryfs/actions/runs/27376116816

### Commit 1: skip fuser_runner self-tests on GitHub-hosted macOS

The `--skip tests::mkdir::` filter added in #548 for the macFUSE-kext problem (GitHub-hosted macOS runners can't approve the kext, so FUSE `mount()` hangs forever — actions/runner-images#4731) missed two tests: `crates/rustfs/src/tests/utils/fuser_runner.rs` has its own `mod tests` whose two self-tests also mount a real FUSE session. They hung every macOS job on main. This adds `--skip tests::utils::fuser_runner::` to the macOS CI invocation. The tests still compile everywhere and still run on Linux CI and on local macOS with an approved kext.

### Commit 2: skip network-dependent http_client tests on macOS

`version::http_client::tests::reqwest_http_client::test_get_valid_{http,https}` fetch example.com over the real network, so they fail whenever the runner's DNS resolver hiccups. Observed on a macos-15-intel job (run 27254378285): both tests panicked with `failed to lookup address information: nodename nor servname provided, or not known` — even though DNS had worked at the start of the same job (brew install and crates.io downloads succeeded). So this is a transient resolver failure under load, not a blocked network; macOS runners have a documented history of flaky resolver behavior (actions/runner-images#12562, actions/runner-images#8649). The tests are reqwest smoke tests, not cryfs unit tests, and still run on Linux CI and locally.

### Validation

- 36-job run (macos-14/15/26): all green — run 27292537287
- 4-job Intel experiment: green in 2h–3h13m — run 27292808115
- Final full 48-job macOS matrix with these exact filters: **all 48 green, zero failures** — run 27376116816 (Intel legs: 1h48m–2h42m; ARM legs: 47m–1h54m)

Note: macos-15-intel runners are ~2-3× slower than the ARM ones (the cli-utils `tests/arguments.rs` suite builds child cargo projects there), so Intel legs take 2-3h. That fits within GitHub's default 6h job cap with room to spare.

https://claude.ai/code/session_01NEzfSVasb3S1SgyLvRbbt6