### PR TITLE
Report a failed mount instead of exiting successfully

### DIFF
--- a/src/cryfs-cli/Cli.cpp
+++ b/src/cryfs-cli/Cli.cpp
@@ -305,10 +305,14 @@ namespace cryfs_cli {
             std::cout << "\nMounting filesystem. To unmount, call:\n$ cryfs-unmount " << options.mountDir() << "\n"
                       << std::endl;
 
-            if (options.foreground()) {
-                fuse->runInForeground(options.mountDir(), options.fuseOptions());
-            } else {
-                fuse->runInBackground(options.mountDir(), options.fuseOptions());
+            const int fuseExitCode = options.foreground()
+                ? fuse->runInForeground(options.mountDir(), options.fuseOptions())
+                : fuse->runInBackground(options.mountDir(), options.fuseOptions());
+            if (0 != fuseExitCode) {
+                // libfuse refused to mount (e.g. an unknown '-o' option, or a missing fusermount3).
+                // It already printed the reason; without this we would exit successfully after
+                // telling the user the filesystem was being mounted.
+                throw CryfsException("Failed to mount filesystem. See error messages above.", ErrorCode::MountFailed);
             }
 
             if (stoppedBecauseOfIntegrityViolation) {

--- a/src/cryfs/impl/ErrorCodes.h
+++ b/src/cryfs/impl/ErrorCodes.h
@@ -56,7 +56,11 @@ enum class ErrorCode : int {
   IntegrityViolationOnPreviousRun = 24,
 
   // An integrity violation was detected and the file system unmounted to make sure the user notices.
-  IntegrityViolation = 25
+  IntegrityViolation = 25,
+
+  // libfuse refused to mount the file system, e.g. because a mount option isn't supported or
+  // because the fusermount3 helper is missing.
+  MountFailed = 26
 };
 
 inline int exitCode(ErrorCode code) {

--- a/src/fspp/fuse/Fuse.cpp
+++ b/src/fspp/fuse/Fuse.cpp
@@ -6,6 +6,7 @@
 #include "Fuse.h"
 #include <memory>
 #include <cassert>
+#include <cstdlib>
 
 #include "../fs_interface/FuseErrnoException.h"
 #include "Filesystem.h"
@@ -266,19 +267,19 @@ void Fuse::_logUnknownException() {
   LOG(ERR, "Unknown exception thrown");
 }
 
-void Fuse::runInForeground(const bf::path &mountdir, vector<string> fuseOptions) {
+int Fuse::runInForeground(const bf::path &mountdir, vector<string> fuseOptions) {
   vector<string> realFuseOptions = std::move(fuseOptions);
   if (std::find(realFuseOptions.begin(), realFuseOptions.end(), "-f") == realFuseOptions.end()) {
     realFuseOptions.push_back("-f");
   }
-  _run(mountdir, std::move(realFuseOptions));
+  return _run(mountdir, std::move(realFuseOptions));
 }
 
-void Fuse::runInBackground(const bf::path &mountdir, vector<string> fuseOptions) {
+int Fuse::runInBackground(const bf::path &mountdir, vector<string> fuseOptions) {
   vector<string> realFuseOptions = std::move(fuseOptions);
   _removeAndWarnIfExists(&realFuseOptions, "-f");
   _removeAndWarnIfExists(&realFuseOptions, "-d");
-  _run(mountdir, std::move(realFuseOptions));
+  return _run(mountdir, std::move(realFuseOptions));
 }
 
 void Fuse::_removeAndWarnIfExists(vector<string> *fuseOptions, const std::string &option) {
@@ -343,7 +344,7 @@ namespace {
   }
 }
 
-void Fuse::_run(const bf::path &mountdir, vector<string> fuseOptions) {
+int Fuse::_run(const bf::path &mountdir, vector<string> fuseOptions) {
 #if defined(__GLIBC__) || defined(__APPLE__) || defined(_MSC_VER)
   // Avoid encoding errors for non-utf8 characters, see https://github.com/cryfs/cryfs/issues/247
   // this is ifdef'd out for non-glibc linux, because musl doesn't handle this correctly.
@@ -361,11 +362,11 @@ void Fuse::_run(const bf::path &mountdir, vector<string> fuseOptions) {
   auto dokan_driver_version = DokanDriverVersion();
   if (dokan_driver_version == 0) {
     std::cerr << "Error: Did not find DokanY driver. Please install the newest version of DokanY from https://github.com/dokan-dev/dokany/releases" << std::endl;
-    return;
+    return EXIT_FAILURE;
   }
   if (dokan_driver_version != 400) {
     std::cerr << "Error: Unknown version of DokanY driver: " << dokan_driver_version << std::endl;
-    return;
+    return EXIT_FAILURE;
   }
 #endif
 
@@ -373,7 +374,7 @@ void Fuse::_run(const bf::path &mountdir, vector<string> fuseOptions) {
   if (!mountdir.has_root_name() || mountdir.has_root_directory() || mountdir.has_relative_path()) {
      // TODO Can we fix this and make mounting to non-drives work?
      std::cerr << "Unsupported mount directory " << mountdir << ". CryFS on Windows currently only supports mounting to drives, e.g. 'G:'" << std::endl;
-     return;
+     return EXIT_FAILURE;
   }
 #endif
 
@@ -386,7 +387,9 @@ void Fuse::_run(const bf::path &mountdir, vector<string> fuseOptions) {
 
   _argv = _build_argv(mountdir, fuseOptions);
 
-  fuse_main(_argv.size(), _argv.data(), operations(), this);
+  // Report the result: libfuse returns non-zero when it refused to mount, and silently
+  // continuing here would make a failed mount look like a successful one to our caller.
+  return fuse_main(_argv.size(), _argv.data(), operations(), this);
 }
 
 void Fuse::_createContext(const vector<string> &fuseOptions) {

--- a/src/fspp/fuse/Fuse.h
+++ b/src/fspp/fuse/Fuse.h
@@ -26,8 +26,14 @@ public:
   explicit Fuse(std::function<std::shared_ptr<Filesystem> (Fuse *fuse)> init, std::function<void()> onMounted, std::string fstype, boost::optional<std::string> fsname);
   ~Fuse();
 
-  void runInBackground(const boost::filesystem::path &mountdir, std::vector<std::string> fuseOptions);
-  void runInForeground(const boost::filesystem::path &mountdir, std::vector<std::string> fuseOptions);
+  // Both return the exit code of fuse_main(), i.e. 0 if the filesystem ran and was unmounted
+  // cleanly and non-zero if libfuse refused to mount it (see 'man fuse_main' / lib/helper.c:
+  // 1 = bad command line, 2 = no mountpoint, 3 = fuse_new failed e.g. an unknown '-o' option,
+  // 4 = mount failed e.g. fusermount3 missing, 5 = daemonize failed, 6 = signal handlers, 7 = loop).
+  // Note that in background mode libfuse forks and the parent exits inside fuse_main, so only
+  // failures that happen before daemonizing (1-4) are reported back to the caller.
+  int runInBackground(const boost::filesystem::path &mountdir, std::vector<std::string> fuseOptions);
+  int runInForeground(const boost::filesystem::path &mountdir, std::vector<std::string> fuseOptions);
   bool running() const;
   void stop();
 
@@ -67,7 +73,7 @@ private:
   static void _logUnknownException();
   static char *_create_c_string(const std::string &str);
   static void _removeAndWarnIfExists(std::vector<std::string> *fuseOptions, const std::string &option);
-  void _run(const boost::filesystem::path &mountdir, std::vector<std::string> fuseOptions);
+  int _run(const boost::filesystem::path &mountdir, std::vector<std::string> fuseOptions);
   static bool _has_option(const std::vector<char *> &vec, const std::string &key);
   static bool _has_entry_with_prefix(const std::string &prefix, const std::vector<char *> &vec);
   std::vector<char *> _build_argv(const boost::filesystem::path &mountdir, const std::vector<std::string> &fuseOptions);

--- a/test/cryfs-cli/CMakeLists.txt
+++ b/test/cryfs-cli/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     testutils/CliTest.cpp
     CliTest_Setup.cpp
     CliTest_WrongEnvironment.cpp
+    CliTest_MountFailure.cpp
     program_options/UtilsTest.cpp
     program_options/ProgramOptionsTest.cpp
     program_options/ParserTest.cpp

--- a/test/cryfs-cli/CliTest_MountFailure.cpp
+++ b/test/cryfs-cli/CliTest_MountFailure.cpp
@@ -1,0 +1,24 @@
+#include "testutils/CliTest.h"
+
+using cryfs::ErrorCode;
+using std::string;
+using std::vector;
+
+// Tests that a mount libfuse refuses is reported as an error instead of a successful run.
+class CliTest_MountFailure: public CliTest {
+public:
+    // libfuse parses 'entry_timeout' as a double, so it rejects this while setting up the file
+    // system and refuses the mount before anything gets mounted.
+    vector<string> argsWithUnparseableFuseOption() {
+        return {basedir.string(), mountdir.string(), "-f", "--cipher", "aes-256-gcm",
+                "-o", "entry_timeout=not_a_number"};
+    }
+};
+
+TEST_F(CliTest_MountFailure, WhenLibfuseRefusesToMount_ThenCryfsExitsWithAnError) {
+    EXPECT_RUN_ERROR(
+        argsWithUnparseableFuseOption(),
+        "Error 26: Failed to mount filesystem",
+        ErrorCode::MountFailed
+    );
+}

--- a/test/fspp/CMakeLists.txt
+++ b/test/fspp/CMakeLists.txt
@@ -2,6 +2,7 @@ project (fspp-test)
 
 set(SOURCES
     testutils/FuseTest.cpp
+    fuse/FuseMountFailureTest.cpp
     testutils/FuseThread.cpp
     testutils/InMemoryFile.cpp
     impl/FuseOpenFileListTest.cpp

--- a/test/fspp/fuse/FuseMountFailureTest.cpp
+++ b/test/fspp/fuse/FuseMountFailureTest.cpp
@@ -1,0 +1,43 @@
+#include "../testutils/FuseTest.h"
+
+#include <cpp-utils/tempfile/TempDir.h>
+
+using fspp::fuse::Fuse;
+using std::string;
+using std::vector;
+
+// Regression test for the mount error handling: Fuse::runInForeground() and Fuse::runInBackground()
+// have to hand libfuse's exit code back to the caller. They used to discard it, which made a mount
+// that libfuse refused look exactly like a file system that had been mounted and unmounted cleanly.
+class FuseMountFailureTest: public FuseTest {
+public:
+  // libfuse parses 'entry_timeout' as a double, so it rejects this while setting up the file system.
+  // The mount is refused before anything is mounted and fuse_main() returns a non-zero exit code.
+  static vector<string> unparseableFuseOptions() {
+    return {"-o", "entry_timeout=not_a_number"};
+  }
+
+  Fuse createFuse() {
+    return Fuse([this] (Fuse*) {return fsimpl;}, []{}, "fusetest", boost::none);
+  }
+};
+
+TEST_F(FuseMountFailureTest, WhenRunningInForeground_ThenLibfusesExitCodeIsReported) {
+  const cpputils::TempDir mountDir;
+  Fuse fuse = createFuse();
+
+  const int exitCode = fuse.runInForeground(mountDir.path(), unparseableFuseOptions());
+
+  EXPECT_NE(0, exitCode);
+  EXPECT_FALSE(fuse.running());
+}
+
+TEST_F(FuseMountFailureTest, WhenRunningInBackground_ThenLibfusesExitCodeIsReported) {
+  const cpputils::TempDir mountDir;
+  Fuse fuse = createFuse();
+
+  const int exitCode = fuse.runInBackground(mountDir.path(), unparseableFuseOptions());
+
+  EXPECT_NE(0, exitCode);
+  EXPECT_FALSE(fuse.running());
+}

--- a/test/fspp/testutils/FuseThread.cpp
+++ b/test/fspp/testutils/FuseThread.cpp
@@ -20,8 +20,18 @@ void FuseThread::start(const bf::path &mountDir, const vector<string> &fuseOptio
   _child = thread([this, mountDir, fuseOptions] () {
     _fuse->runInForeground(mountDir, fuseOptions);
   });
-  //Wait until it is running (busy waiting is simple and doesn't hurt much here)
-  while(!_fuse->running()) {}
+  //Wait until it is running (busy waiting is simple and doesn't hurt much here).
+  //Fuse::running() only becomes true from init(), which libfuse calls after a successful mount,
+  //so if the mount is refused the thread exits and this would otherwise spin forever.
+  const auto deadline = boost::chrono::steady_clock::now() + seconds(30);
+  while(!_fuse->running()) {
+    if (_child.try_join_for(boost::chrono::milliseconds(10))) {
+      ASSERT(false, "The FUSE thread exited before the filesystem was mounted. libfuse probably refused the mount.");
+    }
+    if (boost::chrono::steady_clock::now() > deadline) {
+      ASSERT(false, "Timeout waiting for the filesystem to be mounted.");
+    }
+  }
 #ifdef __APPLE__
   // On Mac OS X, _fuse->running() returns true too early, because macFUSE calls init() when it's not ready yet. Give it a bit time.
   std::this_thread::sleep_for(std::chrono::milliseconds(200));


### PR DESCRIPTION
Part of the review of the libfuse 3 migration. One finding per pull request; this one is independent of the others.

## The problem

`Fuse::runInForeground()` and `Fuse::runInBackground()` called `fuse_main()` and discarded its return value. When libfuse refuses to mount, both functions return normally, and `cryfs-cli` carries on to the end of `_run()` as though the filesystem had been mounted and cleanly unmounted. CryFS exits with status 0.

Reproduced against a real filesystem on libfuse 3.14.0:

```
$ cryfs basedir mountdir -f -o entry_timeout=abc
...
Mounting filesystem. To unmount, call:
$ cryfs-unmount "/tmp/.../mountdir"

fuse: invalid parameter in option `entry_timeout=abc'
$ echo $?
0
```

Nothing was mounted, but a script that mounts and then writes into the mount directory has no way to tell. It writes plaintext into the empty mount directory instead.

This matters more after the libfuse 3 migration than it did before. libfuse 3.15 dropped `atime` from its mount option table and stopped silently accepting options it does not know, so option handling is now a live source of refused mounts, and `fusermount3` is a different binary from `fusermount` and may not be installed on a machine that has libfuse 2 tooling.

## The fix

Both run functions return `fuse_main()`'s exit code. `cryfs-cli` turns a non-zero code into a `CryfsException` with a new error code, `MountFailed = 26`. libfuse has already printed the reason by then, so the message points the user at it rather than trying to restate it.

In background mode libfuse forks inside `fuse_main()` and the parent exits there, so only failures that happen before daemonizing are reported back. Those are exactly the mount failures this change is about; the header comment on the two functions spells that out along with libfuse's exit codes.

`FuseThread`, which the fspp tests use to run a filesystem in a background thread, busy-waited on `Fuse::running()`. That flag is only set from `init()`, which libfuse calls after a successful mount, so a refused mount left the loop spinning forever. It now watches the thread and fails with a clear message instead of hanging.

## Tests

`test/fspp/fuse/FuseMountFailureTest.cpp` covers the fspp layer. It runs both functions with a mount option libfuse cannot parse and asserts they return a non-zero exit code and never report the filesystem as running.

`test/cryfs-cli/CliTest_MountFailure.cpp` covers the CLI layer. It asserts a refused mount exits with error code 26 and prints an error, instead of exiting 0.

Both were verified to fail against the old behaviour. Reinstating the discarded return value makes all three fail, and the fix makes them pass.

| Suite | Result |
|---|---|
| `fspp-test` | 983 passed |
| `cryfs-cli-test` | 226 passed |

The `cryfs-cli-test` run excludes the permission tests, which cannot pass as root because root bypasses permission bits. CI runs them unprivileged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_