### PR TITLE
Build against libFUSE 3 on macOS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,8 +263,8 @@ Dependencies are managed via Conan. See `conanfile.py` for current versions.
 
 | Platform | Dependency | Purpose |
 |----------|-----------|---------|
-| Linux/macOS | libFUSE >= 2.9 | Filesystem in Userspace |
-| macOS | macFUSE | FUSE for macOS |
+| Linux/macOS | libFUSE 3 | Filesystem in Userspace |
+| macOS | macFUSE >= 4.10.0 | ships libFUSE 3 for macOS |
 | Windows | Dokan | Windows filesystem driver (see README for version) |
 
 ### Build Commands
@@ -428,7 +428,12 @@ Configuration in `.clang-tidy`:
 
 ### macOS
 
-- Requires macFUSE from https://osxfuse.github.io/
+- Requires macFUSE >= 4.10.0 from https://osxfuse.github.io/, which is the first release that
+  ships libFUSE 3. Older macFUSE only has the libFUSE 2.9 API.
+- `params.h` defines `FUSE_DARWIN_ENABLE_EXTENSIONS 0`, because macFUSE otherwise replaces some
+  `fuse_operations` members with macOS specific variants that don't match our signatures.
+- macFUSE installs into /usr/local, so pkg-config may need
+  `PKG_CONFIG_PATH=/usr/local/lib/pkgconfig` on Apple Silicon.
 - Apple Clang support varies by macOS version
 
 ## Stability Notes

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Requirements
   - CMake version >= 3.25
   - pkg-config (on Unix)
   - Conan package manager (version 2.x)
-  - libFUSE version >= 3.9 (including development headers) and the `fusermount3` helper it uses to mount and unmount, on Mac OS X instead install macFUSE from https://osxfuse.github.io/
+  - libFUSE version >= 3.9 (including development headers) and the `fusermount3` helper it uses to mount and unmount, on macOS instead install macFUSE 4.10.0 or newer from https://osxfuse.github.io/ - that is the first macFUSE release that ships libFUSE 3
   - Python >= 3.5
   - OpenMP
 

--- a/src/fspp/fuse/CMakeLists.txt
+++ b/src/fspp/fuse/CMakeLists.txt
@@ -40,13 +40,21 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     DESTINATION "${CMAKE_INSTALL_BINDIR}"
   )
 
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin") # macOS
+else() # Linux and macOS
   find_package(PkgConfig REQUIRED)
-  pkg_check_modules(Fuse REQUIRED IMPORTED_TARGET fuse)
-  target_link_libraries(${PROJECT_NAME} PUBLIC PkgConfig::Fuse)
-else() # Linux
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(Fuse3 REQUIRED IMPORTED_TARGET fuse3)
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    # macFUSE installs into /usr/local, which isn't on pkg-config's default search path when
+    # pkg-config itself comes from Homebrew on Apple Silicon.
+    set(ENV{PKG_CONFIG_PATH} "/usr/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
+  endif()
+  pkg_check_modules(Fuse3 IMPORTED_TARGET fuse3)
+  if(NOT Fuse3_FOUND)
+    if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+      message(FATAL_ERROR "Didn't find libfuse 3. On macOS it comes with macFUSE 4.10.0 and newer - install it from https://osxfuse.github.io/ or with 'brew install --cask macfuse'. If macFUSE is already installed, point pkg-config at it with PKG_CONFIG_PATH=/usr/local/lib/pkgconfig.")
+    else()
+      message(FATAL_ERROR "Didn't find libfuse 3. Install it, e.g. 'apt install libfuse3-dev' or 'dnf install fuse3-devel'.")
+    endif()
+  endif()
   target_link_libraries(${PROJECT_NAME} PUBLIC PkgConfig::Fuse3)
 endif()
 

--- a/src/fspp/fuse/CMakeLists.txt
+++ b/src/fspp/fuse/CMakeLists.txt
@@ -47,12 +47,15 @@ else() # Linux and macOS
     # pkg-config itself comes from Homebrew on Apple Silicon.
     set(ENV{PKG_CONFIG_PATH} "/usr/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}")
   endif()
-  pkg_check_modules(Fuse3 IMPORTED_TARGET fuse3)
+  # The minimum is enforced here rather than with a preprocessor check on FUSE_VERSION, because
+  # libfuse 3.9.0 itself ships a stale FUSE_MINOR_VERSION of 2 in its headers (fixed in 3.9.1), so
+  # a header check would reject the very version being asked for. pkg-config reads the real one.
+  pkg_check_modules(Fuse3 IMPORTED_TARGET "fuse3>=3.9")
   if(NOT Fuse3_FOUND)
     if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-      message(FATAL_ERROR "Didn't find libfuse 3. On macOS it comes with macFUSE 4.10.0 and newer - install it from https://osxfuse.github.io/ or with 'brew install --cask macfuse'. If macFUSE is already installed, point pkg-config at it with PKG_CONFIG_PATH=/usr/local/lib/pkgconfig.")
+      message(FATAL_ERROR "Didn't find libfuse 3.9 or newer. On macOS it comes with macFUSE 4.10.0 and newer - install it from https://osxfuse.github.io/ or with 'brew install --cask macfuse'. If macFUSE is already installed, point pkg-config at it with PKG_CONFIG_PATH=/usr/local/lib/pkgconfig.")
     else()
-      message(FATAL_ERROR "Didn't find libfuse 3. Install it, e.g. 'apt install libfuse3-dev' or 'dnf install fuse3-devel'.")
+      message(FATAL_ERROR "Didn't find libfuse 3.9 or newer. Install it, e.g. 'apt install libfuse3-dev' or 'dnf install fuse3-devel'.")
     endif()
   endif()
   target_link_libraries(${PROJECT_NAME} PUBLIC PkgConfig::Fuse3)

--- a/src/fspp/fuse/params.h
+++ b/src/fspp/fuse/params.h
@@ -9,13 +9,14 @@
 // guarded with FUSE_MAJOR_VERSION in Fuse.h and Fuse.cpp.
 #define FUSE_USE_VERSION 27
 #else
-// 309, not 39. libfuse changed FUSE_MAKE_VERSION from (major*10 + minor) to (major*100 + minor) in
-// 3.10.0, so on every header released since then 39 is not 3.9, it is a number that means nothing
-// and happens to land on the right side of each of libfuse's remaining version guards. 309 is
-// FUSE_MAKE_VERSION(3, 9) on a modern header and behaves exactly like 39 on an older one. Spelling
-// it as FUSE_MAKE_VERSION(3, 9) would be nicer still, but this header is shared with the Windows
-// build and Dokany's FUSE 2.7 headers don't define that macro.
-#define FUSE_USE_VERSION 309
+// 39 means API 3.9. libfuse changed FUSE_MAKE_VERSION from (major*10 + minor) to
+// (major*100 + minor) in 3.10.0, but it did not renumber the versions that already existed: the
+// two-digit values 29..39 keep their meaning and the three-digit space starts at 310. libfuse 3.17
+// still spells its own guards for the old versions as literal 30, 32 and 35, and its own examples
+// still use 31, 34 and 35, switching to FUSE_MAKE_VERSION only from 3.12 on. So 39 is the correct
+// spelling for 3.9; FUSE_MAKE_VERSION(3, 9) would be 309, a value in the gap between the two
+// numbering spaces that libfuse gives no meaning to.
+#define FUSE_USE_VERSION 39
 
 #if defined(__APPLE__)
 // macFUSE ships libfuse 3 (since macFUSE 4.10.0), but by default it replaces six fuse_operations

--- a/src/fspp/fuse/params.h
+++ b/src/fspp/fuse/params.h
@@ -9,7 +9,13 @@
 // guarded with FUSE_MAJOR_VERSION in Fuse.h and Fuse.cpp.
 #define FUSE_USE_VERSION 27
 #else
-#define FUSE_USE_VERSION 39
+// 309, not 39. libfuse changed FUSE_MAKE_VERSION from (major*10 + minor) to (major*100 + minor) in
+// 3.10.0, so on every header released since then 39 is not 3.9, it is a number that means nothing
+// and happens to land on the right side of each of libfuse's remaining version guards. 309 is
+// FUSE_MAKE_VERSION(3, 9) on a modern header and behaves exactly like 39 on an older one. Spelling
+// it as FUSE_MAKE_VERSION(3, 9) would be nicer still, but this header is shared with the Windows
+// build and Dokany's FUSE 2.7 headers don't define that macro.
+#define FUSE_USE_VERSION 309
 
 #if defined(__APPLE__)
 // macFUSE ships libfuse 3 (since macFUSE 4.10.0), but by default it replaces six fuse_operations

--- a/src/fspp/fuse/params.h
+++ b/src/fspp/fuse/params.h
@@ -10,9 +10,25 @@
 #define FUSE_USE_VERSION 27
 #else
 #define FUSE_USE_VERSION 39
+
+#if defined(__APPLE__)
+// macFUSE ships libfuse 3 (since macFUSE 4.10.0), but by default it replaces six fuse_operations
+// members with macOS specific variants: getattr and readdir take a 'struct fuse_darwin_attr'
+// instead of a 'struct stat', utimens takes a timespec[3] instead of a timespec[2], statfs takes a
+// 'struct statfs' instead of a 'struct statvfs', and get/setxattr take an extra position argument.
+// We implement the vanilla FUSE 3 signatures, so turn the extensions off. libfuse itself builds
+// with the same define. This has to happen before <fuse.h> is included.
+#define FUSE_DARWIN_ENABLE_EXTENSIONS 0
+#endif
 #endif
 
 #include <fuse.h>
+
+#if !defined(_MSC_VER) && FUSE_MAJOR_VERSION < 3
+// Without this, using a libFUSE 2 header produces a wall of signature mismatches instead of saying
+// what is actually wrong. Windows is exempt because Dokany's FUSE wrapper is still at FUSE 2.7.
+#error "CryFS needs libFUSE 3. On macOS, install macFUSE 4.10.0 or newer - that is the first release that ships libFUSE 3."
+#endif
 
 #if FUSE_MAJOR_VERSION < 3
 // Two types our own interface uses that only exist in FUSE 3. Declaring them here lets fspp keep


### PR DESCRIPTION
This is the macOS half of the blocker from the review: the sources are FUSE 3 only, but CMake still linked the FUSE 2 wrappers on macOS and Windows. Windows is not addressed here and needs a separate change; see the note at the end.

## The problem

`src/fspp/fuse/CMakeLists.txt` resolved the pkg-config module `fuse` on Darwin, which is macFUSE's libFUSE 2.9 API, while `Fuse.h` and `Fuse.cpp` use `fuse_config`, `fuse_readdir_flags`, the three-argument `getattr`, the five-argument filler and `FUSE_CAP_*` unconditionally. Every macOS job in the branch's CI fails at build:

```
macos-14 / clang 15 (job 100906242424)
Fuse.h:57: error: unknown type name 'fuse_readdir_flags'
Fuse.h:60: error: unknown type name 'fuse_config'
Fuse.cpp:207: error: incompatible function pointer types assigning to
              'int (*)(const char *, struct stat *)'
              from 'int (*)(const char *, stat *, fuse_file_info *)'
Fuse.cpp:1117: error: too many arguments to function call, expected 4, have 5
14 errors generated.
```

## Why macOS can simply move to FUSE 3

macFUSE has shipped libFUSE 3 since **macFUSE 4.10.0** (March 2025); the current 5.3.3 carries libFUSE 3.18.2. It installs `fuse3.pc`, `/usr/local/include/fuse3/` and `libfuse3.4.dylib` alongside the old libFUSE 2 files, so both APIs coexist and asking for `fuse3` is enough. `brew install --cask macfuse`, which CI already uses, installs the official 5.3.3 package.

Sources: [macFUSE 4.10.0 release notes](https://macfuse.github.io/2025/03/08/macfuse-4.10.0.html), [5.3.3 notes](https://macfuse.github.io/2026/07/04/macfuse-5.3.3.html), [`lib/meson.build` on `support/libfuse-3.18`](https://raw.githubusercontent.com/macfuse/library/support/libfuse-3.18/lib/meson.build).

## What rides along

**The Darwin API extensions have to be off.** macFUSE replaces six `fuse_operations` members with macOS-specific variants unless `FUSE_DARWIN_ENABLE_EXTENSIONS` is 0. `getattr` and `readdir` take a `struct fuse_darwin_attr` instead of a `struct stat`, `statfs` a `struct statfs` instead of a `struct statvfs`, `utimens` a `timespec[3]` instead of a `timespec[2]`, and `get`/`setxattr` an extra position argument. `params.h` turns them off before including `<fuse.h>`, which is what libFUSE itself does when it builds on macOS.

`utimens` is worth calling out: it would compile either way, because `timespec[2]` and `timespec[3]` decay to the same pointer type in a function signature. It would then be handed a three-element array. That is a good reason to be explicit rather than to rely on the default.

**pkg-config needs a hint.** macFUSE installs into `/usr/local`, which is not on pkg-config's default search path when pkg-config comes from Homebrew on Apple Silicon, and the CI runners are `macos-14`, `macos-15` and `macos-26`. CMake now prepends it. If libFUSE 3 is still not found, the error names macFUSE and the version that has it instead of just failing the pkg-config check.

**A guard for the wrong header.** `params.h` refuses a libFUSE 2 header outright, so someone on an older macFUSE gets one clear message rather than a wall of signature mismatches.

**Unmounting needs no change.** macFUSE builds no `fusermount3` (its meson build excludes `util/` on Darwin, and mounting goes through `MFMount`), and CryFS already calls `umount` on Apple.

## Verification

macOS cannot be built here, so the operations table was compiled against macFUSE's own libFUSE 3.18.2 headers, fetched from `macfuse/library` at `support/libfuse-3.18`, with both GCC and Clang:

| Configuration | Result |
|---|---|
| `__APPLE__`, extensions on (the default) | fails, exactly the Darwin variant mismatches |
| `__APPLE__`, extensions off (what this change does) | compiles clean at FUSE_USE_VERSION 30, 39, 312, 317 |

With the extensions on, the errors are precisely the three ones expected:

```
error: incompatible function pointer types assigning to
  'int (*)(const char *, struct fuse_darwin_attr *, struct fuse_file_info *)'
  from 'int (*)(const char *, stat *, fuse_file_info *)'
error: ... assigning to 'int (*)(const char *, struct statfs *)'
  from 'int (*)(const char *, struct statvfs *)'
error: ... assigning to '... fuse_darwin_fill_dir_t ...' from '... fuse_fill_dir_t ...'
```

The `#error` guard was checked both ways: it fires against a FUSE 2 header and stays quiet against FUSE 3.

Linux is unaffected: `fspp-test` still passes 1007 tests.

## Windows is still broken

Dokany's FUSE wrapper is still FUSE 2.7 and there is no libFUSE 3 version. Its `dokan_fuse/include/fuse_common.h` hardcodes `FUSE_MAJOR_VERSION 2` / `FUSE_MINOR_VERSION 7`, `getattr` has no `fuse_file_info`, `rename` has no `flags`, `init` has no `fuse_config`, and there are no `FUSE_CAP_*` constants at all. [dokany#182](https://github.com/dokan-dev/dokany/issues/182), asking for a newer FUSE API, has been open since 2016.

So Windows needs the compile-time FUSE 2 path that issue #419 describes, and that is a separate change. This one leaves the `_MSC_VER` branch exactly as it was and exempts Windows from the new header check, so nothing here stands in its way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_