### PR TITLE
Don't build every pull request commit twice

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,18 @@
 name: CI
-on: ['push', 'pull_request']
+on:
+  # Only the long-lived branches build on push. A branch that exists to carry a pull
+  # request is already built by the pull_request trigger below, and an unfiltered push
+  # trigger meant every such commit was built twice: once as the branch head, once as
+  # the merge with the base. Tags stay listed so release tags still get a build.
+  push:
+    branches:
+      - main
+      - master
+      - develop
+      - 'feature/**'
+    tags:
+      - '**'
+  pull_request:
 
 jobs:
   linux_macos:


### PR DESCRIPTION
`on: ['push', 'pull_request']` was unfiltered, so a branch pushed in this repository and then opened as a pull request fired **two full runs of the same 130-job matrix for the same commit** — one for the push, one for the pull request. That is 260 jobs per update. Today one commit produced runs 1726 and 1727, which is what prompted this.

### Why narrow `push` and not `pull_request`

The two runs aren't identical, so the choice matters:

- a **`pull_request`** run checks out the *merge* of the branch into its base
- a **`push`** run checks out the branch head as it is

For a branch whose whole purpose is to carry a pull request, the merge result is the interesting one, so the push run is the redundant half.

### The change

```yaml
on:
  push:
    branches: [main, master, develop, 'feature/**']
    tags: ['**']
  pull_request:
```

`main`, `master` and `develop` all exist on the remote; `feature/**` covers `feature/fuse3` and its siblings.

**Tags are listed explicitly on purpose.** The previous unfiltered trigger also built tag pushes, and adding a `branches:` filter alone would have silently stopped building release tags — a regression that wouldn't surface until a release.

### Tradeoff

A branch with **no pull request open** now gets no CI. Pushing one more commit after opening the PR restores it, and any branch that should always build can be added to the list. If you'd rather keep CI on every branch push, the alternative is to leave this as-is and instead accept the double runs.

### Not included

A `concurrency:` block would be the natural companion — it would cancel superseded runs when a branch is pushed again, which is why stale runs on commits that no longer exist kept reporting failures for hours today. I left it out because it is a real behaviour change (it can cancel an in-flight `master` run when two commits land close together) and deserves its own review rather than riding along with a trigger filter. Happy to send it separately.

### Verification

The workflow still parses, and the trigger resolves to:

```
{'push': {'branches': ['main', 'master', 'develop', 'feature/**'], 'tags': ['**']}, 'pull_request': None}
```

with both jobs (`linux_macos`, `windows`) intact. No other line in the file changed.

Note this PR itself is a useful demonstration: it should produce **one** run, not two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_