### PR TITLE
Refuse mounting over a non-empty directory

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -399,7 +399,7 @@ jobs:
             run_build: true
             run_tests: true
             run_cpack: false
-            gtest_args: "--gtest_filter=-LoggingTest.LoggingAlsoWorksAfterFork:AssertTest_*:BacktraceTest.*:SubprocessTest.*:SignalCatcherTest.*_thenDies:SignalHandlerTest.*_thenDies:SignalHandlerTest.givenMultipleSigIntHandlers_whenRaising_thenCatchesCorrectSignal:CliTest_Setup.*:CliTest_IntegrityCheck.*:*/CliTest_WrongEnvironment.*:CliTest_Unmount.*:CliTest.WorksWithCommasInBasedir"
+            gtest_args: "--gtest_filter=-LoggingTest.LoggingAlsoWorksAfterFork:AssertTest_*:BacktraceTest.*:SubprocessTest.*:SignalCatcherTest.*_thenDies:SignalHandlerTest.*_thenDies:SignalHandlerTest.givenMultipleSigIntHandlers_whenRaising_thenCatchesCorrectSignal:CliTest_Setup.*:CliTest_IntegrityCheck.*:*/CliTest_WrongEnvironment.*:CliTest_Unmount.*:CliTest.WorksWithCommasInBasedir:CliTest_NonEmptyMountdir.*ThenMountingSucceeds"
             extra_env_vars_for_test: OMP_NUM_THREADS=1
           - name: clang-tidy
             os: ubuntu-24.04

--- a/doc/man/cryfs.1
+++ b/doc/man/cryfs.1
@@ -230,6 +230,12 @@ root) can access the files.
 This option is similar to allow_other but file access is
 limited to the filesystem owner and root.  This option and
 allow_other are mutually exclusive.
+.TP
+\fB\-o\fR \fInonempty\fR
+Allow mounting over a directory that already contains files.
+Those files are hidden for as long as the filesystem is mounted.
+Without this option CryFS refuses to mount over a non-empty
+directory.
 .
 .
 .

--- a/src/cryfs-cli/Cli.cpp
+++ b/src/cryfs-cli/Cli.cpp
@@ -362,6 +362,7 @@ namespace cryfs_cli {
 
 		if (!options.mountDirIsDriveLetter()) {
 			_checkDirAccessible(options.mountDir(), "mount directory", options.createMissingMountpoint(), ErrorCode::InaccessibleMountDir);
+			_checkMountdirIsEmpty(options);
 			_checkMountdirDoesntContainBasedir(options);
 		} else {
 			if (bf::exists(options.mountDir())) {
@@ -419,6 +420,20 @@ namespace cryfs_cli {
             }
         } catch (const boost::filesystem::filesystem_error &e) {
             throw CryfsException("Could not read from "+name+".", errorCode);
+        }
+    }
+
+    void Cli::_checkMountdirIsEmpty(const ProgramOptions &options) {
+        // libfuse 2 refused to mount over a directory that already had files in it, unless the user
+        // passed '-o nonempty'. libfuse 3.0 removed that check together with the option and left the
+        // decision to the file system, so without this we would silently hide the user's files for
+        // as long as the file system is mounted.
+        if (options.allowNonEmptyMountdir()) {
+            return;
+        }
+        const bf::directory_iterator end;
+        if (end != bf::directory_iterator(options.mountDir())) {
+            throw CryfsException("mount directory is not empty. If you are sure this is safe, pass '-o nonempty'.", ErrorCode::InaccessibleMountDir);
         }
     }
 

--- a/src/cryfs-cli/Cli.h
+++ b/src/cryfs-cli/Cli.h
@@ -46,6 +46,7 @@ namespace cryfs_cli {
         void _initLogfile(const program_options::ProgramOptions &options);
         void _sanityChecks(const program_options::ProgramOptions &options);
         void _checkMountdirDoesntContainBasedir(const program_options::ProgramOptions &options);
+        static void _checkMountdirIsEmpty(const program_options::ProgramOptions &options);
         bool _pathContains(const boost::filesystem::path &parent, const boost::filesystem::path &child);
         void _checkDirAccessible(const boost::filesystem::path &dir, const std::string &name, bool createMissingDir, cryfs::ErrorCode errorCode);
         std::shared_ptr<cpputils::TempFile> _checkDirWriteable(const boost::filesystem::path &dir, const std::string &name, cryfs::ErrorCode errorCode);

--- a/src/cryfs-cli/program_options/ProgramOptions.cpp
+++ b/src/cryfs-cli/program_options/ProgramOptions.cpp
@@ -1,4 +1,5 @@
 #include "ProgramOptions.h"
+#include "utils.h"
 #include <cstring>
 #include <cpp-utils/assert/assert.h>
 #include <cpp-utils/system/path.h>
@@ -27,7 +28,11 @@ ProgramOptions::ProgramOptions(bf::path baseDir, bf::path mountDir, optional<bf:
       _allowIntegrityViolations(allowIntegrityViolations),
       _missingBlockIsIntegrityViolation(std::move(missingBlockIsIntegrityViolation)),
       _fuseOptions(std::move(fuseOptions)),
-      _mountDirIsDriveLetter(cpputils::path_is_just_drive_letter(_mountDir)) {
+      _mountDirIsDriveLetter(cpputils::path_is_just_drive_letter(_mountDir)),
+      // Note: this consumes the 'nonempty' option, i.e. removes it from _fuseOptions, so that we
+      // never hand it to libfuse. _fuseOptions is declared before this member, so it is already
+      // initialized here.
+      _allowNonEmptyMountdir(extractNonemptyOption(&_fuseOptions)) {
 	if (!_mountDirIsDriveLetter) {
 		_mountDir = bf::absolute(std::move(_mountDir));
 	}
@@ -95,4 +100,8 @@ const optional<bool> &ProgramOptions::missingBlockIsIntegrityViolation() const {
 
 const vector<string> &ProgramOptions::fuseOptions() const {
     return _fuseOptions;
+}
+
+bool ProgramOptions::allowNonEmptyMountdir() const {
+    return _allowNonEmptyMountdir;
 }

--- a/src/cryfs-cli/program_options/ProgramOptions.h
+++ b/src/cryfs-cli/program_options/ProgramOptions.h
@@ -41,6 +41,10 @@ namespace cryfs_cli {
             const boost::optional<bool> &missingBlockIsIntegrityViolation() const;
             const std::vector<std::string> &fuseOptions() const;
 			bool mountDirIsDriveLetter() const;
+            // True iff the user passed '-o nonempty', i.e. asked us to mount over a directory that
+            // already has files in it. The option itself is removed from fuseOptions(), see
+            // extractNonemptyOption() in utils.h for why.
+            bool allowNonEmptyMountdir() const;
 
         private:
             boost::filesystem::path _baseDir; // this is always absolute
@@ -59,6 +63,7 @@ namespace cryfs_cli {
             boost::optional<bool> _missingBlockIsIntegrityViolation;
             std::vector<std::string> _fuseOptions;
 			bool _mountDirIsDriveLetter;
+            bool _allowNonEmptyMountdir;
 
             DISALLOW_COPY_AND_ASSIGN(ProgramOptions);
         };

--- a/src/cryfs-cli/program_options/utils.cpp
+++ b/src/cryfs-cli/program_options/utils.cpp
@@ -24,5 +24,60 @@ namespace cryfs_cli {
             );
         }
 
+        namespace {
+            constexpr const char *NONEMPTY_OPTION = "nonempty";
+
+            // Removes 'nonempty' from a comma separated list of mount options and returns whether it was there.
+            bool extractNonemptyOptionFromCsv(string *csvOptions) {
+                bool found = false;
+                string remaining;
+                size_t pos = 0;
+                while (pos <= csvOptions->size()) {
+                    const size_t next = csvOptions->find(',', pos);
+                    const size_t end = (next == string::npos) ? csvOptions->size() : next;
+                    const string option = csvOptions->substr(pos, end - pos);
+                    if (option == NONEMPTY_OPTION) {
+                        found = true;
+                    } else {
+                        if (!remaining.empty()) {
+                            remaining += ",";
+                        }
+                        remaining += option;
+                    }
+                    if (next == string::npos) {
+                        break;
+                    }
+                    pos = next + 1;
+                }
+                *csvOptions = std::move(remaining);
+                return found;
+            }
+        }
+
+        bool extractNonemptyOption(vector<string> *fuseOptions) {
+            bool found = false;
+            bool lastOptionWasDashO = false;
+            size_t i = 0;
+            while (i < fuseOptions->size()) {
+                if (lastOptionWasDashO) {
+                    // A '-o' is always followed by its value, so i >= 1 here.
+                    if (extractNonemptyOptionFromCsv(&(*fuseOptions)[i])) {
+                        found = true;
+                    }
+                    if ((*fuseOptions)[i].empty()) {
+                        // 'nonempty' was the only option in this argument. Remove the now empty
+                        // argument together with the '-o' before it, because libfuse rejects a '-o'
+                        // that has no value.
+                        fuseOptions->erase(fuseOptions->begin() + i - 1, fuseOptions->begin() + i + 1);
+                        i -= 1;
+                        lastOptionWasDashO = false;
+                        continue;
+                    }
+                }
+                lastOptionWasDashO = ((*fuseOptions)[i] == "-o");
+                ++i;
+            }
+            return found;
+        }
     }
 }

--- a/src/cryfs-cli/program_options/utils.h
+++ b/src/cryfs-cli/program_options/utils.h
@@ -12,6 +12,20 @@ namespace cryfs_cli {
          * Splits an array of program options into two arrays of program options, split at a double dash '--' option.
          */
         std::pair<std::vector<std::string>, std::vector<std::string>> splitAtDoubleDash(const std::vector<std::string> &options);
+
+        /**
+         * Removes the 'nonempty' mount option from a list of fuse options and returns whether it was there.
+         *
+         * libfuse 2 refused to mount over a directory that already had files in it unless this option was
+         * given. libfuse 3.0 removed both the check and the option and left the decision to the file system,
+         * and libfuse 3.10.2 brought the option back as a no-op. CryFS therefore does the check itself and
+         * consumes the option here, so it behaves the same way on every libfuse 3 release.
+         *
+         * Options have to be preceded by a '-o', i.e. {..., "-o", "nonempty", ...}, and several of them can be
+         * comma-concatenated, i.e. {..., "-o", "nonempty,allow_other", ...}. A '-o' left without a value is
+         * removed as well, because libfuse rejects it.
+         */
+        bool extractNonemptyOption(std::vector<std::string> *fuseOptions);
     }
 }
 

--- a/test/cryfs-cli/CMakeLists.txt
+++ b/test/cryfs-cli/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     testutils/CliTest.cpp
     CliTest_Setup.cpp
     CliTest_WrongEnvironment.cpp
+    CliTest_NonEmptyMountdir.cpp
     program_options/UtilsTest.cpp
     program_options/ProgramOptionsTest.cpp
     program_options/ParserTest.cpp

--- a/test/cryfs-cli/CliTest_NonEmptyMountdir.cpp
+++ b/test/cryfs-cli/CliTest_NonEmptyMountdir.cpp
@@ -1,0 +1,54 @@
+#include "testutils/CliTest.h"
+
+#include <boost/filesystem.hpp>
+#include <fstream>
+
+namespace bf = boost::filesystem;
+using cryfs::ErrorCode;
+using std::string;
+using std::vector;
+
+// libfuse 2 refused to mount over a directory that already had files in it unless '-o nonempty' was
+// given. libfuse 3.0 removed that check together with the option, so CryFS has to do it itself.
+class CliTest_NonEmptyMountdir: public CliTest {
+public:
+    void PutFileIntoMountdir() {
+        std::ofstream file((mountdir / "important.txt").string());
+        file << "please don't hide me" << std::endl;
+    }
+
+    bool MountdirIsEmpty() {
+        const bf::directory_iterator end;
+        return end == bf::directory_iterator(mountdir);
+    }
+
+    vector<string> args(const vector<string>& extraArgs = {}) {
+        vector<string> result = {basedir.string(), mountdir.string(), "-f", "--cipher", "aes-256-gcm"};
+        result.insert(result.end(), extraArgs.begin(), extraArgs.end());
+        return result;
+    }
+};
+
+TEST_F(CliTest_NonEmptyMountdir, WhenMountdirIsNotEmpty_ThenMountingIsRefused) {
+    PutFileIntoMountdir();
+    EXPECT_RUN_ERROR(
+        args(),
+        "Error 17: mount directory is not empty",
+        ErrorCode::InaccessibleMountDir
+    );
+}
+
+TEST_F(CliTest_NonEmptyMountdir, WhenMountdirIsNotEmptyAndNonemptyOptionIsGiven_ThenMountingSucceeds) {
+    PutFileIntoMountdir();
+    bool wasHiddenWhileMounted = false;
+    EXPECT_RUN_SUCCESS(args({"-o", "nonempty"}), mountdir, [&] {
+        wasHiddenWhileMounted = MountdirIsEmpty();
+    });
+    EXPECT_TRUE(wasHiddenWhileMounted) << "The file in the mount directory should be hidden while mounted.";
+}
+
+// Counter-test: an empty mount directory keeps working without the option.
+TEST_F(CliTest_NonEmptyMountdir, WhenMountdirIsEmpty_ThenMountingSucceeds) {
+    ASSERT_TRUE(MountdirIsEmpty());
+    EXPECT_RUN_SUCCESS(args(), mountdir);
+}

--- a/test/cryfs-cli/program_options/ProgramOptionsTest.cpp
+++ b/test/cryfs-cli/program_options/ProgramOptionsTest.cpp
@@ -157,3 +157,16 @@ TEST_F(ProgramOptionsTest, SomeFuseOptions) {
     //Fuse should have the mount dir as first parameter
     EXPECT_VECTOR_EQ({"-f", "--longoption"}, testobj.fuseOptions());
 }
+
+TEST_F(ProgramOptionsTest, AllowNonEmptyMountdirDefaultsToFalse) {
+    const ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, false, false, none, none, none, none, false, none, {"-o", "allow_other"});
+    EXPECT_FALSE(testobj.allowNonEmptyMountdir());
+    EXPECT_VECTOR_EQ({"-o", "allow_other"}, testobj.fuseOptions());
+}
+
+TEST_F(ProgramOptionsTest, NonemptyFuseOptionIsConsumed) {
+    const ProgramOptions testobj("/rootDir", "/home/user/mydir", none, false, false, false, false, false, none, none, none, none, false, none, {"-o", "nonempty", "-o", "allow_other"});
+    EXPECT_TRUE(testobj.allowNonEmptyMountdir());
+    //libfuse must never see the option, it doesn't know it on all versions we support
+    EXPECT_VECTOR_EQ({"-o", "allow_other"}, testobj.fuseOptions());
+}

--- a/test/cryfs-cli/program_options/UtilsTest.cpp
+++ b/test/cryfs-cli/program_options/UtilsTest.cpp
@@ -112,3 +112,71 @@ TEST_F(ProgramOptionsUtilsTest, SplitAtDoubleDash_RealisticCryfsOptions) {
     EXPECT_VECTOR_EQ({"./executableName", "rootDir", "mountDir"}, result.first);
     EXPECT_VECTOR_EQ({"-f"}, result.second);
 }
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_NoOptions) {
+    vector<string> input = {};
+    EXPECT_FALSE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_NotThere) {
+    vector<string> input = {"-o", "allow_other", "-o", "noatime"};
+    EXPECT_FALSE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"-o", "allow_other", "-o", "noatime"}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_OnlyOption) {
+    vector<string> input = {"-o", "nonempty"};
+    EXPECT_TRUE(extractNonemptyOption(&input));
+    // the '-o' has to go as well, libfuse rejects a '-o' without a value
+    EXPECT_VECTOR_EQ({}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_WithOtherDashOOptions) {
+    vector<string> input = {"-o", "allow_other", "-o", "nonempty", "-o", "noatime"};
+    EXPECT_TRUE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"-o", "allow_other", "-o", "noatime"}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_InACommaSeparatedList) {
+    vector<string> input = {"-o", "allow_other,nonempty,noatime"};
+    EXPECT_TRUE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"-o", "allow_other,noatime"}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_FirstInACommaSeparatedList) {
+    vector<string> input = {"-o", "nonempty,allow_other"};
+    EXPECT_TRUE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"-o", "allow_other"}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_LastInACommaSeparatedList) {
+    vector<string> input = {"-o", "allow_other,nonempty"};
+    EXPECT_TRUE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"-o", "allow_other"}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_OtherArgumentsAreKept) {
+    vector<string> input = {"-f", "-o", "nonempty", "--logfile", "mylog"};
+    EXPECT_TRUE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"-f", "--logfile", "mylog"}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_SeveralTimes) {
+    vector<string> input = {"-o", "nonempty", "-o", "allow_other,nonempty"};
+    EXPECT_TRUE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"-o", "allow_other"}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_WithoutDashO_IsNotTouched) {
+    // an argument that happens to say 'nonempty' but isn't a mount option value
+    vector<string> input = {"--logfile", "nonempty"};
+    EXPECT_FALSE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"--logfile", "nonempty"}, input);
+}
+
+TEST_F(ProgramOptionsUtilsTest, ExtractNonemptyOption_SimilarlyNamedOptionIsNotTouched) {
+    vector<string> input = {"-o", "nonempty_something,somethingnonempty"};
+    EXPECT_FALSE(extractNonemptyOption(&input));
+    EXPECT_VECTOR_EQ({"-o", "nonempty_something,somethingnonempty"}, input);
+}


### PR DESCRIPTION
Part of the review of the libfuse 3 migration. One finding per pull request; this one is independent of the others.

## The problem

`fusermount` refused a non-empty mount point unless the user passed `-o nonempty`. libfuse 3.0 removed both the check and the option and told filesystems to enforce it themselves. `fusermount3` carries no emptiness check at all.

`Cli::_checkDirAccessible` only verifies that the mount directory exists, is a directory, and is readable and writable. So mounting over a directory that already has files in it now succeeds silently and hides those files for as long as the filesystem is mounted.

Reproduced against a real filesystem:

```
$ echo "PRECIOUS USER DATA" > /mnt/cm1/important.txt
$ cryfs /mnt/cb1 /mnt/cm1
$ echo $?
0
$ ls /mnt/cm1
                        # empty, the user's file is hidden
$ fusermount3 -u /mnt/cm1 && ls /mnt/cm1
important.txt           # intact, just hidden while mounted
```

The file survives, so this is not data loss. It is still a footgun: a user who mistypes a mount point gets a working, empty-looking filesystem and no warning that something was covered up.

## The fix

`Cli::_checkMountdirIsEmpty` refuses a non-empty mount directory, with `-o nonempty` as the escape hatch. That restores the libfuse 2 behaviour, including the option name users already know.

The option is consumed before libfuse sees it. libfuse 3 dropped it from its mount option table, and since 3.15 it no longer silently accepts options it does not know, so forwarding it aborts the mount:

```
$ cryfs base mount -o nonempty          # built against libfuse 3.17.2
fuse: unknown option(s): `-o nonempty'
```

`extractNonemptyOption` in `program_options/utils.cpp` removes it, including from comma-concatenated lists such as `-o allow_other,nonempty`, and drops a `-o` that would be left without a value, which libfuse also rejects. `ProgramOptions` consumes it in its constructor and exposes the answer as `allowNonEmptyMountdir()`, so `fuseOptions()` is already clean at every use.

The man page documents the option.

## Note on the error code

The refusal reuses `ErrorCode::InaccessibleMountDir` (17), which is what the other mount-directory sanity checks already return, and the message says exactly what is wrong. A dedicated code would be easy to add if you would rather scripts could tell the cases apart; I avoided one here so this pull request does not collide with the new code added in the mount-failure PR.

## Tests

`ProgramOptionsUtilsTest` covers the extraction: comma-separated lists, several occurrences, the option appearing where it is not a mount option value, and similarly named options such as `nonempty_something` that must not be touched.

`ProgramOptionsTest` asserts the option is consumed and never reaches libfuse.

`CliTest_NonEmptyMountdir` covers the three cases end to end: a non-empty mount directory is refused, `-o nonempty` mounts anyway and hides the file, and an empty mount directory still works.

Verified against the old behaviour. With the check removed, the refusal test does not fail cleanly, it mounts. The run leaves a live `fuse.cryfs` mount over the directory holding `important.txt`, which is the bug itself.

| Suite | Result |
|---|---|
| `cryfs-cli-test` | 241 passed |

That run excludes the permission tests, which cannot pass as root because root bypasses permission bits. CI runs them unprivileged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_