### PR TITLE
Reject renameat2 flags instead of silently ignoring them

### DIFF
--- a/crates/rustfs/src/low_level_api/interface.rs
+++ b/crates/rustfs/src/low_level_api/interface.rs
@@ -263,6 +263,12 @@ pub trait AsyncFilesystemLL {
     ) -> FsResult<ReplyEntry>;
 
     /// Rename a file.
+    ///
+    /// `flags` carries the `renameat2()` flags (`RENAME_NOREPLACE`, `RENAME_EXCHANGE`,
+    /// `RENAME_WHITEOUT`); it is zero for a plain `rename()`. An implementation that doesn't honor
+    /// them must reject a non-zero `flags` with FsError::InvalidOperation rather than ignore it -
+    /// performing a plain rename in response to a `RENAME_EXCHANGE` reports success while
+    /// destroying one of the two files.
     async fn rename(
         &self,
         req: &RequestInfo,

--- a/crates/rustfs/src/object_based_api/low_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/low_level_adapter.rs
@@ -509,11 +509,12 @@ where
         oldname: &PathComponent,
         newparent_ino: InodeNumber,
         newname: &PathComponent,
-        _flags: u32,
+        flags: u32,
     ) -> FsResult<()> {
+        reject_unsupported_rename_flags(flags)?;
+
         self.trigger_on_operation().await?;
 
-        // TODO Honor flags
         // TODO Check that oldparent+oldname/newparent+newname aren't ancestors of each other, or at least write a test that fuse already blocks that
         if oldparent_ino == newparent_ino {
             let shared_parent = self.get_inode(oldparent_ino).await?;
@@ -1158,5 +1159,64 @@ where
         self.inodes.async_drop().await.unwrap();
         self.fs.write().await.async_drop().await.unwrap();
         Ok(())
+    }
+}
+
+/// The object based API cannot honor the `renameat2()` flags, so refuse them instead of silently
+/// ignoring them.
+///
+/// [Dir::rename_child] and [Dir::move_child_to] overwrite an existing target, which is the exact
+/// opposite of `RENAME_NOREPLACE`, and there is no operation that could atomically swap two entries
+/// for `RENAME_EXCHANGE`. Ignoring the flags is not a harmless simplification but destructive:
+/// answering a `RENAME_EXCHANGE` with a plain rename reports success while destroying one of the
+/// two files.
+///
+/// `EINVAL` is what the kernel itself answers once a file system says it doesn't handle
+/// `FUSE_RENAME2` (fs/fuse/dir.c: `fc->no_rename2 = 1; err = -EINVAL;`), and callers such as
+/// coreutils' `mv` react to it by falling back to a plain rename.
+///
+/// The kernel already rejects flags outside `RENAME_NOREPLACE | RENAME_EXCHANGE | RENAME_WHITEOUT`
+/// before they reach us, so in practice this only ever sees those three, but we reject on
+/// "anything set" rather than on a list so that a future flag doesn't silently slip through.
+///
+/// TODO Implement `RENAME_NOREPLACE` and `RENAME_EXCHANGE` instead of rejecting them.
+///      `RENAME_NOREPLACE` needs the "does the target exist" check to happen inside
+///      [Dir::rename_child]/[Dir::move_child_to], `RENAME_EXCHANGE` needs a new atomic
+///      "swap two entries" operation on [Dir].
+fn reject_unsupported_rename_flags(flags: u32) -> FsResult<()> {
+    if flags != 0 {
+        return Err(FsError::InvalidOperation);
+    }
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unflagged_rename_is_allowed() {
+        assert!(reject_unsupported_rename_flags(0).is_ok());
+    }
+
+    #[test]
+    fn renameat2_flags_are_rejected_with_einval() {
+        for flags in [
+            libc::RENAME_NOREPLACE,
+            libc::RENAME_EXCHANGE,
+            libc::RENAME_WHITEOUT,
+            libc::RENAME_NOREPLACE | libc::RENAME_WHITEOUT,
+            // Not something the kernel forwards today, but we must not start honoring a flag
+            // just because we don't know it.
+            1 << 31,
+        ] {
+            let error = reject_unsupported_rename_flags(flags)
+                .expect_err(&format!("flags={flags:#x} should have been rejected"));
+            assert!(
+                matches!(error, FsError::InvalidOperation),
+                "flags={flags:#x} was rejected with {error:?}",
+            );
+            assert_eq!(libc::EINVAL, error.system_error_code(), "flags={flags:#x}");
+        }
     }
 }

--- a/crates/rustfs/src/tests/mod.rs
+++ b/crates/rustfs/src/tests/mod.rs
@@ -4,3 +4,4 @@
 mod utils;
 
 mod mkdir;
+mod rename;

--- a/crates/rustfs/src/tests/rename.rs
+++ b/crates/rustfs/src/tests/rename.rs
@@ -1,0 +1,145 @@
+use cryfs_utils::path::{AbsolutePath, PathComponent};
+use mockall::predicate::{always, eq};
+
+use super::utils::{MockHelper, ROOT_INO, Runner, make_mock_filesystem};
+
+fn path(path: &str) -> &AbsolutePath {
+    AbsolutePath::try_from_str(path).unwrap()
+}
+
+fn pathcomp(path_component: &str) -> &PathComponent {
+    PathComponent::try_from_str(path_component).unwrap()
+}
+
+/// `rename(2)` has no flags, and the kernel sends it as `FUSE_RENAME` rather than `FUSE_RENAME2`,
+/// so the file system must see `flags == 0`. This is the case that has to keep working after we
+/// started rejecting non-zero flags.
+#[tokio::test]
+async fn plain_rename_passes_no_flags() {
+    let mut mock_filesystem = make_mock_filesystem();
+    let mut mock_helper = MockHelper::new(&mut mock_filesystem.fs);
+    mock_helper.expect_lookup_path_is_file(path("/source"));
+    mock_helper.expect_lookup_doesnt_exist(ROOT_INO, pathcomp("target"));
+    mock_filesystem
+        .fs
+        .expect_rename()
+        .once()
+        .with(
+            always(),
+            eq(ROOT_INO),
+            eq(pathcomp("source").to_owned()),
+            eq(ROOT_INO),
+            eq(pathcomp("target").to_owned()),
+            eq(0u32),
+        )
+        .return_once(|_, _, _, _, _, _| Ok(()));
+
+    let runner = Runner::start(mock_filesystem).await;
+    runner.driver().rename("/source", "/target").await.unwrap();
+}
+
+/// The `renameat2()` flags really do reach the file system - the kernel forwards them in
+/// `FUSE_RENAME2` instead of handling them itself. That is what makes ignoring them dangerous:
+/// a `RENAME_EXCHANGE` answered with a plain rename reports success while destroying one of the
+/// two files.
+///
+/// These tests cover the path from the syscall to [crate::low_level_api::AsyncFilesystemLL::rename]
+/// and back. That the object based API then refuses those flags is covered by the unit tests of
+/// `reject_unsupported_rename_flags` in [crate::object_based_api]; here the file system is a mock,
+/// so we assert on what it is handed and that its refusal arrives at the caller as `EINVAL`.
+#[cfg(all(target_os = "linux", target_env = "gnu"))]
+mod renameat2_flags {
+    use super::*;
+    use crate::common::FsError;
+    use nix::errno::Errno;
+    use nix::fcntl::RenameFlags;
+
+    /// The target must exist for `RENAME_EXCHANGE`, otherwise the VFS answers `ENOENT` without
+    /// ever asking the file system.
+    #[tokio::test]
+    async fn exchange_reaches_the_filesystem_and_is_rejected_with_einval() {
+        let mut mock_filesystem = make_mock_filesystem();
+        let mut mock_helper = MockHelper::new(&mut mock_filesystem.fs);
+        mock_helper.expect_lookup_path_is_file(path("/source"));
+        mock_helper.expect_lookup_path_is_file(path("/target"));
+        mock_filesystem
+            .fs
+            .expect_rename()
+            .once()
+            .with(
+                always(),
+                eq(ROOT_INO),
+                eq(pathcomp("source").to_owned()),
+                eq(ROOT_INO),
+                eq(pathcomp("target").to_owned()),
+                eq(libc::RENAME_EXCHANGE),
+            )
+            .return_once(|_, _, _, _, _, _| Err(FsError::InvalidOperation));
+
+        let runner = Runner::start(mock_filesystem).await;
+        let result = runner
+            .driver()
+            .renameat2("/source", "/target", RenameFlags::RENAME_EXCHANGE)
+            .await;
+        assert_eq!(Err(Errno::EINVAL), result);
+    }
+
+    /// The target must *not* exist for `RENAME_NOREPLACE`, otherwise the VFS answers `EEXIST`
+    /// without ever asking the file system.
+    #[tokio::test]
+    async fn noreplace_reaches_the_filesystem_and_is_rejected_with_einval() {
+        let mut mock_filesystem = make_mock_filesystem();
+        let mut mock_helper = MockHelper::new(&mut mock_filesystem.fs);
+        mock_helper.expect_lookup_path_is_file(path("/source"));
+        mock_helper.expect_lookup_doesnt_exist(ROOT_INO, pathcomp("target"));
+        mock_filesystem
+            .fs
+            .expect_rename()
+            .once()
+            .with(
+                always(),
+                eq(ROOT_INO),
+                eq(pathcomp("source").to_owned()),
+                eq(ROOT_INO),
+                eq(pathcomp("target").to_owned()),
+                eq(libc::RENAME_NOREPLACE),
+            )
+            .return_once(|_, _, _, _, _, _| Err(FsError::InvalidOperation));
+
+        let runner = Runner::start(mock_filesystem).await;
+        let result = runner
+            .driver()
+            .renameat2("/source", "/target", RenameFlags::RENAME_NOREPLACE)
+            .await;
+        assert_eq!(Err(Errno::EINVAL), result);
+    }
+
+    /// `renameat2()` without flags is a plain rename and must not be rejected.
+    #[tokio::test]
+    async fn empty_flags_are_a_plain_rename() {
+        let mut mock_filesystem = make_mock_filesystem();
+        let mut mock_helper = MockHelper::new(&mut mock_filesystem.fs);
+        mock_helper.expect_lookup_path_is_file(path("/source"));
+        mock_helper.expect_lookup_doesnt_exist(ROOT_INO, pathcomp("target"));
+        mock_filesystem
+            .fs
+            .expect_rename()
+            .once()
+            .with(
+                always(),
+                eq(ROOT_INO),
+                eq(pathcomp("source").to_owned()),
+                eq(ROOT_INO),
+                eq(pathcomp("target").to_owned()),
+                eq(0u32),
+            )
+            .return_once(|_, _, _, _, _, _| Ok(()));
+
+        let runner = Runner::start(mock_filesystem).await;
+        runner
+            .driver()
+            .renameat2("/source", "/target", RenameFlags::empty())
+            .await
+            .unwrap();
+    }
+}

--- a/crates/rustfs/src/tests/utils/filesystem_driver.rs
+++ b/crates/rustfs/src/tests/utils/filesystem_driver.rs
@@ -1,5 +1,5 @@
 use cryfs_utils::path::AbsolutePathBuf;
-use nix::{Result, unistd};
+use nix::{Result, fcntl, unistd};
 use std::path::PathBuf;
 
 use crate::Mode;
@@ -33,5 +33,32 @@ impl FilesystemDriver {
         tokio::task::spawn_blocking(move || unistd::mkdir(&path, mode))
             .await
             .unwrap()
+    }
+
+    pub async fn rename(&self, oldpath: &str, newpath: &str) -> Result<()> {
+        let oldpath = self._path(oldpath);
+        let newpath = self._path(newpath);
+        tokio::task::spawn_blocking(move || {
+            fcntl::renameat(fcntl::AT_FDCWD, &oldpath, fcntl::AT_FDCWD, &newpath)
+        })
+        .await
+        .unwrap()
+    }
+
+    /// `rename` with `renameat2()` flags. `renameat2` only exists on Linux.
+    #[cfg(all(target_os = "linux", target_env = "gnu"))]
+    pub async fn renameat2(
+        &self,
+        oldpath: &str,
+        newpath: &str,
+        flags: fcntl::RenameFlags,
+    ) -> Result<()> {
+        let oldpath = self._path(oldpath);
+        let newpath = self._path(newpath);
+        tokio::task::spawn_blocking(move || {
+            fcntl::renameat2(fcntl::AT_FDCWD, &oldpath, fcntl::AT_FDCWD, &newpath, flags)
+        })
+        .await
+        .unwrap()
     }
 }


### PR DESCRIPTION
This is the Rust counterpart of #568, which fixed the same bug in the C++ tree on `feature/fuse3`. The Rust rewrite has it too, and here it is worse.

## The bug

`ObjectBasedFsAdapterLL::rename` took `_flags: u32` with a `// TODO Honor flags` and dropped it on the floor. The kernel forwards the `renameat2()` flags in `FUSE_RENAME2` and expects the filesystem to honor them, so a `RENAME_EXCHANGE` became a plain rename — and our rename overwrites the target and deletes its blob.

Reproduced on a real CryFS mount built from `main`:

```
before:      a = AAAA    b = BBBB
renameat2(a -> b, RENAME_EXCHANGE) = -1 EIO
same mount:  ls -> [b]
remounted:   ls -> [b]
             b = AAAA                  <- a is destroyed, b's content is gone
```

Note the `EIO`. The rename itself succeeds; what fails afterwards is the adapter's inode bookkeeping (`_move_inode` finds the destination inode already occupied). So the caller is told the operation failed while half of it was in fact carried out, destructively. That is arguably worse than the C++ case, which reported success.

`RENAME_NOREPLACE` happens to be safe today because the VFS rejects it before the filesystem is reached (`fs/namei.c`: `if ((flags & RENAME_NOREPLACE) && d_is_positive(new_dentry)) goto exit`), but only when the target exists — with a negative target dentry the flag is passed straight down to us, and relying on that is not something to encode by accident.

## The fix

Return `EINVAL` (`FsError::InvalidOperation`) for any non-zero flags. `EINVAL` is what the kernel itself answers once a filesystem says it doesn't handle `FUSE_RENAME2` (`fs/fuse/dir.c`: `fc->no_rename2 = 1; err = -EINVAL;`), and callers such as coreutils' `mv` react to it by falling back to a plain rename. Implementing the flags properly is left as a TODO — `RENAME_NOREPLACE` needs the "does the target exist" check to happen inside `Dir::rename_child`/`Dir::move_child_to`, and `RENAME_EXCHANGE` needs a new atomic "swap two entries" operation on `Dir`.

The check deliberately lives in the object based adapter rather than in the fuser backend adapter: it is the object based API that cannot express those semantics, while a low level filesystem implementing `AsyncFilesystemLL` directly may well be able to. So the trait keeps the parameter and now documents that an implementation must either honor it or reject it.

## Tests

Nothing covered this — every existing rename test goes through `rename(2)`, which cannot carry flags.

* Unit tests for the flag check itself: `0` is allowed; `RENAME_NOREPLACE`, `RENAME_EXCHANGE`, `RENAME_WHITEOUT`, a combination, and an unknown flag are all rejected, and the rejection maps to `EINVAL`.
* Mount level tests (new `src/tests/rename.rs`, using the existing mock filesystem harness) that call `renameat2()` against a mounted filesystem. They establish the premise of the bug — that the flags really do arrive at the filesystem, the kernel does not handle them for us — and that a refusal reaches the caller as `EINVAL`. Plus a regression guard that a plain rename still arrives with `flags == 0` and succeeds, and that `renameat2()` with empty flags is a plain rename.
* `FilesystemDriver` gained `rename` and (Linux-only) `renameat2`.

Verified end to end by mounting the `passthrough` example and a real CryFS filesystem before and after the change: before, `a` is destroyed; after, `renameat2` returns `EINVAL` and both files are untouched. `cargo test -p cryfs-rustfs` is green (39 tests), `cargo fmt --check` is clean, and clippy reports no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_