### PR TITLE
Raise recursion_limit to fix rustc ICE on nightly CI

### DIFF
--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -1,3 +1,7 @@
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
 // TODO #![deny(missing_docs)]
 // TODO Forbid unsafe code?
 

--- a/crates/check/src/lib.rs
+++ b/crates/check/src/lib.rs
@@ -1,3 +1,7 @@
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
 #![forbid(unsafe_code)]
 // TODO #![deny(missing_docs)]
 

--- a/crates/check/tests/blob_missing.rs
+++ b/crates/check/tests/blob_missing.rs
@@ -1,5 +1,10 @@
 //! Tests where whole blobs are missing
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use rstest::rstest;
 use std::iter;
 

--- a/crates/check/tests/blob_referenced_multiple_times.rs
+++ b/crates/check/tests/blob_referenced_multiple_times.rs
@@ -1,6 +1,11 @@
 //! Tests where a blob is referenced multiple times, either from the same or from a different directory
 //! Note: Tests for the blob being referenced from an inner node is in [super::node_referenced_multiple_times::root_node_referenced]
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use futures::future::BoxFuture;
 use rstest::rstest;
 use std::collections::BTreeSet;

--- a/crates/check/tests/blob_unreadable.rs
+++ b/crates/check/tests/blob_unreadable.rs
@@ -1,5 +1,10 @@
 //! Tests where all individual nodes are readable but there is something wrong in the blob data.
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use rstest::rstest;
 use std::iter;
 

--- a/crates/check/tests/blob_unreferenced.rs
+++ b/crates/check/tests/blob_unreferenced.rs
@@ -1,5 +1,10 @@
 //! Tests where there are blobs that aren't referenced from anywhere
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use futures::future::BoxFuture;
 use rstest::rstest;
 use std::iter;

--- a/crates/check/tests/blob_with_wrong_parent_pointer.rs
+++ b/crates/check/tests/blob_with_wrong_parent_pointer.rs
@@ -1,5 +1,10 @@
 //! Tests where blobs have wrong parent pointers set
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use futures::future::BoxFuture;
 use rstest::rstest;
 use std::collections::BTreeSet;

--- a/crates/check/tests/node_missing.rs
+++ b/crates/check/tests/node_missing.rs
@@ -1,5 +1,10 @@
 //! Tests where individual nodes in a blob are missing
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use rstest::rstest;
 use std::iter;
 

--- a/crates/check/tests/node_referenced_multiple_times.rs
+++ b/crates/check/tests/node_referenced_multiple_times.rs
@@ -1,5 +1,10 @@
 //! Tests where a node is referenced multiple times, either from the same or from a different blob
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use pretty_assertions::{assert_eq, assert_ne};
 use rand::{SeedableRng, rngs::SmallRng};
 use rstest::rstest;

--- a/crates/check/tests/node_unreadable.rs
+++ b/crates/check/tests/node_unreadable.rs
@@ -1,5 +1,10 @@
 //! Tests where individual nodes are unreadable
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use rstest::rstest;
 
 use cryfs_check::{BlobReference, BlobReferenceWithId, BlobUnreadableError, NodeUnreadableError};

--- a/crates/check/tests/node_unreferenced.rs
+++ b/crates/check/tests/node_unreferenced.rs
@@ -1,5 +1,10 @@
 //! Tests where there are nodes that aren't referenced from anywhere
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use cryfs_blockstore::BlockId;
 use cryfs_check::{
     CorruptedError, MaybeBlobReferenceWithId, NodeAndBlobReference, NodeInfoAsSeenByLookingAtNode,

--- a/crates/check/tests/valid.rs
+++ b/crates/check/tests/valid.rs
@@ -1,5 +1,10 @@
 //! Tests where the filesystem doesn't have errors
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use cryfs_check::CorruptedError;
 
 mod common;

--- a/crates/cryfs-cli/src/lib.rs
+++ b/crates/cryfs-cli/src/lib.rs
@@ -1,3 +1,7 @@
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
 #![forbid(unsafe_code)]
 // TODO #![deny(missing_docs)]
 

--- a/crates/cryfs-config/src/lib.rs
+++ b/crates/cryfs-config/src/lib.rs
@@ -1,3 +1,7 @@
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
 #![forbid(unsafe_code)]
 // TODO #![deny(missing_docs)]
 #![allow(rustdoc::private_intra_doc_links)] // TODO Remove this?

--- a/crates/crypto/benches/symmetric.rs
+++ b/crates/crypto/benches/symmetric.rs
@@ -1,3 +1,8 @@
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
+
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use rand::{Rng, SeedableRng, rngs::StdRng};
 use std::hint::black_box;

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -59,6 +59,20 @@
 //! assert_eq!(decrypted.as_ref(), b"Hello, CryFS!");
 //! ```
 
+// Our ciphers are parameterized by `typenum` type-level integers, and proving
+// `generic_array::ArrayLength` for one of them (e.g. `U16`) unrolls typenum's
+// `Shl` recursion deeper than rustc's default recursion limit of 128, so the
+// obligation overflows. rustc used to accept that silently; as of
+// 1.100.0-nightly it reports `recursion_depth_exceeding_limit`
+// (rust-lang/rust#159228) and will make it a hard error in a future release.
+// Where the overflowing obligation is an auto trait (e.g. the `Send` bound on a
+// boxed future), the failure is worse than a warning: the coercion to
+// `dyn Future + Send` then looks unimplemented to the monomorphization
+// collector, which ICEs. Raise the limit so these obligations resolve.
+//
+// This has to be repeated in every crate that instantiates a concrete cipher
+// type, because `recursion_limit` is a per-crate attribute.
+#![recursion_limit = "512"]
 #![forbid(unsafe_code)]
 #![deny(missing_docs)]
 

--- a/crates/e2e-perf-tests/src/lib.rs
+++ b/crates/e2e-perf-tests/src/lib.rs
@@ -28,6 +28,10 @@
 //! - #[cfg(feature = "benchmark")]      // Code only necessary for benchmarks
 //! - #[cfg(not(feature = "benchmark"))] // Code only necessary for perf tests
 
+// Raise the trait-solver recursion limit above rustc's default of 128: proving
+// `generic_array::ArrayLength` for our typenum-parameterized ciphers overflows
+// it. See crates/crypto/src/lib.rs for the full explanation.
+#![recursion_limit = "512"]
 // TODO #![deny(missing_docs)]
 #![cfg(any(test, feature = "benchmark"))]
 


### PR DESCRIPTION
## What's broken

CI on `main` is red: [run 1097](https://github.com/cryfs/cryfs/actions/runs/33839262490) on 17a61be. Of its 255 jobs, exactly 8 fail, and they are exactly the 8 Linux `nightly` jobs — every combination of `{ubuntu-22.04, ubuntu-24.04} × {debug, --release} × {default, --no-default-features}` on the `nightly` toolchain. Every other job either passed or is one of the macOS jobs that sat queued for 24h until GitHub timed them out and marked them *cancelled* (that queueing is pre-existing and unrelated; this PR does not touch it).

The 8 die after ~5 minutes with an **rustc ICE** in the monomorphization collector while compiling `cryfs-cli`:

```
error: internal compiler error: compiler/rustc_monomorphize/src/lib.rs:46:13:
  invalid `CoerceUnsized` from
    Pin<Box<{async block@<ObjectBasedFsAdapterLL<CryDevice<…Aes256Gcm…>>>
             as AsyncFilesystemLL>::destroy<'_, '_>::{closure#0}}>>
    to Pin<Box<dyn Future<Output = ()> + Send>>: impl_source: Err(Unimplemented)
note: rustc 1.100.0-nightly (a69a63265 2026-09-03)
```

## Cause

Not the coercion — the trait solver's recursion limit.

Our ciphers are parameterized by `typenum` type-level integers, and proving `U16: generic_array::ArrayLength` goes through `IsWithinUsizeBound`, which unrolls typenum's `Shl` recursion past rustc's default limit of 128. That overflow used to be accepted silently. The same nightly turned it into the `recursion_depth_exceeding_limit` future-incompatibility lint ([rust-lang/rust#159228](https://github.com/rust-lang/rust/issues/159228)), which is scheduled to become a hard error — so this reaches stable eventually, it is not only a nightly problem.

Five crates hit the overflow, and in most of them it is only the warning. In `cryfs-cli` it is worse: the overflowing obligation there is the `Send` bound on the boxed `destroy` future, so the failed proof makes the `Box<async block>` → `Box<dyn Future + Send>` coercion look unimplemented to the monomorphization collector, and rustc bugs out instead of reporting an error.

rustc should not ICE here either way — that part is a compiler bug worth reporting upstream — but the overflow is ours to fix.

## Fix

`#[recursion_limit = "512"]` in every crate root whose compilation overflows. `recursion_limit` is a per-crate attribute, and integration tests and benchmarks are their own crates, which is why this touches 17 files:

- libs: `crypto` (the `AUTH_TAG_SIZE = U16` associated type — the root of the chain), `blockstore`, `cryfs-config`, `check`, `cryfs-cli`, `e2e-perf-tests`
- `crypto`'s `symmetric` benchmark
- `check`'s ten integration tests

The full explanation lives in `crates/crypto/src/lib.rs`; the other crates carry a three-line pointer to it.

Two judgement calls worth flagging for review:

- **512, not the 256 rustc first suggests.** At 256 the ICE is gone, but `cryfs-cli` still overflows — on the `CoerceUnsized` obligation itself — and rustc then asks for 512. A residual overflow is precisely the state that ICEs, so the limit goes up until no obligation overflows at all.
- **All ten `check` integration tests, not just the ones that overflow today.** `node_unreadable`, `blob_unreadable` and `valid` each overflowed across the verification runs. They are peers sharing one fixture, so they all get the attribute rather than leaving the rest to trip over this later.

## Verification

All with rustc 1.100.0-nightly (a69a63265 2026-09-03) — the exact compiler the failing CI jobs used, pinned via `nightly-2026-09-04`:

- `cargo build -p cryfs-cli` reproduces the ICE verbatim on unmodified `main`, and succeeds with this change.
- `cargo build --workspace --all-targets` finishes (exit 0) with zero `recursion_depth_exceeding_limit` warnings and zero ICEs, both with default features and with `--no-default-features`.
- `cargo fmt --all --check` is clean.

The change is additive and inert on the toolchains that already pass: `recursion_limit` only raises a solver bound, so `stable` and `1.95` are unaffected.

*Correction: an earlier revision of this description said three jobs were failing. That was an undercount — it came from enumerating only the first 60 of the run's 255 jobs. The full census is the 8 given above; the diagnosis and fix are unchanged, since all 8 fail on the same ICE.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rvim5Wko3GoV2kTiEJnhsJ