### PR TITLE
Bump the Linux/macOS conan cache key to v8 to abandon corrupt entries

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -463,7 +463,7 @@ jobs:
         uses: ./.github/workflows/actions/conan/cache
         with:
           action: load
-          cache_key: v7-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.compiler.compiler}}__${{matrix.compiler.version}}__${{matrix.build_type}}__${{matrix.install_dependencies_manually}}__${{steps.hash_flags.outputs.hash_flags}}__
+          cache_key: v8-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.compiler.compiler}}__${{matrix.compiler.version}}__${{matrix.build_type}}__${{matrix.install_dependencies_manually}}__${{steps.hash_flags.outputs.hash_flags}}__
       # Setup conan is after restoring the cache so the cache doesn't overwrite the conan profile
       - name: Setup conan
         uses: ./.github/workflows/actions/conan/setup
@@ -531,7 +531,7 @@ jobs:
           action: save
           secret_aws_access_key_id: ${{ secrets.CACHE_AWS_ACCESS_KEY_ID }}
           secret_aws_secret_access_key: ${{ secrets.CACHE_AWS_SECRET_ACCESS_KEY }}
-          cache_key: v7-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.compiler.compiler}}__${{matrix.compiler.version}}__${{matrix.build_type}}__${{matrix.install_dependencies_manually}}__${{steps.hash_flags.outputs.hash_flags}}__
+          cache_key: v8-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.compiler.compiler}}__${{matrix.compiler.version}}__${{matrix.build_type}}__${{matrix.install_dependencies_manually}}__${{steps.hash_flags.outputs.hash_flags}}__
       - name: Test
         if: ${{ matrix.run_tests }}
         uses: ./.github/workflows/actions/run_tests


### PR DESCRIPTION
The conan cache restored on Linux and macOS is corrupt. Every job that restores it dies in `Install dependencies` in well under two seconds, before a single file compiles, so the failure says nothing about the code that triggered it.

Two distinct shapes, on two different matrix keys:

```
ERROR: Package 'boost/1.84.0' not resolved: Error, the file to download already exists:
  '/home/runner/work/cryfs/cryfs/conan-cache/p/boost40cb51d33534d/d/conan_export.tgz'
```
```
ERROR: Package 'libcurl/8.9.1' not resolved: libcurl/8.9.1: Cannot load recipe.
  Error loading conanfile at '.../conan-cache/p/libcudb3b033a14f1b/e/conanfile.py': not found!
```

One package directory has a stray download that blocks a re-download; another is missing its `conanfile.py` entirely. That is a partially written tree, not a single bad object, which is why it shows up as different errors on different jobs.

**Re-running does not help.** The same objects get restored again. I saw this five times, across `gcc-10` and `clang-19` and across several heads, including current ones.

### Why the key is the right lever

This is not GitHub's `actions/cache`. `.github/workflows/actions/conan/cache` delegates to `.github/workflows/actions/s3_cache`, so the objects live in the project's own S3 bucket and the key is the only thing deciding which of them a job reads. Bumping the version prefix abandons every poisoned object at once and lets the next run repopulate from conancenter. The first run after this is slower; after that it is back to normal.

The alternative is deleting the bad objects from the bucket, which I have no access to. If you would rather do that, this PR can be closed.

### Scope

Deliberately narrow — three things are **not** changed:

| Key | Lines | Change | Why |
|---|---|---|---|
| Linux/macOS conan | 466 (load), 534 (save) | `v7-` → `v8-` | the corrupt one |
| Windows conan | 591, 620 | unchanged at `v9-` | separate key, different shape; Windows has been installing dependencies successfully throughout — which is what pointed at the cache rather than at conan or the recipes |
| ccache (both) | 460/525, 585/611 | unchanged | the corruption is in the conan cache only; discarding a working compiler cache would slow every job for nothing |

Load and save move together. If only one moved, every job would miss the cache and then save under a key nothing reads.

### Verification

- The workflow still parses as YAML.
- Each of the four cache key families still appears exactly twice, load and save identical.
- No `v7-` key remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_