### PR TITLE
Route stat and truncate through the file handle again

### DIFF
--- a/src/cryfs/impl/filesystem/CryOpenFile.cpp
+++ b/src/cryfs/impl/filesystem/CryOpenFile.cpp
@@ -31,6 +31,21 @@ void CryOpenFile::flush() {
   _parent->flush();
 }
 
+fspp::Node::stat_info CryOpenFile::stat() const {
+  _device->callFsActionCallbacks();
+  auto childOpt = _parent->GetChild(_fileBlob->blockId());
+  if (childOpt == boost::none) {
+    throw fspp::fuse::FuseErrnoException(ENOENT);
+  }
+  return dirEntryToStatInfo(*childOpt, _fileBlob->size());
+}
+
+void CryOpenFile::truncate(fspp::num_bytes_t size) const {
+  _device->callFsActionCallbacks();
+  _fileBlob->resize(size);
+  _parent->updateModificationTimestampForChild(_fileBlob->blockId());
+}
+
 fspp::num_bytes_t CryOpenFile::read(void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) const {
   _device->callFsActionCallbacks();
   _parent->updateAccessTimestampForChild(_fileBlob->blockId(), timestampUpdateBehavior());

--- a/src/cryfs/impl/filesystem/CryOpenFile.h
+++ b/src/cryfs/impl/filesystem/CryOpenFile.h
@@ -14,6 +14,8 @@ public:
   explicit CryOpenFile(const CryDevice *device, std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> parent, cpputils::unique_ref<parallelaccessfsblobstore::FileBlobRef> fileBlob);
   ~CryOpenFile() override;
 
+  stat_info stat() const override;
+  void truncate(fspp::num_bytes_t size) const override;
   fspp::num_bytes_t read(void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) const override;
   void write(const void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) override;
   void flush() override;

--- a/src/fspp/fs_interface/OpenFile.h
+++ b/src/fspp/fs_interface/OpenFile.h
@@ -14,6 +14,8 @@ public:
 
   using stat_info = fspp::stat_info;
 
+  virtual stat_info stat() const = 0;
+  virtual void truncate(fspp::num_bytes_t size) const = 0;
   virtual fspp::num_bytes_t read(void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) const = 0;
   virtual void write(const void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) = 0;
   virtual void flush() = 0;

--- a/src/fspp/fstest/FsppOpenFileTest.h
+++ b/src/fspp/fstest/FsppOpenFileTest.h
@@ -7,6 +7,19 @@
 template<class ConcreteFileSystemTestFixture>
 class FsppOpenFileTest: public FileSystemTest<ConcreteFileSystemTestFixture> {
 public:
+    void IN_STAT(fspp::OpenFile *openFile, std::function<void (const fspp::OpenFile::stat_info&)> callback) {
+        auto st = openFile->stat();
+        callback(st);
+    }
+
+    void EXPECT_SIZE(fspp::num_bytes_t expectedSize, fspp::OpenFile *openFile) {
+        IN_STAT(openFile, [expectedSize] (const fspp::OpenFile::stat_info& st) {
+            EXPECT_EQ(expectedSize, st.size);
+        });
+
+        EXPECT_NUMBYTES_READABLE(expectedSize, openFile);
+    }
+
     void EXPECT_NUMBYTES_READABLE(fspp::num_bytes_t expectedSize, fspp::OpenFile *openFile) {
         cpputils::Data data(expectedSize.value());
         //Try to read one byte more than the expected size
@@ -21,11 +34,20 @@ TYPED_TEST_SUITE_P(FsppOpenFileTest);
 TYPED_TEST_P(FsppOpenFileTest, CreatedFileIsEmpty) {
     auto file = this->CreateFile("/myfile");
     auto openFile = this->LoadFile("/myfile")->open(fspp::openflags_t::RDONLY());
-    this->EXPECT_NUMBYTES_READABLE(fspp::num_bytes_t(0), openFile.get());
+    this->EXPECT_SIZE(fspp::num_bytes_t(0), openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, FileIsFile) {
+    auto file = this->CreateFile("/myfile");
+    auto openFile = this->LoadFile("/myfile")->open(fspp::openflags_t::RDONLY());
+    this->IN_STAT(openFile.get(), [] (const fspp::OpenFile::stat_info& st) {
+        EXPECT_TRUE(st.mode.hasFileFlag());
+    });
 }
 
 REGISTER_TYPED_TEST_SUITE_P(FsppOpenFileTest,
-    CreatedFileIsEmpty
+    CreatedFileIsEmpty,
+    FileIsFile
 );
 
 //TODO Test stat

--- a/src/fspp/fstest/FsppOpenFileTest_Timestamps.h
+++ b/src/fspp/fstest/FsppOpenFileTest_Timestamps.h
@@ -14,6 +14,7 @@ public:
         auto file = this->CreateFile(path);
         file->truncate(size);
         auto openFile = file->open(fspp::openflags_t::RDWR());
+        ASSERT(this->stat(*openFile).size == size, "");
         ASSERT(this->stat(*this->Load(path)).size == size, "");
         return openFile;
     }
@@ -24,165 +25,268 @@ public:
     cpputils::unique_ref<fspp::OpenFile> OpenFile(const boost::filesystem::path &path, fspp::num_bytes_t size) {
         auto file = this->LoadFile(path);
         auto openFile = file->open(fspp::openflags_t::RDWR());
+        ASSERT(this->stat(*openFile).size == size, "");
         ASSERT(this->stat(*this->Load(path)).size == size, "");
         return openFile;
     }
 };
 TYPED_TEST_SUITE_P(FsppOpenFileTest_Timestamps);
 
-TYPED_TEST_P(FsppOpenFileTest_Timestamps, givenAtimeNewerThanMtimeButBeforeYesterday_read_inbounds) {
-    const boost::filesystem::path path = "/myfile";
-    auto operation = [this, path] () {
-        this->CreateFileWithSize(path, fspp::num_bytes_t(10));
-        this->setAtimeNewerThanMtimeButBeforeYesterday(path);
-        auto openFile = this->OpenFile(path, fspp::num_bytes_t(10));
+TYPED_TEST_P(FsppOpenFileTest_Timestamps, stat) {
+    auto operation = [] (fspp::OpenFile* openFile){
+        return [openFile] {
+            openFile->stat();
+        };
+    };
+    this->testBuilder().withAnyAtimeConfig([&] {
+        auto openFile = this->CreateAndOpenFile("/mynode");
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAnyTimestamps});
+    });
+}
 
-        return [openFile = std::move(openFile)] {
+TYPED_TEST_P(FsppOpenFileTest_Timestamps, truncate_empty_to_empty) {
+    auto operation = [] (fspp::OpenFile* openFile){
+        return [openFile] {
+            openFile->truncate(fspp::num_bytes_t(0));
+        };
+    };
+    this->testBuilder().withAnyAtimeConfig([&] {
+        auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(0));
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
+    });
+}
+
+TYPED_TEST_P(FsppOpenFileTest_Timestamps, truncate_empty_to_nonempty) {
+    auto operation = [] (fspp::OpenFile* openFile){
+        return [openFile] {
+            openFile->truncate(fspp::num_bytes_t(10));
+        };
+    };
+    this->testBuilder().withAnyAtimeConfig([&] {
+        auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(0));
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
+    });
+}
+
+TYPED_TEST_P(FsppOpenFileTest_Timestamps, truncate_nonempty_to_empty) {
+    auto operation = [] (fspp::OpenFile* openFile){
+        return [openFile] {
+            openFile->truncate(fspp::num_bytes_t(0));
+        };
+    };
+    this->testBuilder().withAnyAtimeConfig([&] {
+        auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
+    });
+}
+
+TYPED_TEST_P(FsppOpenFileTest_Timestamps, truncate_nonempty_to_nonempty_shrink) {
+    auto operation = [] (fspp::OpenFile* openFile){
+        return [openFile] {
+            openFile->truncate(fspp::num_bytes_t(5));
+        };
+    };
+    this->testBuilder().withAnyAtimeConfig([&] {
+        auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
+    });
+}
+
+TYPED_TEST_P(FsppOpenFileTest_Timestamps, truncate_nonempty_to_nonempty_grow) {
+    auto operation = [] (fspp::OpenFile* openFile){
+        return [openFile] {
+            openFile->truncate(fspp::num_bytes_t(20));
+        };
+    };
+    this->testBuilder().withAnyAtimeConfig([&] {
+        auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
+    });
+}
+
+TYPED_TEST_P(FsppOpenFileTest_Timestamps, givenAtimeNewerThanMtimeButBeforeYesterday_read_inbounds) {
+    auto operation = [this] () {
+        this->CreateFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->setAtimeNewerThanMtimeButBeforeYesterday("/myfile");
+        auto openFile = this->OpenFile("/myfile", fspp::num_bytes_t(10));
+        auto* openFilePtr = openFile.get();
+
+        return std::make_pair(openFilePtr, [openFile = std::move(openFile)] {
             std::array<char, 5> buffer{};
             openFile->read(buffer.data(), fspp::num_bytes_t(5), fspp::num_bytes_t(0));
-        };
+        });
     };
     this->testBuilder()
       .withNoatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withNodiratimeRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withNodiratimeStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     });
 }
 
 TYPED_TEST_P(FsppOpenFileTest_Timestamps, givenAtimeNewerThanMtime_read_inbounds) {
-    const boost::filesystem::path path = "/myfile";
-    auto operation = [this, path] () {
-        this->CreateFileWithSize(path, fspp::num_bytes_t(10));
-        this->setAtimeNewerThanMtime(path);
-        auto openFile = this->OpenFile(path, fspp::num_bytes_t(10));
+    auto operation = [this] () {
+        this->CreateFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->setAtimeNewerThanMtime("/myfile");
+        auto openFile = this->OpenFile("/myfile", fspp::num_bytes_t(10));
+        auto* openFilePtr = openFile.get();
 
-        return [openFile = std::move(openFile)] {
+        return std::make_pair(openFilePtr, [openFile = std::move(openFile)] {
             std::array<char, 5> buffer{};
             openFile->read(buffer.data(), fspp::num_bytes_t(5), fspp::num_bytes_t(0));
-        };
+        });
     };
     this->testBuilder()
       .withNoatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withNodiratimeRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withNodiratimeStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     });
 }
 
 TYPED_TEST_P(FsppOpenFileTest_Timestamps, givenAtimeOlderThanMtime_read_inbounds) {
-    const boost::filesystem::path path = "/myfile";
-    auto operation = [this, path] () {
-        this->CreateFileWithSize(path, fspp::num_bytes_t(10));
-        this->setAtimeOlderThanMtime(path);
-        auto openFile = this->OpenFile(path, fspp::num_bytes_t(10));
+    auto operation = [this] () {
+        this->CreateFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->setAtimeOlderThanMtime("/myfile");
+        auto openFile = this->OpenFile("/myfile", fspp::num_bytes_t(10));
+        auto* openFilePtr = openFile.get();
 
-        return [openFile = std::move(openFile)] {
+        return std::make_pair(openFilePtr, [openFile = std::move(openFile)] {
             std::array<char, 5> buffer{};
             openFile->read(buffer.data(), fspp::num_bytes_t(5), fspp::num_bytes_t(0));
-        };
+        });
     };
     this->testBuilder()
       .withNoatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withNodiratimeRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withNodiratimeStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     });
 }
 
 TYPED_TEST_P(FsppOpenFileTest_Timestamps, givenAtimeNewerThanMtimeButBeforeYesterday_read_outofbounds) {
-    const boost::filesystem::path path = "/myfile";
-    auto operation = [this, path] () {
-        this->CreateFileWithSize(path, fspp::num_bytes_t(10));
-        this->setAtimeNewerThanMtimeButBeforeYesterday(path);
-        auto openFile = this->OpenFile(path, fspp::num_bytes_t(10));
+    auto operation = [this] () {
+        this->CreateFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->setAtimeNewerThanMtimeButBeforeYesterday("/myfile");
+        auto openFile = this->OpenFile("/myfile", fspp::num_bytes_t(10));
+        auto* openFilePtr = openFile.get();
 
-        return [openFile = std::move(openFile)] {
+        return std::make_pair(openFilePtr, [openFile = std::move(openFile)] {
             std::array<char, 5> buffer{};
             openFile->read(buffer.data(), fspp::num_bytes_t(5), fspp::num_bytes_t(2));
-        };
+        });
     };
     this->testBuilder()
       .withNoatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withNodiratimeRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withNodiratimeStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     });
 }
 
 TYPED_TEST_P(FsppOpenFileTest_Timestamps, givenAtimeNewerThanMtime_read_outofbounds) {
-    const boost::filesystem::path path = "/myfile";
-    auto operation = [this, path] () {
-        this->CreateFileWithSize(path, fspp::num_bytes_t(10));
-        this->setAtimeNewerThanMtime(path);
-        auto openFile = this->OpenFile(path, fspp::num_bytes_t(10));
+    auto operation = [this] () {
+        this->CreateFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->setAtimeNewerThanMtime("/myfile");
+        auto openFile = this->OpenFile("/myfile", fspp::num_bytes_t(10));
+        auto* openFilePtr = openFile.get();
 
-        return [openFile = std::move(openFile)] {
+        return std::make_pair(openFilePtr, [openFile = std::move(openFile)] {
             std::array<char, 5> buffer{};
             openFile->read(buffer.data(), fspp::num_bytes_t(5), fspp::num_bytes_t(2));
-        };
+        });
     };
     this->testBuilder()
       .withNoatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withNodiratimeRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withNodiratimeStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     });
 }
 
 TYPED_TEST_P(FsppOpenFileTest_Timestamps, givenAtimeOlderThanMtime_read_outofbounds) {
-    const boost::filesystem::path path = "/myfile";
-    auto operation = [this, path] () {
-        this->CreateFileWithSize(path, fspp::num_bytes_t(10));
-        this->setAtimeOlderThanMtime(path);
-        auto openFile = this->OpenFile(path, fspp::num_bytes_t(10));
+    auto operation = [this] () {
+        this->CreateFileWithSize("/myfile", fspp::num_bytes_t(10));
+        this->setAtimeOlderThanMtime("/myfile");
+        auto openFile = this->OpenFile("/myfile", fspp::num_bytes_t(10));
+        auto* openFilePtr = openFile.get();
 
-        return [openFile = std::move(openFile)] {
+        return std::make_pair(openFilePtr, [openFile = std::move(openFile)] {
             std::array<char, 5> buffer{};
             openFile->read(buffer.data(), fspp::num_bytes_t(5), fspp::num_bytes_t(2));
-        };
+        });
     };
     this->testBuilder()
       .withNoatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectDoesntUpdateAnyTimestamps});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectDoesntUpdateAnyTimestamps});
     }).withStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withNodiratimeRelatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     }).withNodiratimeStrictatime([&] {
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(path, operation(), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
+        auto op = operation();
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*op.first, std::move(op.second), {this->ExpectUpdatesAccessTimestamp, this->ExpectDoesntUpdateModificationTimestamp, this->ExpectDoesntUpdateMetadataTimestamp});
     });
 }
 
@@ -194,7 +298,7 @@ TYPED_TEST_P(FsppOpenFileTest_Timestamps, write_inbounds) {
     };
     this->testBuilder().withAnyAtimeConfig([&] {
         auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(10));
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS("/myfile", operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
     });
 }
 
@@ -206,7 +310,7 @@ TYPED_TEST_P(FsppOpenFileTest_Timestamps, write_outofbounds) {
     };
     this->testBuilder().withAnyAtimeConfig([&] {
         auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(0));
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS("/myfile", operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAccessTimestamp, this->ExpectUpdatesModificationTimestamp, this->ExpectUpdatesMetadataTimestamp});
     });
 }
 
@@ -219,7 +323,7 @@ TYPED_TEST_P(FsppOpenFileTest_Timestamps, flush) {
     };
     this->testBuilder().withAnyAtimeConfig([&] {
         auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(10));
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS("/myfile", operation(openFile.get()), {this->ExpectDoesntUpdateAnyTimestamps});
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAnyTimestamps});
     });
 }
 
@@ -232,7 +336,7 @@ TYPED_TEST_P(FsppOpenFileTest_Timestamps, fsync) {
     };
     this->testBuilder().withAnyAtimeConfig([&] {
         auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(10));
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS("/myfile", operation(openFile.get()), {this->ExpectDoesntUpdateAnyTimestamps});
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAnyTimestamps});
     });
 }
 
@@ -245,11 +349,17 @@ TYPED_TEST_P(FsppOpenFileTest_Timestamps, fdatasync) {
     };
     this->testBuilder().withAnyAtimeConfig([&] {
         auto openFile = this->CreateAndOpenFileWithSize("/myfile", fspp::num_bytes_t(10));
-        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS("/myfile", operation(openFile.get()), {this->ExpectDoesntUpdateAnyTimestamps});
+        this->EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(*openFile, operation(openFile.get()), {this->ExpectDoesntUpdateAnyTimestamps});
     });
 }
 
 REGISTER_TYPED_TEST_SUITE_P(FsppOpenFileTest_Timestamps,
+   stat,
+   truncate_empty_to_empty,
+   truncate_empty_to_nonempty,
+   truncate_nonempty_to_empty,
+   truncate_nonempty_to_nonempty_shrink,
+   truncate_nonempty_to_nonempty_grow,
    givenAtimeNewerThanMtimeButBeforeYesterday_read_inbounds,
    givenAtimeNewerThanMtime_read_inbounds,
    givenAtimeOlderThanMtime_read_inbounds,

--- a/src/fspp/fstest/testutils/TimestampTestUtils.h
+++ b/src/fspp/fstest/testutils/TimestampTestUtils.h
@@ -38,6 +38,16 @@ public:
     }
 
     template<class Operation>
+    void EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(const fspp::OpenFile &node, Operation&& operation, std::initializer_list<TimestampUpdateExpectation> behaviorChecks) {
+        EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(
+            [this, &node](){return this->stat(node);},
+            [this, &node](){return this->stat(node);},
+            std::forward<Operation>(operation),
+            behaviorChecks
+        );
+    }
+
+    template<class Operation>
     void EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(const boost::filesystem::path &oldPath, const boost::filesystem::path &newPath, Operation&& operation, std::initializer_list<TimestampUpdateExpectation> behaviorChecks) {
         EXPECT_OPERATION_UPDATES_TIMESTAMPS_AS(
             [this, oldPath](){return this->stat(*this->Load(oldPath));},
@@ -69,6 +79,10 @@ public:
 
     static fspp::Node::stat_info stat(const fspp::Node &node) {
         return node.stat();
+    }
+
+    static fspp::Node::stat_info stat(const fspp::OpenFile &openFile) {
+        return openFile.stat();
     }
 
     timespec xSecondsAgo(int sec) {

--- a/src/fspp/fuse/Filesystem.h
+++ b/src/fspp/fuse/Filesystem.h
@@ -28,11 +28,13 @@ public:
   virtual void flush(int descriptor) = 0;
   virtual void closeFile(int descriptor) = 0;
   virtual void lstat(const boost::filesystem::path &path, fspp::fuse::STAT *stbuf) = 0;
+  virtual void fstat(int descriptor, fspp::fuse::STAT *stbuf) = 0;
   //TODO Test chmod
   virtual void chmod(const boost::filesystem::path &path, ::mode_t mode) = 0;
   //TODO Test chown
   virtual void chown(const boost::filesystem::path &path, ::uid_t uid, ::gid_t gid) = 0;
   virtual void truncate(const boost::filesystem::path &path, fspp::num_bytes_t size) = 0;
+  virtual void ftruncate(int descriptor, fspp::num_bytes_t size) = 0;
   virtual fspp::num_bytes_t read(int descriptor, void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) = 0;
   virtual void write(int descriptor, const void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) = 0;
   virtual void fsync(int descriptor) = 0;

--- a/src/fspp/fuse/Fuse.cpp
+++ b/src/fspp/fuse/Fuse.cpp
@@ -514,14 +514,20 @@ void Fuse::unmount(const bf::path& mountdir, bool force) {
 }
 
 int Fuse::getattr(const bf::path &path, fspp::fuse::STAT *stbuf, fuse_file_info* file_info) {
-  UNUSED(file_info);
   const ThreadNameForDebugging _threadName("getattr");
 #ifdef FSPP_LOG
   LOG(DEBUG, "getattr({}, _, _)", path);
 #endif
   try {
-    ASSERT(is_valid_fspp_path(path), "has to be an absolute path");
-    _fs->lstat(path, stbuf);
+    if (file_info != nullptr) {
+      // The request came from a file that is already open, e.g. from fstat(2) or from the lookup
+      // libfuse does right after create(). Answering from the handle saves resolving the path,
+      // which is one directory blob load and lookup per component in CryFS.
+      _fs->fstat(file_info->fh, stbuf);
+    } else {
+      ASSERT(is_valid_fspp_path(path), "has to be an absolute path");
+      _fs->lstat(path, stbuf);
+    }
 #ifdef FSPP_LOG
     LOG(DEBUG, "getattr({}, _, _): success", path);
 #endif
@@ -811,14 +817,18 @@ int Fuse::chown(const bf::path &path, ::uid_t uid, ::gid_t gid, fuse_file_info* 
 }
 
 int Fuse::truncate(const bf::path &path, int64_t size, fuse_file_info* file_info) {
-  UNUSED(file_info);
   const ThreadNameForDebugging _threadName("truncate");
 #ifdef FSPP_LOG
   LOG(DEBUG, "truncate({}, {})", path, size);
 #endif
   try {
-    ASSERT(is_valid_fspp_path(path), "has to be an absolute path");
-    _fs->truncate(path, fspp::num_bytes_t(size));
+    if (file_info != nullptr) {
+      // ftruncate(2), i.e. the file is already open and we don't have to resolve the path again.
+      _fs->ftruncate(file_info->fh, fspp::num_bytes_t(size));
+    } else {
+      ASSERT(is_valid_fspp_path(path), "has to be an absolute path");
+      _fs->truncate(path, fspp::num_bytes_t(size));
+    }
 #ifdef FSPP_LOG
     LOG(DEBUG, "truncate({}, {}): success", path, size);
 #endif

--- a/src/fspp/fuse/InvalidFilesystem.h
+++ b/src/fspp/fuse/InvalidFilesystem.h
@@ -32,6 +32,10 @@ namespace fspp {
                 throw std::logic_error("Filesystem not initialized yet");
             }
 
+            void fstat(int , fspp::fuse::STAT *) override {
+                throw std::logic_error("Filesystem not initialized yet");
+            }
+
             void chmod(const boost::filesystem::path &, ::mode_t ) override {
                 throw std::logic_error("Filesystem not initialized yet");
             }
@@ -41,6 +45,10 @@ namespace fspp {
             }
 
             void truncate(const boost::filesystem::path &, fspp::num_bytes_t ) override {
+                throw std::logic_error("Filesystem not initialized yet");
+            }
+
+            void ftruncate(int , fspp::num_bytes_t ) override {
                 throw std::logic_error("Filesystem not initialized yet");
             }
 

--- a/src/fspp/impl/FilesystemImpl.cpp
+++ b/src/fspp/impl/FilesystemImpl.cpp
@@ -36,8 +36,8 @@ FilesystemImpl::FilesystemImpl(cpputils::unique_ref<Device> device)
   :
 #ifdef FSPP_PROFILE
    _loadFileNanosec(0), _loadDirNanosec(0), _loadSymlinkNanosec(0), _openFileNanosec(0), _flushNanosec(0),
-   _closeFileNanosec(0), _lstatNanosec(0), _chmodNanosec(0), _chownNanosec(0), _truncateNanosec(0),
-   _readNanosec(0), _writeNanosec(0), _fsyncNanosec(0), _fdatasyncNanosec(0), _accessNanosec(0),
+   _closeFileNanosec(0), _lstatNanosec(0), _fstatNanosec(0), _chmodNanosec(0), _chownNanosec(0), _truncateNanosec(0),
+   _ftruncateNanosec(0), _readNanosec(0), _writeNanosec(0), _fsyncNanosec(0), _fdatasyncNanosec(0), _accessNanosec(0),
    _createAndOpenFileNanosec(0), _createAndOpenFileNanosec_withoutLoading(0), _mkdirNanosec(0),
    _mkdirNanosec_withoutLoading(0), _rmdirNanosec(0), _rmdirNanosec_withoutLoading(0), _unlinkNanosec(0),
    _unlinkNanosec_withoutLoading(0), _renameNanosec(0), _readDirNanosec(0), _readDirNanosec_withoutLoading(0),
@@ -60,9 +60,11 @@ FilesystemImpl::~FilesystemImpl() {
     << std::setw(40) << "Flush: " << static_cast<double>(_flushNanosec)/1000000000 << "\n"
     << std::setw(40) << "CloseFile: " << static_cast<double>(_closeFileNanosec)/1000000000 << "\n"
     << std::setw(40) << "Lstat: " << static_cast<double>(_lstatNanosec)/1000000000 << "\n"
+    << std::setw(40) << "Fstat: " << static_cast<double>(_fstatNanosec)/1000000000 << "\n"
     << std::setw(40) << "Chmod: " << static_cast<double>(_chmodNanosec)/1000000000 << "\n"
     << std::setw(40) << "Chown: " << static_cast<double>(_chownNanosec)/1000000000 << "\n"
     << std::setw(40) << "Truncate: " << static_cast<double>(_truncateNanosec)/1000000000 << "\n"
+    << std::setw(40) << "Ftruncate: " << static_cast<double>(_ftruncateNanosec)/1000000000 << "\n"
     << std::setw(40) << "Read: " << static_cast<double>(_readNanosec)/1000000000 << "\n"
     << std::setw(40) << "Write: " << static_cast<double>(_writeNanosec)/1000000000 << "\n"
     << std::setw(40) << "Fsync: " << static_cast<double>(_fsyncNanosec)/1000000000 << "\n"
@@ -167,6 +169,14 @@ void FilesystemImpl::lstat(const bf::path &path, fspp::fuse::STAT *stbuf) {
   }
 }
 
+void FilesystemImpl::fstat(int descriptor, fspp::fuse::STAT *stbuf) {
+	PROFILE(_fstatNanosec);
+	auto stat_info = _open_files.load(descriptor, [] (OpenFile* openFile) {
+		return openFile->stat();
+	});
+	convert_stat_info_(stat_info, stbuf);
+}
+
 void FilesystemImpl::chmod(const boost::filesystem::path &path, ::mode_t mode) {
   PROFILE(_chmodNanosec);
   auto node = _device->Load(path);
@@ -190,6 +200,13 @@ void FilesystemImpl::chown(const boost::filesystem::path &path, ::uid_t uid, ::g
 void FilesystemImpl::truncate(const bf::path &path, fspp::num_bytes_t size) {
   PROFILE(_truncateNanosec);
   LoadFile(path)->truncate(size);
+}
+
+void FilesystemImpl::ftruncate(int descriptor, fspp::num_bytes_t size) {
+  PROFILE(_ftruncateNanosec);
+  _open_files.load(descriptor, [size] (OpenFile* openFile) {
+	  openFile->truncate(size);
+  });
 }
 
 fspp::num_bytes_t FilesystemImpl::read(int descriptor, void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) {

--- a/src/fspp/impl/FilesystemImpl.h
+++ b/src/fspp/impl/FilesystemImpl.h
@@ -30,9 +30,11 @@ public:
 	void flush(int descriptor) override;
 	void closeFile(int descriptor) override;
 	void lstat(const boost::filesystem::path &path, fspp::fuse::STAT *stbuf) override;
+	void fstat(int descriptor, fspp::fuse::STAT *stbuf) override;
 	void chmod(const boost::filesystem::path &path, ::mode_t mode) override;
 	void chown(const boost::filesystem::path &path, ::uid_t uid, ::gid_t gid) override;
 	void truncate(const boost::filesystem::path &path, fspp::num_bytes_t size) override;
+	void ftruncate(int descriptor, fspp::num_bytes_t size) override;
 	fspp::num_bytes_t read(int descriptor, void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) override;
 	void write(int descriptor, const void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) override;
 	void fsync(int descriptor) override;
@@ -64,9 +66,11 @@ private:
     std::atomic<uint64_t> _flushNanosec;
     std::atomic<uint64_t> _closeFileNanosec;
     std::atomic<uint64_t> _lstatNanosec;
+    std::atomic<uint64_t> _fstatNanosec;
     std::atomic<uint64_t> _chmodNanosec;
     std::atomic<uint64_t> _chownNanosec;
     std::atomic<uint64_t> _truncateNanosec;
+    std::atomic<uint64_t> _ftruncateNanosec;
     std::atomic<uint64_t> _readNanosec;
     std::atomic<uint64_t> _writeNanosec;
     std::atomic<uint64_t> _fsyncNanosec;

--- a/test/fspp/CMakeLists.txt
+++ b/test/fspp/CMakeLists.txt
@@ -6,6 +6,14 @@ set(SOURCES
     testutils/InMemoryFile.cpp
     impl/FuseOpenFileListTest.cpp
     impl/IdListTest.cpp
+    fuse/fstat/testutils/FuseFstatTest.cpp
+    fuse/fstat/FuseFstatErrorTest.cpp
+    fuse/fstat/FuseFstatParameterTest.cpp
+    fuse/fstat/FuseFstatOnOpenFileTest.cpp
+    fuse/ftruncate/testutils/FuseFTruncateTest.cpp
+    fuse/ftruncate/FuseFTruncateErrorTest.cpp
+    fuse/ftruncate/FuseFTruncateFileDescriptorTest.cpp
+    fuse/ftruncate/FuseFTruncateSizeTest.cpp
     fuse/lstat/FuseLstatReturnUidTest.cpp
     fuse/lstat/testutils/FuseLstatTest.cpp
     fuse/lstat/FuseLstatReturnCtimeTest.cpp

--- a/test/fspp/fuse/createAndOpenFile/FuseCreateAndOpenErrorTest.cpp
+++ b/test/fspp/fuse/createAndOpenFile/FuseCreateAndOpenErrorTest.cpp
@@ -6,7 +6,7 @@ using ::testing::WithParamInterface;
 using ::testing::Values;
 using ::testing::Throw;
 using ::testing::Eq;
-using ::testing::Invoke;
+using ::testing::Return;
 
 using namespace fspp::fuse;
 
@@ -15,13 +15,11 @@ class FuseCreateAndOpenErrorTest: public FuseCreateAndOpenTest, public WithParam
 INSTANTIATE_TEST_SUITE_P(FuseCreateAndOpenErrorTest, FuseCreateAndOpenErrorTest, Values(EACCES, EDQUOT, EEXIST, EFAULT, EFBIG, EINTR, EOVERFLOW, EINVAL, EISDIR, ELOOP, EMFILE, ENAMETOOLONG, ENFILE, ENODEV, ENOENT, ENOMEM, ENOSPC, ENOTDIR, ENXIO, EOPNOTSUPP, EPERM, EROFS, ETXTBSY, EWOULDBLOCK, EBADF, ENOTDIR));
 
 TEST_F(FuseCreateAndOpenErrorTest, ReturnNoError) {
-  bool created = false;
-  ReturnIsFileOnLstatIfFlagIsSet(FILENAME, &created);
-  EXPECT_CALL(*fsimpl, createAndOpenFile(Eq(FILENAME), testing::_, testing::_, testing::_)).Times(1).WillOnce(Invoke([&] () {
-    ASSERT(!created, "called created multiple times");
-    created = true;
-    return 1;
-  }));
+  ReturnDoesntExistOnLstat(FILENAME);
+  EXPECT_CALL(*fsimpl, createAndOpenFile(Eq(FILENAME), testing::_, testing::_, testing::_))
+    .Times(1).WillOnce(Return(1));
+  //libfuse asks for the new file's attributes through the handle create() returned
+  ReturnIsFileOnFstat(1);
 
   const int error = CreateAndOpenFileReturnError(FILENAME, O_RDONLY);
   EXPECT_EQ(0, error);

--- a/test/fspp/fuse/createAndOpenFile/FuseCreateAndOpenFileDescriptorTest.cpp
+++ b/test/fspp/fuse/createAndOpenFile/FuseCreateAndOpenFileDescriptorTest.cpp
@@ -4,6 +4,7 @@ using ::testing::Eq;
 using ::testing::WithParamInterface;
 using ::testing::Values;
 using ::testing::Invoke;
+using ::testing::Return;
 using cpputils::unique_ref;
 using cpputils::make_unique_ref;
 
@@ -32,14 +33,12 @@ private:
 INSTANTIATE_TEST_SUITE_P(FuseCreateAndOpenFileDescriptorTest, FuseCreateAndOpenFileDescriptorTest, Values(0, 2, 5, 1000, 1024*1024*1024));
 
 TEST_P(FuseCreateAndOpenFileDescriptorTest, TestReturnedFileDescriptor) {
-  bool created = false;
-  ReturnIsFileOnLstatWithSizeIfFlagIsSet(FILENAME, fspp::num_bytes_t(100), &created);
+  ReturnDoesntExistOnLstat(FILENAME);
   EXPECT_CALL(*fsimpl, createAndOpenFile(Eq(FILENAME), testing::_, testing::_, testing::_))
-    .Times(1).WillOnce(Invoke([&] () {
-      ASSERT(!created, "called createAndOpenFile multiple times");
-      created = true;
-      return GetParam();
-    }));
+    .Times(1).WillOnce(Return(GetParam()));
+  //libfuse asks for the new file's attributes through the handle create() returned. The file has to
+  //look non-empty, otherwise the kernel answers our read from the (empty) file itself.
+  ReturnIsFileOnFstatWithSize(GetParam(), fspp::num_bytes_t(100));
   EXPECT_CALL(*fsimpl, read(Eq(GetParam()), testing::_, testing::_, testing::_)).Times(1).WillOnce(Invoke([] () {
     return fspp::num_bytes_t(1);
   }));

--- a/test/fspp/fuse/createAndOpenFile/FuseCreateAndOpenFilenameTest.cpp
+++ b/test/fspp/fuse/createAndOpenFile/FuseCreateAndOpenFilenameTest.cpp
@@ -1,50 +1,42 @@
 #include "testutils/FuseCreateAndOpenTest.h"
 
 using ::testing::Eq;
-using ::testing::Invoke;
+using ::testing::Return;
 
 class FuseCreateAndOpenFilenameTest: public FuseCreateAndOpenTest {
 public:
+  static constexpr int DESCRIPTOR = 0;
 };
 
+// After create(), libfuse asks for the new file's attributes through the handle create() just
+// returned, so the answer comes from fstat() and the path is never looked up a second time.
+
 TEST_F(FuseCreateAndOpenFilenameTest, CreateAndOpenFile) {
-  bool created = false;
-  ReturnIsFileOnLstatIfFlagIsSet("/myfile", &created);
+  ReturnDoesntExistOnLstat("/myfile");
   EXPECT_CALL(*fsimpl, createAndOpenFile(Eq("/myfile"), testing::_, testing::_, testing::_))
-    .Times(1).WillOnce(Invoke([&] () {
-      ASSERT(!created, "called createAndOpenFile multiple times");
-      created = true;
-      return 0;
-    }));
+    .Times(1).WillOnce(Return(DESCRIPTOR));
+  ReturnIsFileOnFstat(DESCRIPTOR);
 
   CreateAndOpenFile("/myfile", O_RDONLY);
 }
 
 TEST_F(FuseCreateAndOpenFilenameTest, CreateAndOpenFileNested) {
-  bool created = false;
   ReturnIsDirOnLstat("/mydir");
-  ReturnIsFileOnLstatIfFlagIsSet("/mydir/myfile", &created);
+  ReturnDoesntExistOnLstat("/mydir/myfile");
   EXPECT_CALL(*fsimpl, createAndOpenFile(Eq("/mydir/myfile"), testing::_, testing::_, testing::_))
-    .Times(1).WillOnce(Invoke([&] () {
-      ASSERT(!created, "called createAndOpenFile multiple times");
-      created = true;
-      return 0;
-    }));
+    .Times(1).WillOnce(Return(DESCRIPTOR));
+  ReturnIsFileOnFstat(DESCRIPTOR);
 
   CreateAndOpenFile("/mydir/myfile", O_RDONLY);
 }
 
 TEST_F(FuseCreateAndOpenFilenameTest, CreateAndOpenFileNested2) {
-  bool created = false;
   ReturnIsDirOnLstat("/mydir");
   ReturnIsDirOnLstat("/mydir/mydir2");
-  ReturnIsFileOnLstatIfFlagIsSet("/mydir/mydir2/myfile", &created);
+  ReturnDoesntExistOnLstat("/mydir/mydir2/myfile");
   EXPECT_CALL(*fsimpl, createAndOpenFile(Eq("/mydir/mydir2/myfile"), testing::_, testing::_, testing::_))
-    .Times(1).WillOnce(Invoke([&] () {
-      ASSERT(!created, "called createAndOpenFile multiple times");
-      created = true;
-      return 0;
-    }));
+    .Times(1).WillOnce(Return(DESCRIPTOR));
+  ReturnIsFileOnFstat(DESCRIPTOR);
 
   CreateAndOpenFile("/mydir/mydir2/myfile", O_RDONLY);
 }

--- a/test/fspp/fuse/fstat/FuseFstatErrorTest.cpp
+++ b/test/fspp/fuse/fstat/FuseFstatErrorTest.cpp
@@ -1,0 +1,37 @@
+#include "testutils/FuseFstatTest.h"
+
+#include "fspp/fs_interface/FuseErrnoException.h"
+
+using ::testing::WithParamInterface;
+using ::testing::Values;
+using ::testing::Eq;
+using ::testing::Throw;
+
+
+using namespace fspp::fuse;
+
+// Cite from FUSE documentation on the fgetattr function:
+// "Currently this is only called after the create() method if that is implemented (see above).
+//  Later it may be called for invocations of fstat() too."
+// So we need to issue a create to get our fstat called.
+
+class FuseFstatErrorTest: public FuseFstatTest, public WithParamInterface<int> {
+public:
+  /*unique_ref<OpenFileHandle> CreateFileAllowErrors(const TempTestFS *fs, const std::string &filename) {
+    auto real_path = fs->mountDir() / filename;
+    return make_unique_ref<OpenFileHandle>(real_path.string().c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  }*/
+};
+INSTANTIATE_TEST_SUITE_P(FuseFstatErrorTest, FuseFstatErrorTest, Values(EACCES, EBADF, EFAULT, ELOOP, ENAMETOOLONG, ENOENT, ENOMEM, ENOTDIR, EOVERFLOW));
+
+TEST_P(FuseFstatErrorTest, ReturnedErrorCodeIsCorrect) {
+  ReturnDoesntExistOnLstat(FILENAME);
+  OnCreateAndOpenReturnFileDescriptor(FILENAME, 0);
+
+  EXPECT_CALL(*fsimpl, fstat(Eq(0), testing::_)).Times(1).WillOnce(Throw(FuseErrnoException(GetParam())));
+
+  auto fs = TestFS();
+
+  const int error = CreateFileReturnError(fs.get(), FILENAME);
+  EXPECT_EQ(GetParam(), error);
+}

--- a/test/fspp/fuse/fstat/FuseFstatOnOpenFileTest.cpp
+++ b/test/fspp/fuse/fstat/FuseFstatOnOpenFileTest.cpp
@@ -1,0 +1,94 @@
+#include "testutils/FuseFstatTest.h"
+
+#include "fspp/fs_interface/FuseErrnoException.h"
+
+using ::testing::AtLeast;
+using ::testing::Eq;
+using ::testing::Throw;
+using ::testing::Values;
+using ::testing::WithParamInterface;
+
+using cpputils::make_unique_ref;
+using cpputils::unique_ref;
+
+using namespace fspp::fuse;
+
+// libfuse 2 only called fgetattr() after create(). libfuse 3 merged it into getattr() and hands us
+// the open file's fuse_file_info, so requests that come from an open file reach us through the
+// handle and the path never has to be resolved again.
+//
+// The call used here is lseek(fd, 0, SEEK_END). Plain fstat(2) would not do: the kernel's getattr
+// inode operation has no struct file to take a handle from, so it asks by path. lseek(SEEK_END)
+// goes through fuse_file_llseek(), which does have the file and sets FATTR_FH. The mount uses
+// attr_timeout=0 so the kernel asks us instead of answering out of its attribute cache.
+class FuseFstatOnOpenFileTest: public FuseTest {
+public:
+  const char *FILENAME = "/myfile";
+
+  unique_ref<TempTestFS> MountWithoutAttributeCache() {
+    return TestFS({"-o", "attr_timeout=0"});
+  }
+
+  unique_ref<OpenFileHandle> OpenFile(const TempTestFS *fs) {
+    auto realpath = fs->mountDir() / FILENAME;
+    auto fd = make_unique_ref<OpenFileHandle>(realpath.string().c_str(), O_RDONLY);
+    EXPECT_GE(fd->fd(), 0) << "Opening file failed";
+    return fd;
+  }
+};
+
+class FuseFstatOnOpenFileDescriptorTest: public FuseFstatOnOpenFileTest, public WithParamInterface<int> {
+};
+INSTANTIATE_TEST_SUITE_P(FuseFstatOnOpenFileDescriptorTest, FuseFstatOnOpenFileDescriptorTest, Values(0, 1, 10, 1000, 1024*1024*1024));
+
+TEST_P(FuseFstatOnOpenFileDescriptorTest, FstatGoesThroughTheFileDescriptor) {
+  ReturnIsFileOnLstat(FILENAME);
+  OnOpenReturnFileDescriptor(FILENAME, GetParam());
+  //this is the point: fstat() and not lstat() answers, and it gets the descriptor open() returned
+  EXPECT_CALL(*fsimpl, fstat(Eq(GetParam()), testing::_))
+    .Times(AtLeast(1)).WillRepeatedly(ReturnIsFileFstatWithSize(fspp::num_bytes_t(1024)));
+
+  auto fs = MountWithoutAttributeCache();
+  auto fd = OpenFile(fs.get());
+
+  EXPECT_EQ(1024, ::lseek(fd->fd(), 0, SEEK_END));
+}
+
+class FuseFstatOnOpenFileSizeTest: public FuseFstatOnOpenFileTest, public WithParamInterface<fspp::num_bytes_t> {
+};
+INSTANTIATE_TEST_SUITE_P(FuseFstatOnOpenFileSizeTest, FuseFstatOnOpenFileSizeTest, Values(
+    fspp::num_bytes_t(0),
+    fspp::num_bytes_t(1),
+    fspp::num_bytes_t(10),
+    fspp::num_bytes_t(1024),
+    fspp::num_bytes_t(1024*1024*1024)));
+
+TEST_P(FuseFstatOnOpenFileSizeTest, ReturnedSizeIsCorrect) {
+  ReturnIsFileOnLstat(FILENAME);
+  OnOpenReturnFileDescriptor(FILENAME, 0);
+  EXPECT_CALL(*fsimpl, fstat(Eq(0), testing::_))
+    .Times(AtLeast(1)).WillRepeatedly(ReturnIsFileFstatWithSize(GetParam()));
+
+  auto fs = MountWithoutAttributeCache();
+  auto fd = OpenFile(fs.get());
+
+  EXPECT_EQ(GetParam().value(), ::lseek(fd->fd(), 0, SEEK_END));
+}
+
+class FuseFstatOnOpenFileErrorTest: public FuseFstatOnOpenFileTest, public WithParamInterface<int> {
+};
+INSTANTIATE_TEST_SUITE_P(FuseFstatOnOpenFileErrorTest, FuseFstatOnOpenFileErrorTest, Values(EACCES, EBADF, EFAULT, ELOOP, ENAMETOOLONG, ENOENT, ENOMEM, ENOTDIR, EOVERFLOW));
+
+TEST_P(FuseFstatOnOpenFileErrorTest, ReturnedErrorIsCorrect) {
+  ReturnIsFileOnLstat(FILENAME);
+  OnOpenReturnFileDescriptor(FILENAME, 0);
+  EXPECT_CALL(*fsimpl, fstat(Eq(0), testing::_))
+    .Times(AtLeast(1)).WillRepeatedly(Throw(FuseErrnoException(GetParam())));
+
+  auto fs = MountWithoutAttributeCache();
+  auto fd = OpenFile(fs.get());
+
+  errno = 0;
+  ASSERT_EQ(-1, ::lseek(fd->fd(), 0, SEEK_END)) << "lseek should have failed";
+  EXPECT_EQ(GetParam(), errno);
+}

--- a/test/fspp/fuse/fstat/FuseFstatParameterTest.cpp
+++ b/test/fspp/fuse/fstat/FuseFstatParameterTest.cpp
@@ -1,0 +1,33 @@
+#include "testutils/FuseFstatTest.h"
+
+#include "fspp/fs_interface/FuseErrnoException.h"
+
+using ::testing::WithParamInterface;
+using ::testing::Values;
+using ::testing::Eq;
+
+using namespace fspp::fuse;
+
+// Cite from FUSE documentation on the fgetattr function:
+// "Currently this is only called after the create() method if that is implemented (see above).
+//  Later it may be called for invocations of fstat() too."
+// So we need to issue a create to get our fstat called.
+
+class FuseFstatParameterTest: public FuseFstatTest, public WithParamInterface<int> {
+public:
+  void CallFstat(const char *filename) {
+    auto fs = TestFS();
+    CreateFile(fs.get(), filename);
+  }
+};
+INSTANTIATE_TEST_SUITE_P(FuseFstatParameterTest, FuseFstatParameterTest, Values(0,1,10,1000,1024*1024*1024));
+
+
+TEST_P(FuseFstatParameterTest, FileDescriptorIsCorrect) {
+  ReturnDoesntExistOnLstat(FILENAME);
+  OnCreateAndOpenReturnFileDescriptor(FILENAME, GetParam());
+
+  EXPECT_CALL(*fsimpl, fstat(Eq(GetParam()), testing::_)).Times(1).WillOnce(ReturnIsFileFstat);
+
+  CallFstat(FILENAME);
+}

--- a/test/fspp/fuse/fstat/README
+++ b/test/fspp/fuse/fstat/README
@@ -1,0 +1,13 @@
+libfuse 2 only ever called fgetattr() after the create() method, which is what
+FuseFstatErrorTest and FuseFstatParameterTest exercise: they issue a create to get
+fstat called, so they can't check the values it returns.
+
+libfuse 3 merged fgetattr() into getattr() and passes the open file's fuse_file_info,
+so requests that come from an open file reach the file system through the handle too.
+FuseFstatOnOpenFileTest covers that, including the values fstat returns.
+
+It uses lseek(fd, 0, SEEK_END) rather than fstat(2). The kernel's getattr inode
+operation has no struct file to take a handle from, so a plain fstat(2) is answered by
+path; lseek(SEEK_END) goes through fuse_file_llseek(), which does have the file and
+sets FATTR_FH. The mount uses attr_timeout=0, because the kernel would otherwise
+answer out of its attribute cache without asking us at all.

--- a/test/fspp/fuse/fstat/testutils/FuseFstatTest.cpp
+++ b/test/fspp/fuse/fstat/testutils/FuseFstatTest.cpp
@@ -1,0 +1,28 @@
+#include "FuseFstatTest.h"
+
+using ::testing::Eq;
+using ::testing::Return;
+using cpputils::unique_ref;
+using cpputils::make_unique_ref;
+
+
+unique_ref<OpenFileHandle> FuseFstatTest::CreateFile(const TempTestFS *fs, const std::string &filename) {
+  auto fd = CreateFileAllowErrors(fs, filename);
+  EXPECT_GE(fd->fd(), 0) << "Opening file failed";
+  return fd;
+}
+
+int FuseFstatTest::CreateFileReturnError(const TempTestFS *fs, const std::string &filename) {
+  auto fd = CreateFileAllowErrors(fs, filename);
+  return fd->errorcode();
+}
+
+unique_ref<OpenFileHandle> FuseFstatTest::CreateFileAllowErrors(const TempTestFS *fs, const std::string &filename) {
+  auto real_path = fs->mountDir() / filename;
+  auto fd = make_unique_ref<OpenFileHandle>(real_path.string().c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  return fd;
+}
+
+void FuseFstatTest::OnCreateAndOpenReturnFileDescriptor(const char *filename, int descriptor) {
+  EXPECT_CALL(*fsimpl, createAndOpenFile(Eq(filename), testing::_, testing::_, testing::_)).Times(1).WillOnce(Return(descriptor));
+}

--- a/test/fspp/fuse/fstat/testutils/FuseFstatTest.h
+++ b/test/fspp/fuse/fstat/testutils/FuseFstatTest.h
@@ -1,0 +1,18 @@
+#pragma once
+#ifndef MESSMER_FSPP_TEST_FUSE_FSTAT_TESTUTILS_FUSEFSTATTEST_H_
+#define MESSMER_FSPP_TEST_FUSE_FSTAT_TESTUTILS_FUSEFSTATTEST_H_
+
+#include "../../../testutils/FuseTest.h"
+#include "../../../testutils/OpenFileHandle.h"
+
+class FuseFstatTest: public FuseTest {
+public:
+  cpputils::unique_ref<OpenFileHandle> CreateFile(const TempTestFS *fs, const std::string &filename);
+  int CreateFileReturnError(const TempTestFS *fs, const std::string &filename);
+  void OnCreateAndOpenReturnFileDescriptor(const char *filename, int descriptor);
+private:
+  cpputils::unique_ref<OpenFileHandle> CreateFileAllowErrors(const TempTestFS *fs, const std::string &filename);
+};
+
+
+#endif

--- a/test/fspp/fuse/ftruncate/FuseFTruncateErrorTest.cpp
+++ b/test/fspp/fuse/ftruncate/FuseFTruncateErrorTest.cpp
@@ -1,0 +1,25 @@
+#include "testutils/FuseFTruncateTest.h"
+
+#include "fspp/fs_interface/FuseErrnoException.h"
+
+using ::testing::Throw;
+using ::testing::WithParamInterface;
+using ::testing::Values;
+
+using namespace fspp::fuse;
+
+class FuseFTruncateErrorTest: public FuseFTruncateTest, public WithParamInterface<int> {
+};
+INSTANTIATE_TEST_SUITE_P(FuseFTruncateErrorTest, FuseFTruncateErrorTest, Values(EACCES, EFAULT, EFBIG, EINTR, EINVAL, EIO, EISDIR, ELOOP, ENAMETOOLONG, ENOENT, ENOTDIR, EPERM, EROFS, ETXTBSY, EBADF));
+
+TEST_P(FuseFTruncateErrorTest, ReturnedErrorIsCorrect) {
+  ReturnIsFileOnLstat(FILENAME);
+  OnOpenReturnFileDescriptor(FILENAME, 0);
+  EXPECT_CALL(*fsimpl, ftruncate(0, testing::_))
+    .Times(1).WillOnce(Throw(FuseErrnoException(GetParam())));
+  //Needed to make ::ftruncate system call return successfully
+  ReturnIsFileOnFstat(0);
+
+  const int error = FTruncateFileReturnError(FILENAME, fspp::num_bytes_t(0));
+  EXPECT_EQ(GetParam(), error);
+}

--- a/test/fspp/fuse/ftruncate/FuseFTruncateFileDescriptorTest.cpp
+++ b/test/fspp/fuse/ftruncate/FuseFTruncateFileDescriptorTest.cpp
@@ -1,0 +1,26 @@
+#include "testutils/FuseFTruncateTest.h"
+
+#include "fspp/fs_interface/FuseErrnoException.h"
+
+using ::testing::WithParamInterface;
+using ::testing::Values;
+using ::testing::Eq;
+using ::testing::Return;
+
+using namespace fspp::fuse;
+
+class FuseFTruncateFileDescriptorTest: public FuseFTruncateTest, public WithParamInterface<int> {
+};
+INSTANTIATE_TEST_SUITE_P(FuseFTruncateFileDescriptorTest, FuseFTruncateFileDescriptorTest, Values(0,1,10,1000,1024*1024*1024));
+
+
+TEST_P(FuseFTruncateFileDescriptorTest, FileDescriptorIsCorrect) {
+  ReturnIsFileOnLstat(FILENAME);
+  OnOpenReturnFileDescriptor(FILENAME, GetParam());
+  EXPECT_CALL(*fsimpl, ftruncate(Eq(GetParam()), testing::_))
+    .Times(1).WillOnce(Return());
+  //Needed to make ::ftruncate system call return successfully
+  ReturnIsFileOnFstat(GetParam());
+
+  FTruncateFile(FILENAME, fspp::num_bytes_t(0));
+}

--- a/test/fspp/fuse/ftruncate/FuseFTruncateSizeTest.cpp
+++ b/test/fspp/fuse/ftruncate/FuseFTruncateSizeTest.cpp
@@ -1,0 +1,27 @@
+#include "testutils/FuseFTruncateTest.h"
+
+using ::testing::Eq;
+using ::testing::Return;
+using ::testing::WithParamInterface;
+using ::testing::Values;
+
+class FuseFTruncateSizeTest: public FuseFTruncateTest, public WithParamInterface<fspp::num_bytes_t> {
+};
+INSTANTIATE_TEST_SUITE_P(FuseFTruncateSizeTest, FuseFTruncateSizeTest, Values(
+    fspp::num_bytes_t(0),
+    fspp::num_bytes_t(1),
+    fspp::num_bytes_t(10),
+    fspp::num_bytes_t(1024),
+    fspp::num_bytes_t(1024*1024*1024)));
+
+
+TEST_P(FuseFTruncateSizeTest, FTruncateFile) {
+  ReturnIsFileOnLstat(FILENAME);
+  OnOpenReturnFileDescriptor(FILENAME, 0);
+  EXPECT_CALL(*fsimpl, ftruncate(Eq(0), GetParam()))
+    .Times(1).WillOnce(Return());
+  //Needed to make ::ftruncate system call return successfully
+  ReturnIsFileOnFstat(0);
+
+  FTruncateFile(FILENAME, fspp::num_bytes_t(GetParam()));
+}

--- a/test/fspp/fuse/ftruncate/testutils/FuseFTruncateTest.cpp
+++ b/test/fspp/fuse/ftruncate/testutils/FuseFTruncateTest.cpp
@@ -1,0 +1,28 @@
+#include "FuseFTruncateTest.h"
+
+using cpputils::unique_ref;
+using cpputils::make_unique_ref;
+
+void FuseFTruncateTest::FTruncateFile(const char *filename, fspp::num_bytes_t size) {
+  const int error = FTruncateFileReturnError(filename, size);
+  EXPECT_EQ(0, error);
+}
+
+int FuseFTruncateTest::FTruncateFileReturnError(const char *filename, fspp::num_bytes_t size) {
+  auto fs = TestFS();
+
+  auto fd = OpenFile(fs.get(), filename);
+  const int retval = ::ftruncate(fd->fd(), size.value());
+  if (0 == retval) {
+    return 0;
+  } else {
+    return errno;
+  }
+}
+
+unique_ref<OpenFileHandle> FuseFTruncateTest::OpenFile(const TempTestFS *fs, const char *filename) {
+  auto realpath = fs->mountDir() / filename;
+  auto fd = make_unique_ref<OpenFileHandle>(realpath.string().c_str(), O_RDWR);
+  EXPECT_GE(fd->fd(), 0) << "Error opening file";
+  return fd;
+}

--- a/test/fspp/fuse/ftruncate/testutils/FuseFTruncateTest.h
+++ b/test/fspp/fuse/ftruncate/testutils/FuseFTruncateTest.h
@@ -1,0 +1,19 @@
+#pragma once
+#ifndef MESSMER_FSPP_TEST_FUSE_FTRUNCATE_TESTUTILS_FUSEFTRUNCATETEST_H_
+#define MESSMER_FSPP_TEST_FUSE_FTRUNCATE_TESTUTILS_FUSEFTRUNCATETEST_H_
+
+#include "../../../testutils/FuseTest.h"
+#include "../../../testutils/OpenFileHandle.h"
+
+class FuseFTruncateTest: public FuseTest {
+public:
+  const char *FILENAME = "/myfile";
+
+  void FTruncateFile(const char *filename, fspp::num_bytes_t size);
+  int FTruncateFileReturnError(const char *filename, fspp::num_bytes_t size);
+
+private:
+  cpputils::unique_ref<OpenFileHandle> OpenFile(const TempTestFS *fs, const char *filename);
+};
+
+#endif

--- a/test/fspp/impl/FuseOpenFileListTest.cpp
+++ b/test/fspp/impl/FuseOpenFileListTest.cpp
@@ -17,6 +17,8 @@ public:
 
   ~MockOpenFile() override {destructed = true;}
 
+  MOCK_METHOD(OpenFile::stat_info, stat, (), (const, override));
+  MOCK_METHOD(void, truncate, (fspp::num_bytes_t), (const, override));
   MOCK_METHOD(fspp::num_bytes_t, read, (void*, fspp::num_bytes_t, fspp::num_bytes_t), (const, override));
   MOCK_METHOD(void, write, (const void*, fspp::num_bytes_t, fspp::num_bytes_t), (override));
   MOCK_METHOD(void, flush, (), (override));

--- a/test/fspp/testutils/FuseTest.cpp
+++ b/test/fspp/testutils/FuseTest.cpp
@@ -24,7 +24,9 @@ FuseTest::FuseTest(): fsimpl(make_shared<MockFilesystem>()), _context(boost::non
   ON_CALL(*fsimpl, openFile(_,_)).WillByDefault(defaultAction);
   ON_CALL(*fsimpl, closeFile(_)).WillByDefault(defaultAction);
   ON_CALL(*fsimpl, lstat(_,_)).WillByDefault(Throw(FuseErrnoException(ENOENT)));
+  ON_CALL(*fsimpl, fstat(_,_)).WillByDefault(Throw(FuseErrnoException(ENOENT)));
   ON_CALL(*fsimpl, truncate(_,_)).WillByDefault(defaultAction);
+  ON_CALL(*fsimpl, ftruncate(_,_)).WillByDefault(defaultAction);
   ON_CALL(*fsimpl, read(_,_,_,_)).WillByDefault(defaultAction);
   ON_CALL(*fsimpl, write(_,_,_,_)).WillByDefault(defaultAction);
   ON_CALL(*fsimpl, fsync(_)).WillByDefault(defaultAction);
@@ -146,4 +148,12 @@ void FuseTest::ReturnIsDirOnLstat(const bf::path &path) {
 
 void FuseTest::ReturnDoesntExistOnLstat(const bf::path &path) {
   EXPECT_CALL(*fsimpl, lstat(Eq(path), ::testing::_)).WillRepeatedly(ReturnDoesntExist);
+}
+
+void FuseTest::ReturnIsFileOnFstat(int descriptor) {
+  EXPECT_CALL(*fsimpl, fstat(descriptor, testing::_)).WillRepeatedly(ReturnIsFileFstat);
+}
+
+void FuseTest::ReturnIsFileOnFstatWithSize(int descriptor, fspp::num_bytes_t size) {
+  EXPECT_CALL(*fsimpl, fstat(descriptor, testing::_)).WillRepeatedly(ReturnIsFileFstatWithSize(size));
 }

--- a/test/fspp/testutils/FuseTest.h
+++ b/test/fspp/testutils/FuseTest.h
@@ -24,7 +24,9 @@ public:
   MOCK_METHOD(int, openFile, (const boost::filesystem::path&, int), (override));
   MOCK_METHOD(void, closeFile, (int), (override));
   MOCK_METHOD(void, lstat, (const boost::filesystem::path&, fspp::fuse::STAT*), (override));
+  MOCK_METHOD(void, fstat, (int, fspp::fuse::STAT*), (override));
   MOCK_METHOD(void, truncate, (const boost::filesystem::path&, fspp::num_bytes_t), (override));
+  MOCK_METHOD(void, ftruncate, (int, fspp::num_bytes_t), (override));
   MOCK_METHOD(fspp::num_bytes_t, read, (int, void*, fspp::num_bytes_t, fspp::num_bytes_t), (override));
   MOCK_METHOD(void, write, (int, const void*, fspp::num_bytes_t, fspp::num_bytes_t), (override));
   MOCK_METHOD(void, flush, (int), (override));
@@ -92,6 +94,8 @@ public:
   void ReturnIsDirOnLstat(const boost::filesystem::path &path);
   void ReturnDoesntExistOnLstat(const boost::filesystem::path &path);
   void OnOpenReturnFileDescriptor(const char *filename, int descriptor);
+  void ReturnIsFileOnFstat(int descriptor);
+  void ReturnIsFileOnFstatWithSize(int descriptor, fspp::num_bytes_t size);
 };
 
 #endif


### PR DESCRIPTION
Part of the review of the libfuse 3 migration. One finding per pull request; this one is independent of the others.

## The problem

libfuse 3 merged `fgetattr` into `getattr` and `ftruncate` into `truncate`, passing the open file's `fuse_file_info` alongside the path. The idiomatic migration is to use `fi->fh` when it is there and fall back to the path when it is not, which is what libfuse's own passthrough example does:

```c
/* libfuse 3.9.0, example/passthrough.c:249 */
if (fi != NULL) res = ftruncate(fi->fh, size);
else            res = truncate(path, size);
```

The migration instead deleted the handle-based path. `OpenFile::stat`, `OpenFile::truncate`, `Filesystem::fstat` and `Filesystem::ftruncate` are gone and the new parameters are marked `UNUSED`. Requests that arrive with a handle now resolve the full path instead, one directory blob load and lookup per component, where the old code did a single `GetChild(blockId)` on a blob it already held.

Correctness was never at stake, since libfuse keeps the path valid for open files across unlink and rename. The work is real though: many of those loads are served by the caching blob store, so the cost is latency and lock traffic rather than disk I/O.

The seven `fstat` and `ftruncate` test files were deleted along with the code, so the one code path that changed had no test at all.

## The fix

The interfaces come back and `Fuse::getattr` and `Fuse::truncate` dispatch on `file_info != nullptr`.

Two request paths actually reach us with a handle, both confirmed on a mount:

- `ftruncate(2)`. The kernel sets `FATTR_FH` in the setattr request and libfuse hands us the `fi`.
- `getattr` after `create()`, where libfuse looks the new file up through the handle `create` just returned, and `lseek(fd, 0, SEEK_END)`, which goes through `fuse_file_llseek` in the kernel and has the `struct file` to take the handle from.

Worth recording, because it is not obvious: plain `fstat(2)` does **not** carry a handle. The kernel's `getattr` inode operation has no `struct file` to take one from, so it asks by path, and the fallback handles it. That is also why the deleted test suites could only reach `fgetattr` through `create()`.

## Tests

The deleted `fstat` and `ftruncate` suites are back unchanged. They cover the descriptor, the size and the error code for `ftruncate`, and the descriptor and errors for `fstat` via `create()`.

`FuseFstatOnOpenFileTest` is new and covers what libfuse 2 never could, which the old README in that directory says outright. It drives `lseek(SEEK_END)` on an open file, mounting with `attr_timeout=0` so the kernel asks us instead of answering from its attribute cache, and checks the descriptor, the returned size and the error code.

The create-and-open tests now expect the attribute lookup after `create()` to come through `fstat`. That also lets them drop the `created` flag they needed to tell the `lstat` before create from the one after, which was read and written from different libfuse worker threads without an atomic.

`FsppOpenFileTest` and `FsppOpenFileTest_Timestamps` get their `stat` and `truncate` cases back. Those run against real CryFS in `cryfs-test`.

Verified end to end on a mounted filesystem:

```
after ftruncate(4096): fstat size=4096  lseek(SEEK_END)=4096
after ftruncate(5):    fstat size=5     read=5 content='hello'
after close:           stat  size=5
```

| Suite | Before | After |
|---|---|---|
| `fspp-test` | 981 | 1039 passed |
| `cryfs-test` | 716 | 723 passed |
| `cryfs-cli-test` | 225 | 225 passed |

The `cryfs-cli-test` run excludes the permission tests, which cannot pass as root. CI runs them unprivileged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_