### PR TITLE
fuse3: reject renameat2 flags instead of silently ignoring them

### DIFF
--- a/src/fspp/fuse/Fuse.cpp
+++ b/src/fspp/fuse/Fuse.cpp
@@ -708,9 +708,19 @@ int Fuse::symlink(const bf::path &to, const bf::path &from) {
 }
 
 int Fuse::rename(const bf::path &from, const bf::path &to, unsigned int flags) {
-  // TODO Handle flags correctly (see man renameat2)
-  UNUSED(flags);
   const ThreadNameForDebugging _threadName("rename");
+  // libfuse 3 forwards the renameat2() flags to us and expects the filesystem to honour them.
+  // We cannot: RENAME_EXCHANGE needs an atomic swap of two entries, and RENAME_NOREPLACE needs
+  // the "does the target exist" check to happen inside the rename. Silently ignoring them is
+  // not an option - a plain rename in response to RENAME_EXCHANGE reports success while
+  // destroying one of the two files, because our rename overwrites (and deletes) the target.
+  // Rejecting them restores exactly what happened before the move to libfuse 3: libfuse 2 had
+  // no FUSE_RENAME2 handler at all, so the kernel answered every flagged rename with EINVAL and
+  // callers fell back to a plain rename. This is also what libfuse's own passthrough example does.
+  // TODO Implement RENAME_NOREPLACE and RENAME_EXCHANGE instead of rejecting them.
+  if (flags != 0) {
+    return -EINVAL;
+  }
 #ifdef FSPP_LOG
   LOG(DEBUG, "rename({}, {})", from, to);
 #endif

--- a/test/fspp/CMakeLists.txt
+++ b/test/fspp/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     fuse/rename/testutils/FuseRenameTest.cpp
     fuse/rename/FuseRenameErrorTest.cpp
     fuse/rename/FuseRenameFilenameTest.cpp
+    fuse/rename/FuseRenameFlagsTest.cpp
     fuse/utimens/testutils/FuseUtimensTest.cpp
     fuse/utimens/FuseUtimensErrorTest.cpp
     fuse/utimens/FuseUtimensFilenameTest.cpp

--- a/test/fspp/fuse/rename/FuseRenameFlagsTest.cpp
+++ b/test/fspp/fuse/rename/FuseRenameFlagsTest.cpp
@@ -1,0 +1,74 @@
+#include "testutils/FuseRenameTest.h"
+
+#include <cerrno>
+
+using ::testing::Eq;
+using ::testing::Return;
+using ::testing::_;
+
+// libfuse 3 hands the renameat2() flags to the filesystem and expects it to honour them.
+// CryFS cannot: RENAME_EXCHANGE needs an atomic swap and RENAME_NOREPLACE needs the
+// existence check to happen inside the rename. Ignoring the flags is actively dangerous -
+// a plain rename in response to RENAME_EXCHANGE reports success while destroying one of the
+// two files. So we reject them, which is what the kernel did for us under libfuse 2.
+
+#if defined(__linux__)
+
+// From <linux/fs.h>; defined here so the test does not depend on that header being available.
+#ifndef RENAME_NOREPLACE
+#define RENAME_NOREPLACE (1 << 0)
+#endif
+#ifndef RENAME_EXCHANGE
+#define RENAME_EXCHANGE (1 << 1)
+#endif
+#ifndef RENAME_WHITEOUT
+#define RENAME_WHITEOUT (1 << 2)
+#endif
+
+class FuseRenameFlagsTest: public FuseRenameTest {
+public:
+  void ReturnTwoExistingFiles() {
+    ReturnIsFileOnLstat(FILENAME1);
+    ReturnIsFileOnLstat(FILENAME2);
+  }
+};
+
+TEST_F(FuseRenameFlagsTest, RenameExchange_IsRejectedAndDoesNotReachTheFilesystem) {
+  // Without this, the rename would go through as a plain rename: it would report success
+  // while overwriting (and deleting) one of the two files.
+  ReturnTwoExistingFiles();
+  EXPECT_CALL(*fsimpl, rename(_, _)).Times(0);
+
+  const int error = Renameat2ReturnError(FILENAME1, FILENAME2, RENAME_EXCHANGE);
+  EXPECT_EQ(EINVAL, error);
+}
+
+TEST_F(FuseRenameFlagsTest, RenameNoreplace_IsRejectedAndDoesNotReachTheFilesystem) {
+  ReturnIsFileOnLstat(FILENAME1);
+  ReturnDoesntExistOnLstat(FILENAME2);
+  EXPECT_CALL(*fsimpl, rename(_, _)).Times(0);
+
+  const int error = Renameat2ReturnError(FILENAME1, FILENAME2, RENAME_NOREPLACE);
+  EXPECT_EQ(EINVAL, error);
+}
+
+TEST_F(FuseRenameFlagsTest, RenameWhiteout_IsRejected) {
+  ReturnIsFileOnLstat(FILENAME1);
+  ReturnDoesntExistOnLstat(FILENAME2);
+  EXPECT_CALL(*fsimpl, rename(_, _)).Times(0);
+
+  const int error = Renameat2ReturnError(FILENAME1, FILENAME2, RENAME_WHITEOUT);
+  EXPECT_EQ(EINVAL, error);
+}
+
+TEST_F(FuseRenameFlagsTest, WithoutFlags_TheRenameStillGoesThrough) {
+  // Regression guard: rejecting flags must not break the ordinary rename path.
+  ReturnIsFileOnLstat(FILENAME1);
+  ReturnDoesntExistOnLstat(FILENAME2);
+  EXPECT_CALL(*fsimpl, rename(Eq(FILENAME1), Eq(FILENAME2))).Times(1).WillOnce(Return());
+
+  const int error = Renameat2ReturnError(FILENAME1, FILENAME2, 0);
+  EXPECT_EQ(0, error);
+}
+
+#endif

--- a/test/fspp/fuse/rename/testutils/FuseRenameTest.cpp
+++ b/test/fspp/fuse/rename/testutils/FuseRenameTest.cpp
@@ -1,5 +1,12 @@
 #include "FuseRenameTest.h"
 
+#include <fcntl.h>
+#include <cerrno>
+#if defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
 
 void FuseRenameTest::Rename(const char *from, const char *to) {
   const int error = RenameReturnError(from, to);
@@ -17,4 +24,23 @@ int FuseRenameTest::RenameReturnError(const char *from, const char *to) {
   } else {
     return errno;
   }
+}
+
+int FuseRenameTest::Renameat2ReturnError(const char *from, const char *to, unsigned int flags) {
+#if defined(__linux__)
+  auto fs = TestFS();
+
+  auto realfrom = fs->mountDir() / from;
+  auto realto = fs->mountDir() / to;
+  // Call the syscall directly: glibc only grew a renameat2() wrapper in 2.28.
+  const int retval = ::syscall(SYS_renameat2, AT_FDCWD, realfrom.string().c_str(), AT_FDCWD, realto.string().c_str(), flags);
+  if (0 == retval) {
+    return 0;
+  } else {
+    return errno;
+  }
+#else
+  UNUSED(from); UNUSED(to); UNUSED(flags);
+  return ENOSYS;
+#endif
 }

--- a/test/fspp/fuse/rename/testutils/FuseRenameTest.h
+++ b/test/fspp/fuse/rename/testutils/FuseRenameTest.h
@@ -11,6 +11,10 @@ public:
 
   void Rename(const char *from, const char *to);
   int RenameReturnError(const char *from, const char *to);
+
+  // rename(2) cannot carry flags, so exercising the renameat2() flags needs a separate entry
+  // point. Returns the errno, or 0 on success.
+  int Renameat2ReturnError(const char *from, const char *to, unsigned int flags);
 };
 
 #endif


### PR DESCRIPTION
## Problem

libfuse 3 forwards the `renameat2()` flags to the filesystem and documents that the filesystem must honour them:

```c
// libfuse 3.9.0 include/fuse.h:349
 * If RENAME_NOREPLACE is specified, the filesystem must not overwrite
 * *newname* if it exists and return an error instead. If RENAME_EXCHANGE
 * is specified, the filesystem must atomically exchange the two files.
int (*rename) (const char *, const char *, unsigned int flags);
```

`Fuse::rename` discards them with a `UNUSED(flags)` TODO. That is not merely incomplete, it is destructive — `CryNode::rename` overwrites the target and its `onOverwritten` callback removes the target's blob, so a `RENAME_EXCHANGE` becomes a plain rename that **reports success while destroying one of the two files**.

**Reproduced on a real CryFS mount built from this branch:**

```
before:  a = AAAA    b = BBBB
$ renameat2(a -> b, RENAME_EXCHANGE) = 0        <-- reports success
after :  ls = [b]
         a IS GONE                              <-- data loss
         b = AAAA
```

`RENAME_NOREPLACE` happens to be safe today, because the VFS rejects it before the filesystem is ever reached:

```c
// Linux fs/namei.c:4886
if ((flags & RENAME_NOREPLACE) && d_is_positive(new_dentry))
        goto exit5;   /* -EEXIST */
```

(confirmed on a live mount: the target survived and the `rename` callback was never invoked). But `RENAME_EXCHANGE` has no such guard — `vfs_rename` calls `->rename` and then only swaps the dcache entries.

## Fix

Return `-EINVAL` for any non-zero flags.

This restores exactly the behaviour that existed before the migration: libfuse 2.9 had no `FUSE_RENAME2` handler, so the kernel answered every flagged rename with `EINVAL` and callers (coreutils `mv -n` among them) fall back to a plain rename. It is also what libfuse's own `passthrough.c` does:

```c
static int xmp_rename(const char *from, const char *to, unsigned int flags)
{
	if (flags)
		return -EINVAL;
```

Implementing the flags properly is left as a `TODO` — it needs an "overwrite allowed" flag plumbed through `fspp::Device::rename` down to `DirEntryList::rename`, which is a larger change than this fix warrants.

## Tests

The existing rename tests all go through `rename(2)`, which cannot carry flags, so nothing covered this. `FuseRenameFlagsTest` calls `renameat2()` directly (via `syscall`, since glibc only grew a wrapper in 2.28) and asserts both that the syscall fails and that the rename never reaches the filesystem:

| Test | Asserts |
|---|---|
| `RenameExchange_IsRejectedAndDoesNotReachTheFilesystem` | `EINVAL`, `rename` called 0 times |
| `RenameNoreplace_IsRejectedAndDoesNotReachTheFilesystem` | `EINVAL`, `rename` called 0 times |
| `RenameWhiteout_IsRejected` | `EINVAL` |
| `WithoutFlags_TheRenameStillGoesThrough` | regression guard: unflagged rename still works |

**3 of the 4 fail without this change.** Full `fspp-test` suite: **985 passing**.

The tests are guarded by `#if defined(__linux__)` since `renameat2` is Linux-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_