### PR TITLE
Depend on fuse3 instead of fuse

### DIFF
--- a/.github/workflows/actions/setup_linux/action.yaml
+++ b/.github/workflows/actions/setup_linux/action.yaml
@@ -51,7 +51,7 @@ runs:
           sudo chmod o-w /etc/apt/sources.list.d/clang.list
         fi
         sudo apt-get update
-        sudo apt-get install ninja-build libfuse3-dev ccache ${{inputs.extra_apt_packages}}
+        sudo apt-get install ninja-build libfuse3-dev fuse3 ccache ${{inputs.extra_apt_packages}}
     - name: Speed up random generator
       run: |
         set -v

--- a/README.md
+++ b/README.md
@@ -91,17 +91,17 @@ Requirements
   - CMake version >= 3.25
   - pkg-config (on Unix)
   - Conan package manager (version 2.x)
-  - libFUSE version >= 3.9 (including development headers), on Mac OS X instead install macFUSE from https://osxfuse.github.io/
+  - libFUSE version >= 3.9 (including development headers) and the `fusermount3` helper it uses to mount and unmount, on Mac OS X instead install macFUSE from https://osxfuse.github.io/
   - Python >= 3.5
   - OpenMP
 
 You can use the following commands to install these requirements
 
     # Ubuntu
-    $ sudo apt install git python3 g++ cmake libomp-dev pkg-config libfuse3-dev fuse
+    $ sudo apt install git python3 g++ cmake libomp-dev pkg-config libfuse3-dev fuse3
 
     # Fedora
-    $ sudo dnf install git python3 gcc-c++ cmake pkgconf fuse3-devel perl
+    $ sudo dnf install git python3 gcc-c++ cmake pkgconf fuse3-devel fuse3 perl
 
     # Macintosh
     # TODO Update the package list

--- a/cpack/CMakeLists.txt
+++ b/cpack/CMakeLists.txt
@@ -56,10 +56,15 @@ else()
     set(CPACK_PACKAGE_EXECUTABLES "cryfs" "CryFS")
     set(CPACK_DEBIAN_PACKAGE_SECTION "utils")
     set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "fuse")
+    # cryfs, cryfs-unmount and Fuse::stop() all run the fusermount3 helper, and libfuse 3 needs it
+    # for unprivileged mounts. It ships in 'fuse3' on Debian and Ubuntu; the FUSE 2 'fuse' package
+    # doesn't contain it and the two conflict, so depending on 'fuse' would leave CryFS unable to
+    # mount or unmount. Fedora and openSUSE ship the same binary in a package of the same name.
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "fuse3")
 
     set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "https://www.cryfs.org")
     set(CPACK_RPM_PACKAGE_LICENSE "LGPLv3")
+    set(CPACK_RPM_PACKAGE_REQUIRES "fuse3")
     set(CPACK_RPM_PACKAGE_DESCRIPTION ${CPACK_PACKAGE_DESCRIPTION})
     set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/bin;/usr/share/man;/usr/share/man/man1")
 

--- a/doc/man/cryfs-unmount.1
+++ b/doc/man/cryfs-unmount.1
@@ -45,8 +45,8 @@ package.
 .
 .SH SEE ALSO
 .
-.BR mount.fuse (1),
-.BR fusermount (1),
+.BR mount.fuse3 (8),
+.BR fusermount3 (1),
 .BR cryfs (1)
 .PP
 .

--- a/doc/man/cryfs.1
+++ b/doc/man/cryfs.1
@@ -268,8 +268,8 @@ Default value: ${HOME}/.cryfs
 .
 .SH SEE ALSO
 .
-.BR mount.fuse (1),
-.BR fusermount (1)
+.BR mount.fuse3 (8),
+.BR fusermount3 (1),
 .BR cryfs-unmount (1)
 .PP
 .


### PR DESCRIPTION
Part of the review of the libfuse 3 migration. One finding per pull request; this one is independent of the others.

## The problem

`Fuse::unmount`, used by `cryfs`, `cryfs-unmount` and `Fuse::stop`, now runs `fusermount3`, and libfuse 3 needs that helper for unprivileged mounts. The packaging and the documentation still name FUSE 2's package.

On Debian and Ubuntu `fusermount3` ships in `fuse3`, while `fuse` is the FUSE 2 package, and the two declare `Provides`/`Conflicts` against each other:

```
Provides:  fuse (= ${source:Version})
Conflicts: fuse (<< ${source:Version})
```

So a user who follows the README, which said `apt install ... libfuse3-dev fuse`, has `fuse3` removed and ends up with a CryFS that can neither mount nor unmount. The `.deb` declared `Depends: fuse`, which is satisfiable by FUSE 2 on a machine that has neither, and the RPM declared no FUSE requirement at all.

CI never caught it because the runner images already carry `fuse3`.

## The fix

`CPACK_DEBIAN_PACKAGE_DEPENDS` becomes `fuse3`, and the RPM package gains the same requirement. Verified on a generated package:

```
$ dpkg-deb -I cryfs-...-Linux.deb | grep Depends
 Depends: fuse3, libboost-chrono1.83.0t64 (>= 1.83.0), ..., libfuse3-3 (>= 3.2.3), ...
```

The README installs `fuse3` on Ubuntu and Fedora. On Fedora the helper is not pulled in by `fuse3-devel`, which only needs `fuse3-libs`, so it has to be named there too. The requirements list now mentions the helper next to the library.

Both man pages point at `fusermount3(1)` and `mount.fuse3(8)` instead of the FUSE 2 pages. A missing comma in the `cryfs(1)` SEE ALSO list is fixed on the way past.

CI installs `fuse3` explicitly rather than relying on the runner image happening to carry it.

## Note

The README's "libFUSE version >= 3.9" claim is a separate finding and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_