### PR TITLE
Don't build every pull request commit twice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,17 @@ permissions:
   contents: read
 
 on:
-  - push
-  - pull_request
+  # Only the long-lived branches build on push. A branch that exists to carry a pull
+  # request is already built by the pull_request trigger below, and an unfiltered push
+  # trigger meant every such commit was built twice: once as the branch head, once as
+  # the merge with the base. Tags stay listed so release tags still get a build.
+  push:
+    branches:
+      - main
+      - 'feature/**'
+    tags:
+      - '**'
+  pull_request:
 
 # Cancel in-progress runs on the same ref when a new commit is pushed,
 # so a fix-up push doesn't have to wait behind the superseded run.


### PR DESCRIPTION
Same fix as #583, for this branch's `ci.yml`. `on: [push, pull_request]` was unfiltered, so a branch pushed in this repository and then opened as a pull request fired **two full runs for the same commit**.

Observed directly rather than inferred:

| Run | Event | head_sha |
|---|---|---|
| 1102 | `push` | `6e9c8fd9` |
| 1103 | `pull_request` | `6e9c8fd9` |
| 1100 | `push` | `e86c8c0f` |
| 1101 | `pull_request` | `e86c8c0f` |

Created ~26 seconds apart in each pair.

This matrix is **255 jobs** — 72 `test`, 180 `crates_individually_testable`, 3 others — so every pull request update was costing **510**.

### The existing `concurrency` block does not cover this

Worth stating explicitly, because it looks like it should:

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

`github.ref` is `refs/heads/<branch>` for the push run but `refs/pull/N/merge` for the pull request run, so the two land in **different groups** and both survive. That block only collapses superseded runs of the same kind — genuinely useful, and it stays, but it is a different problem.

### The change

```yaml
on:
  push:
    branches: [main, 'feature/**']
    tags: ['**']
  pull_request:
```

- Narrowing `push` rather than `pull_request` is deliberate: a `pull_request` run checks out the **merge** of the branch into its base, a `push` run checks out the branch head as-is. For a branch that exists to carry a PR, the merge result is the interesting one.
- **`feature/**` is kept** because Rust feature branches such as `feature/cachingfsblobstore` push-build with this workflow (run 1098).
- **`develop` and `master` are not listed** — they belong to the other CI setup.
- **Tags are listed explicitly.** The previous unfiltered trigger also built tag pushes, and a `branches:` filter alone would have silently stopped building release tags. There's no tag-conditional logic in this workflow, so nothing else would have caught it.

### Tradeoff

A branch with no pull request open now gets no CI. Pushing one more commit after opening the PR restores it, and any branch that should always build can be added to the list.

### Verification

The workflow still parses, with all five jobs intact and the trigger resolving to:

```
{'push': {'branches': ['main', 'feature/**'], 'tags': ['**']}, 'pull_request': None}
```

On #583 the equivalent change proved itself: that branch produced exactly one run (#1731, `event: pull_request`) instead of two, confirming GitHub reads the trigger config from the pushed commit, so the filter applies before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_