### PR TITLE
Fix the capability set we negotiate with libfuse

### DIFF
--- a/src/fspp/fuse/CMakeLists.txt
+++ b/src/fspp/fuse/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
   ../impl/FilesystemImpl.cpp
   ../impl/Profiler.cpp
   ../fuse/Fuse.cpp
+  ../fuse/Capabilities.cpp
 )
 
 add_library(${PROJECT_NAME} STATIC ${SOURCES})

--- a/src/fspp/fuse/Capabilities.cpp
+++ b/src/fspp/fuse/Capabilities.cpp
@@ -1,0 +1,54 @@
+#include "Capabilities.h"
+#include "params.h"
+
+namespace fspp {
+namespace fuse {
+
+uint32_t unsupportedCapabilities() {
+  return
+      // CryFile::open() ignores the open flags, so it doesn't truncate a file that was opened with
+      // O_TRUNC. With this capability the kernel would stop sending the separate truncate request
+      // and expect open() to have done it.
+      FUSE_CAP_ATOMIC_O_TRUNC
+
+      // We don't implement locking. libfuse already clears this itself when a file system has no
+      // lock handler (fuse_fs_init() in libfuse's lib/fuse.c), but saying so explicitly keeps the
+      // intent in one place and keeps it off if libfuse ever changes that default.
+      | FUSE_CAP_POSIX_LOCKS
+
+      // libfuse 2 had no such capability, libfuse 3 wants it by default. It makes the kernel
+      // refresh attributes on every read and drop a file's page cache whenever the reported mtime
+      // differs from the cached one, and CryFS stamps mtime from its own clock, so the two rarely
+      // match. Measured on a mount, the cost of leaving it on is an extra getattr per file per
+      // attribute timeout on read-heavy workloads, and each getattr is a full path traversal in
+      // CryFS. It buys us nothing in return: CryFS does not support concurrent access from several
+      // clients, so the data the kernel has cached cannot change behind its back.
+      | FUSE_CAP_AUTO_INVAL_DATA
+
+      // Our readdir() only fills in st_mode and never passes FUSE_FILL_DIR_PLUS, so answering
+      // readdirplus requests would only make the replies bigger without saving the kernel any
+      // lookups. On libfuse 3.0 to 3.10.2 it is worse than that: the non-plus branch there doesn't
+      // copy st_mode into the entry, so every entry comes back as DT_UNKNOWN and tools like
+      // 'find -type' or 'ls --color' fall back to one lstat per entry - again a full path traversal
+      // each. If readdir ever fills in complete stat data, this is the capability to re-enable.
+      | FUSE_CAP_READDIRPLUS | FUSE_CAP_READDIRPLUS_AUTO
+
+      // A file system that accepts this promises to clear S_ISUID/S_ISGID itself on write, truncate
+      // and chown. CryFS has no such code, so we must not claim it. What has been saving us is a
+      // libfuse quirk: 3.0 to 3.16 never copy the bit into the INIT reply, and 3.17 removed it from
+      // the defaults. Clearing it makes that independent of the libfuse version: the kernel keeps
+      // stripping those bits for us, which is what CryFS relied on under libfuse 2 as well.
+      | FUSE_CAP_HANDLE_KILLPRIV;
+
+  // Note that FUSE_CAP_EXPORT_SUPPORT is deliberately *not* in this list. It is implemented by
+  // libfuse's own high level library, which enables it by default in both libfuse 2 (fuse_lib_init()
+  // in lib/fuse.c) and libfuse 3, so clearing it would newly turn off NFS export for mounts that had
+  // it before.
+}
+
+uint32_t removeUnsupportedCapabilities(uint32_t want) {
+  return want & ~unsupportedCapabilities();
+}
+
+}
+}

--- a/src/fspp/fuse/Capabilities.h
+++ b/src/fspp/fuse/Capabilities.h
@@ -1,0 +1,27 @@
+#pragma once
+#ifndef MESSMER_FSPP_FUSE_CAPABILITIES_H_
+#define MESSMER_FSPP_FUSE_CAPABILITIES_H_
+
+#include <cstdint>
+
+namespace fspp {
+namespace fuse {
+
+/**
+ * Before libfuse calls our init() handler, it fills fuse_conn_info::want with the capabilities it
+ * would like to negotiate with the kernel. Some of those we can't support and some we don't want,
+ * so this takes the set libfuse proposed and returns the set we actually want.
+ *
+ * The implementation documents why each capability is in or out.
+ */
+uint32_t removeUnsupportedCapabilities(uint32_t want);
+
+/**
+ * The capabilities removeUnsupportedCapabilities() clears. Exposed for tests.
+ */
+uint32_t unsupportedCapabilities();
+
+}
+}
+
+#endif

--- a/src/fspp/fuse/Fuse.cpp
+++ b/src/fspp/fuse/Fuse.cpp
@@ -16,6 +16,7 @@
 #include <cpp-utils/thread/debugging.h>
 #include <csignal>
 #include "InvalidFilesystem.h"
+#include "Capabilities.h"
 #include <codecvt>
 #include <boost/algorithm/string/replace.hpp>
 
@@ -1166,8 +1167,12 @@ void Fuse::init(fuse_conn_info *conn, fuse_config *config) {
   
   const ThreadNameForDebugging _threadName("init");
 
-  // Disable capabilities that we don't support
-  conn->want &= ~(FUSE_CAP_POSIX_LOCKS | FUSE_CAP_ATOMIC_O_TRUNC | FUSE_CAP_EXPORT_SUPPORT);
+  // Opt out of the capabilities libfuse would otherwise negotiate for us, see Capabilities.cpp.
+  // libfuse 3.17 deprecates conn->want in favour of the 64 bit conn->want_ext, but it keeps
+  // converting one into the other around every init() call (convert_to_conn_want_ext() in libfuse's
+  // lib/fuse_i.h), so writing conn->want stays correct on every libfuse 3 release. Switching to
+  // fuse_unset_feature_flag() belongs together with raising FUSE_USE_VERSION.
+  conn->want = removeUnsupportedCapabilities(conn->want);
 
   _fs = _init(this);
 

--- a/test/fspp/CMakeLists.txt
+++ b/test/fspp/CMakeLists.txt
@@ -2,6 +2,7 @@ project (fspp-test)
 
 set(SOURCES
     testutils/FuseTest.cpp
+    fuse/CapabilitiesTest.cpp
     testutils/FuseThread.cpp
     testutils/InMemoryFile.cpp
     impl/FuseOpenFileListTest.cpp
@@ -82,6 +83,7 @@ set(SOURCES
     fuse/readDir/FuseReadDirDirnameTest.cpp
     fuse/readDir/FuseReadDirErrorTest.cpp
     fuse/readDir/FuseReadDirReturnTest.cpp
+    fuse/readDir/FuseReadDirEntryTypeTest.cpp
     fuse/createAndOpenFile/FuseCreateAndOpenFilenameTest.cpp
     fuse/createAndOpenFile/testutils/FuseCreateAndOpenTest.cpp
     fuse/createAndOpenFile/FuseCreateAndOpenFlagsTest.cpp

--- a/test/fspp/fuse/CapabilitiesTest.cpp
+++ b/test/fspp/fuse/CapabilitiesTest.cpp
@@ -1,0 +1,64 @@
+#include <gtest/gtest.h>
+
+#include "fspp/fuse/Capabilities.h"
+#include "fspp/fuse/params.h"
+
+using fspp::fuse::removeUnsupportedCapabilities;
+using fspp::fuse::unsupportedCapabilities;
+
+namespace {
+// What libfuse offers us in the worst case: it wants everything the kernel can do.
+constexpr uint32_t ALL_CAPABILITIES = 0xFFFFFFFFu;
+
+bool wants(uint32_t capability) {
+  return 0 != (removeUnsupportedCapabilities(ALL_CAPABILITIES) & capability);
+}
+}
+
+// CryFile::open() ignores the open flags, so it never truncates on O_TRUNC and the kernel has to
+// keep sending us a separate truncate request.
+TEST(CapabilitiesTest, AtomicOTruncIsRefused) {
+  EXPECT_FALSE(wants(FUSE_CAP_ATOMIC_O_TRUNC));
+}
+
+// We don't implement locking.
+TEST(CapabilitiesTest, PosixLocksAreRefused) {
+  EXPECT_FALSE(wants(FUSE_CAP_POSIX_LOCKS));
+}
+
+// libfuse 2 had no such capability and it costs us an extra getattr per read, see Capabilities.cpp.
+TEST(CapabilitiesTest, AutoInvalDataIsRefused) {
+  EXPECT_FALSE(wants(FUSE_CAP_AUTO_INVAL_DATA));
+}
+
+// Our readdir() doesn't fill in plus data, so readdirplus replies would be larger for nothing, and
+// on libfuse 3.0 to 3.10.2 they lose d_type entirely.
+TEST(CapabilitiesTest, ReaddirplusIsRefused) {
+  EXPECT_FALSE(wants(FUSE_CAP_READDIRPLUS));
+  EXPECT_FALSE(wants(FUSE_CAP_READDIRPLUS_AUTO));
+}
+
+// Accepting this would make us responsible for clearing setuid/setgid ourselves, and we aren't.
+TEST(CapabilitiesTest, HandleKillprivIsRefused) {
+  EXPECT_FALSE(wants(FUSE_CAP_HANDLE_KILLPRIV));
+}
+
+// libfuse's own high level library implements this and enables it by default, in libfuse 2 as well,
+// so refusing it would newly break NFS export.
+TEST(CapabilitiesTest, ExportSupportIsKept) {
+  EXPECT_TRUE(wants(FUSE_CAP_EXPORT_SUPPORT));
+}
+
+// We only ever clear capabilities, we never ask for one libfuse didn't offer.
+TEST(CapabilitiesTest, NoCapabilityIsAdded) {
+  EXPECT_EQ(0u, removeUnsupportedCapabilities(0));
+  EXPECT_EQ(0u, removeUnsupportedCapabilities(unsupportedCapabilities()));
+  const uint32_t someWantedCapability = FUSE_CAP_EXPORT_SUPPORT;
+  EXPECT_EQ(someWantedCapability, removeUnsupportedCapabilities(someWantedCapability));
+}
+
+// Capabilities libfuse never offered stay off, whatever we do.
+TEST(CapabilitiesTest, RemovingIsIdempotent) {
+  const uint32_t once = removeUnsupportedCapabilities(ALL_CAPABILITIES);
+  EXPECT_EQ(once, removeUnsupportedCapabilities(once));
+}

--- a/test/fspp/fuse/readDir/FuseReadDirEntryTypeTest.cpp
+++ b/test/fspp/fuse/readDir/FuseReadDirEntryTypeTest.cpp
@@ -1,0 +1,59 @@
+#include "testutils/FuseReadDirTest.h"
+
+#include "fspp/fs_interface/Dir.h"
+
+using ::testing::Eq;
+using ::testing::Return;
+
+using std::string;
+using std::vector;
+
+// The kernel gets an entry's type from the file-type bits our readdir() puts into st_mode, and
+// reports it back to readdir(3) as d_type. Everything that walks a directory tree uses it to avoid
+// a stat() per entry, and in CryFS every one of those stats is a full path traversal.
+//
+// This is easy to lose. libfuse enables readdirplus by default because the high level library
+// always registers a readdirplus handler, and on libfuse 3.0 to 3.10.2 the branch that handles a
+// plain (non-plus) reply to a readdirplus request drops st_mode, so every entry comes back as
+// DT_UNKNOWN. CryFS refuses the readdirplus capability for that reason, see fspp/fuse/Capabilities.
+class FuseReadDirEntryTypeTest: public FuseReadDirTest {
+public:
+  vector<std::pair<string, unsigned char>> readEntryTypesOf(vector<fspp::Dir::Entry> entries) {
+    ReturnIsDirOnLstat(DIRNAME);
+    EXPECT_CALL(*fsimpl, readDir(Eq(DIRNAME))).Times(1).WillOnce(Return(std::move(entries)));
+    return ReadDirEntryTypes(DIRNAME);
+  }
+};
+
+TEST_F(FuseReadDirEntryTypeTest, FileEntriesAreReportedAsFiles) {
+  const auto entries = readEntryTypesOf({fspp::Dir::Entry(fspp::Dir::EntryType::FILE, "myfile")});
+  ASSERT_EQ(1u, entries.size());
+  EXPECT_EQ("myfile", entries[0].first);
+  EXPECT_EQ(DT_REG, entries[0].second);
+}
+
+TEST_F(FuseReadDirEntryTypeTest, DirEntriesAreReportedAsDirs) {
+  const auto entries = readEntryTypesOf({fspp::Dir::Entry(fspp::Dir::EntryType::DIR, "mydir")});
+  ASSERT_EQ(1u, entries.size());
+  EXPECT_EQ("mydir", entries[0].first);
+  EXPECT_EQ(DT_DIR, entries[0].second);
+}
+
+TEST_F(FuseReadDirEntryTypeTest, SymlinkEntriesAreReportedAsSymlinks) {
+  const auto entries = readEntryTypesOf({fspp::Dir::Entry(fspp::Dir::EntryType::SYMLINK, "mylink")});
+  ASSERT_EQ(1u, entries.size());
+  EXPECT_EQ("mylink", entries[0].first);
+  EXPECT_EQ(DT_LNK, entries[0].second);
+}
+
+TEST_F(FuseReadDirEntryTypeTest, MixedEntriesKeepTheirOwnType) {
+  const auto entries = readEntryTypesOf({
+      fspp::Dir::Entry(fspp::Dir::EntryType::FILE, "myfile"),
+      fspp::Dir::Entry(fspp::Dir::EntryType::DIR, "mydir"),
+      fspp::Dir::Entry(fspp::Dir::EntryType::SYMLINK, "mylink"),
+  });
+  ASSERT_EQ(3u, entries.size());
+  EXPECT_EQ(std::make_pair(string("myfile"), static_cast<unsigned char>(DT_REG)), entries[0]);
+  EXPECT_EQ(std::make_pair(string("mydir"), static_cast<unsigned char>(DT_DIR)), entries[1]);
+  EXPECT_EQ(std::make_pair(string("mylink"), static_cast<unsigned char>(DT_LNK)), entries[2]);
+}

--- a/test/fspp/fuse/readDir/testutils/FuseReadDirTest.cpp
+++ b/test/fspp/fuse/readDir/testutils/FuseReadDirTest.cpp
@@ -18,6 +18,24 @@ vector<string> FuseReadDirTest::ReadDir(const char *dirname) {
   return result;
 }
 
+vector<std::pair<string, unsigned char>> FuseReadDirTest::ReadDirEntryTypes(const char *dirname) {
+  auto fs = TestFS();
+
+  DIR *dir = openDir(fs.get(), dirname);
+
+  vector<std::pair<string, unsigned char>> result;
+  errno = 0;
+  struct dirent *entry = ::readdir(dir);
+  while (entry != nullptr) {
+    result.emplace_back(entry->d_name, entry->d_type);
+    errno = 0;
+    entry = ::readdir(dir);
+  }
+  EXPECT_EQ(0, errno) << "Reading directory entries failed";
+  closeDir(dir);
+  return result;
+}
+
 int FuseReadDirTest::ReadDirReturnError(const char *dirname) {
   auto fs = TestFS();
 

--- a/test/fspp/fuse/readDir/testutils/FuseReadDirTest.h
+++ b/test/fspp/fuse/readDir/testutils/FuseReadDirTest.h
@@ -4,6 +4,7 @@
 
 #include "../../../testutils/FuseTest.h"
 #include <dirent.h>
+#include <utility>
 #include "fspp/fs_interface/Dir.h"
 
 class FuseReadDirTest: public FuseTest {
@@ -11,6 +12,9 @@ public:
   const char *DIRNAME = "/mydir";
 
   std::vector<std::string> ReadDir(const char *dirname);
+  // Reads the directory and returns each entry's name together with the d_type the kernel reported
+  // for it. d_type is DT_UNKNOWN if the file system didn't tell the kernel what the entry is.
+  std::vector<std::pair<std::string, unsigned char>> ReadDirEntryTypes(const char *dirname);
   int ReadDirReturnError(const char *dirname);
 
   static ::testing::Action<std::vector<fspp::Dir::Entry>(const boost::filesystem::path&)> ReturnDirEntries(std::vector<std::string> entries);


### PR DESCRIPTION
Part of the review of the libfuse 3 migration. This one covers four findings that all live on the same line of `Fuse::init`.

## The problem

libfuse fills `fuse_conn_info::want` with its own defaults before calling `init()`, and libfuse 3's defaults are not libfuse 2's. The migration kept masking the same three capabilities as before:

```cpp
conn->want &= ~(FUSE_CAP_POSIX_LOCKS | FUSE_CAP_ATOMIC_O_TRUNC | FUSE_CAP_EXPORT_SUPPORT);
```

A probe filesystem was used to dump what `init()` is actually handed on a live mount, because CryFS does not expose it:

```
POSIX_LOCKS        capable=1 want=0    already off
ATOMIC_O_TRUNC     capable=1 want=1    mask is meaningful
EXPORT_SUPPORT     capable=1 want=1    the library's own feature
AUTO_INVAL_DATA    capable=1 want=1    new in libfuse 3
READDIRPLUS        capable=1 want=1    new in libfuse 3
HANDLE_KILLPRIV    capable=1 want=1    new in libfuse 3
```

Four things follow from that.

**`FUSE_CAP_AUTO_INVAL_DATA`** is new in libfuse 3 and on by default. It makes the kernel refresh attributes on every read and drop a file's page cache whenever the reported mtime differs from the cached one, and CryFS stamps mtime from its own clock, so the two rarely match. An A/B run with the capability masked measured the cost as one extra `getattr` per file per attribute-timeout window on read-heavy workloads. Each of those is a full path traversal in CryFS. It buys nothing in return: CryFS does not support concurrent access from several clients, so the kernel's cached data cannot change behind its back. Now masked.

**`FUSE_CAP_READDIRPLUS`** and **`FUSE_CAP_READDIRPLUS_AUTO`** are on by default because the high-level library always registers a readdirplus handler. Our `readdir` only fills the file-type bits of `st_mode` and never passes `FUSE_FILL_DIR_PLUS`, so the only effect is bigger replies. On libfuse 3.0 through 3.10.2 it is worse. The branch that answers a readdirplus request with a plain reply does not copy `st_mode`, so every entry comes back as `DT_UNKNOWN`, observed on a probe mount against 3.9.0:

```
readdir(/, flags=0x1 FUSE_READDIR_PLUS)
f       d_type=DT_UNKNOWN
subdir  d_type=DT_UNKNOWN
```

Tools like `find -type` and `ls --color` then fall back to one `lstat` per entry, again a full path walk each. Now masked. If `readdir` ever fills in complete stat data, this is the capability to turn back on.

**`FUSE_CAP_HANDLE_KILLPRIV`** is on by default, and a filesystem that accepts it promises to clear `S_ISUID` and `S_ISGID` itself on write, truncate and chown. CryFS has no such code. What saves it today is a libfuse quirk: 3.0 through 3.16 never copy the bit into the INIT reply, and 3.17 dropped it from the defaults. Masking it makes the behaviour independent of the libfuse version. The kernel keeps stripping the bits, which is what CryFS relied on under libfuse 2 as well.

**`FUSE_CAP_EXPORT_SUPPORT` should not be masked at all.** It is implemented by libfuse's own high-level library, which enables it by default in libfuse 2 as well. Both versions do it in `fuse_lib_init`:

```c
/* libfuse 2.9.9, lib/fuse.c:2664 */   conn->want |= FUSE_CAP_EXPORT_SUPPORT;
/* libfuse 3.17.2, lib/fuse.c:2650 */  fuse_set_feature_flag(conn, FUSE_CAP_EXPORT_SUPPORT);
```

So clearing it newly turns off NFS export for mounts that had it before. Removed from the mask.

`FUSE_CAP_POSIX_LOCKS` and `FUSE_CAP_ATOMIC_O_TRUNC` stay. libfuse already clears POSIX_LOCKS itself for a filesystem with no lock handler, so masking it is a no-op, but I kept it so the intent lives in one place and survives a change of that default. `ATOMIC_O_TRUNC` genuinely has to go, because `CryFile::open` ignores the open flags and never truncates on `O_TRUNC`.

## Structure

The mask moves into `fspp/fuse/Capabilities`, so each decision carries its reason next to it and the whole thing is unit-testable.

`Fuse::init` keeps writing `conn->want`. libfuse 3.17 deprecates it in favour of the 64-bit `conn->want_ext`, but it converts one into the other around every `init()` call, in both the high-level and low-level layers (`convert_to_conn_want_ext` in `lib/fuse_i.h`), so this stays correct on every libfuse 3 release. CryFS built against 3.17.2 mounts fine. Switching to `fuse_unset_feature_flag()` belongs together with raising `FUSE_USE_VERSION`, which is a separate finding. Say the word if you would rather have it here.

## Tests

`CapabilitiesTest` asserts each capability is refused or kept for the reason given, and that we only ever clear capabilities and never ask for one libfuse did not offer. Against the old mask, five of its eight cases fail.

`FuseReadDirEntryTypeTest` reads a directory through a real mount and checks the `d_type` the kernel reports for a file, a directory and a symlink. That is the user-visible half of the readdirplus problem, and nothing covered it before.

CryFS itself was also built and mounted with the new mask. Entry types, kernel setuid stripping and timestamps all behave as before:

```
$ find /mnt/capm -mindepth 1 -printf '%y %p\n'
d /mnt/capm/sub
f /mnt/capm/f
l /mnt/capm/l
$ chmod 6777 /mnt/capm/f && capsh --drop=cap_fsetid -- -c 'printf more >> /mnt/capm/f'
before 6777
after  777
```

| Suite | Result |
|---|---|
| `fspp-test` | 993 passed |
| `cryfs-test` | 716 passed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_