### PR TITLE
Cancel superseded CI runs on the same branch or pull request

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,6 +14,14 @@ on:
       - '**'
   pull_request:
 
+# Cancel in-progress runs on the same ref when a new commit is pushed, so a fix-up
+# push doesn't have to wait behind the superseded run. Without this, runs for commits
+# that no longer exist kept occupying the queue and reporting failures long after the
+# branch had moved on. Same setting the Rust workflow on main already uses.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   linux_macos:
     name: CI


### PR DESCRIPTION
When a branch is pushed again, the run for the previous commit keeps going. On a 130-job matrix that is a lot of runners spent on a commit nobody will look at.

It is worse than merely wasteful. Today those runs kept **reporting failures for commits that no longer existed**, long after the branch had moved on — the checks list showed red for heads that had already been replaced, and each one had to be traced back to a dead SHA before it could be dismissed.

```yaml
concurrency:
  group: ci-${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

`github.ref` is `refs/heads/<branch>` for a push and `refs/pull/N/merge` for a pull request, so **each branch and each pull request forms its own group** and a new run cancels only its own predecessor. Different pull requests never cancel each other.

This is the same block the Rust workflow on `main` already uses, so after this the two setups behave the same way.

### One behaviour change worth naming

This also cancels an in-flight run on a long-lived branch when two commits land close together. The later commit's run is the one that survives, which is the state anyone would look at anyway — but if you'd rather mainline runs always finish, adding `github.event_name` to the group key, or gating `cancel-in-progress` on `github.event_name == 'pull_request'`, gets that instead. Say the word and I'll change it.

### Relationship to the other CI PRs

Three separate, independent changes:

- #583 (merged) — stop building each commit twice, this workflow
- #584 — the same trigger fix for `main`'s `ci.yml`
- this one — cancel superseded runs, this workflow

`main`'s `ci.yml` already has the concurrency block, so it needs no equivalent of this PR.

### Verification

The workflow still parses, with both jobs intact and:

```
concurrency: {'group': 'ci-${{ github.workflow }}-${{ github.ref }}', 'cancel-in-progress': True}
jobs:        ['linux_macos', 'windows']
```

The diff is 8 added lines and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_