### PR TITLE
Make the setAtime* test helpers move whole timespecs

### DIFF
--- a/src/fspp/fstest/FsppNodeTest_Timestamps.h
+++ b/src/fspp/fstest/FsppNodeTest_Timestamps.h
@@ -369,9 +369,56 @@ public:
             EXPECT_EQ(mtime, this->stat(*node).mtime);
         });
     }
+
+    // The three setAtime* helpers used to patch only tv_nsec and leave tv_sec alone, so they
+    // established the ordering they promise only while atime and mtime happened to share a
+    // second. These pin them a second apart first, which is the case that used to come out
+    // backwards and made the atime tests fail intermittently in CI.
+    void Test_SetAtimeNewerThanMtime_AcrossSecondBoundary() {
+        auto node = this->CreateNode("/mynode");
+        const timespec mtime = this->xSecondsAgo(100);
+        timespec atime = mtime;
+        atime.tv_sec -= 1;   // atime starts a whole second older than mtime
+        node->utimens(atime, mtime);
+
+        this->setAtimeNewerThanMtime("/mynode");
+
+        const auto st = this->stat(*node);
+        EXPECT_LT(st.mtime, st.atime);
+    }
+
+    void Test_SetAtimeOlderThanMtime_AcrossSecondBoundary() {
+        auto node = this->CreateNode("/mynode");
+        const timespec mtime = this->xSecondsAgo(100);
+        timespec atime = mtime;
+        atime.tv_sec += 1;   // atime starts a whole second newer than mtime
+        node->utimens(atime, mtime);
+
+        this->setAtimeOlderThanMtime("/mynode");
+
+        const auto st = this->stat(*node);
+        EXPECT_LT(st.atime, st.mtime);
+    }
+
+    void Test_SetAtimeNewerThanMtimeButBeforeYesterday_IsNewerThanMtime() {
+        auto node = this->CreateNode("/mynode");
+
+        this->setAtimeNewerThanMtimeButBeforeYesterday("/mynode");
+
+        const auto st = this->stat(*node);
+        EXPECT_LT(st.mtime, st.atime);   // the "newer than mtime" half of the name
+        const timespec yesterday {
+                /*.tv_sec = */ cpputils::time::now().tv_sec - 60*60*24,
+                /*.tv_nsec = */ 0
+        };
+        EXPECT_LT(st.atime, yesterday);  // and the "before yesterday" half
+    }
 };
 
 REGISTER_NODE_TEST_SUITE(FsppNodeTest_Timestamps,
+    SetAtimeNewerThanMtime_AcrossSecondBoundary,
+    SetAtimeOlderThanMtime_AcrossSecondBoundary,
+    SetAtimeNewerThanMtimeButBeforeYesterday_IsNewerThanMtime,
     Create,
     Stat,
     Chmod,

--- a/src/fspp/fstest/testutils/FileSystemTest.h
+++ b/src/fspp/fstest/testutils/FileSystemTest.h
@@ -102,10 +102,34 @@ public:
     EXPECT_NE(nullptr, dynamic_cast<const fspp::Symlink*>(node.get()));
   }
 
+  // The next two derive one timestamp from the other, so they have to move whole timespecs.
+  // Touching only tv_nsec would leave tv_sec alone, which silently produces the opposite
+  // ordering whenever the two timestamps are not already in the same second, and can also
+  // produce an out-of-range tv_nsec at the ends of a second.
+  static timespec plusOneNanosecond(timespec time) {
+    if (time.tv_nsec == 999999999) {
+      time.tv_nsec = 0;
+      ++time.tv_sec;
+    } else {
+      ++time.tv_nsec;
+    }
+    return time;
+  }
+
+  static timespec minusOneNanosecond(timespec time) {
+    if (time.tv_nsec == 0) {
+      time.tv_nsec = 999999999;
+      --time.tv_sec;
+    } else {
+      --time.tv_nsec;
+    }
+    return time;
+  }
+
   void setAtimeOlderThanMtime(const boost::filesystem::path& path) {
     auto node = device->Load(path).value();
     auto st = node->stat();
-    st.atime.tv_nsec = st.mtime.tv_nsec - 1;
+    st.atime = minusOneNanosecond(st.mtime);
     node->utimens(
             st.atime,
             st.mtime
@@ -115,7 +139,7 @@ public:
   void setAtimeNewerThanMtime(const boost::filesystem::path& path) {
     auto node = device->Load(path).value();
     auto st = node->stat();
-    st.atime.tv_nsec = st.mtime.tv_nsec + 1;
+    st.atime = plusOneNanosecond(st.mtime);
     node->utimens(
             st.atime,
             st.mtime
@@ -131,7 +155,9 @@ public:
               /*.tv_nsec = */ now.tv_nsec
       };
       st.atime = before_yesterday;
-      st.mtime.tv_nsec = st.atime.tv_nsec - 1;
+      // mtime has to move with atime. Patching only its tv_nsec left it at the node's current
+      // mtime, roughly now, which made atime older than mtime instead of newer.
+      st.mtime = minusOneNanosecond(st.atime);
       node->utimens(
               st.atime,
               st.mtime


### PR DESCRIPTION
This is the intermittent atime failure that has been showing up in CI on unrelated pull requests, for example on #576's `ubuntu-24.04 / Debug / gcc-10` job:

```
CryFS/FsppOpenFileTest_Timestamps/0.givenAtimeNewerThanMtime_read_outofbounds
TimestampTestUtils.h:175: Expected equality of these values:
  statBeforeOperation.atime   1788692363.029810
  statAfterOperation.atime    1788692364.110249
```

atime moved forward by exactly one second, with fresh nanoseconds — i.e. relatime really did update it, in a test asserting it would not.

## Root cause

The three helpers that arrange a node's atime relative to its mtime each patched **only `tv_nsec`**, leaving `tv_sec` alone:

```cpp
setAtimeOlderThanMtime:  st.atime.tv_nsec = st.mtime.tv_nsec - 1;
setAtimeNewerThanMtime:  st.atime.tv_nsec = st.mtime.tv_nsec + 1;
...ButBeforeYesterday:   st.atime = before_yesterday;
                         st.mtime.tv_nsec = st.atime.tv_nsec - 1;
```

That establishes the promised ordering only while atime and mtime already share a second.

`givenAtimeNewerThanMtime_read_*` calls `CreateFileWithSize`, which creates the file and *then* truncates it. The truncate moves mtime but not atime, so when those two straddle a second boundary mtime ends up a whole second ahead. `setAtimeNewerThanMtime` then fixes up only the nanoseconds and leaves atime a second **behind** mtime — the opposite of its name. relatime's `oldATime < oldMTime` rule then correctly updates atime on the following read, and the assertion fails. The window is however long create-then-truncate takes, which is why it fired rarely and read as a flake.

Two more defects fall out of the same pattern:

- **`setAtimeOlderThanMtime`** has the mirror-image bug — so far unobserved, but equally reachable.
- **`setAtimeNewerThanMtimeButBeforeYesterday`** is wrong in a third way: it sets atime to a full timespec near yesterday but patches only `mtime.tv_nsec`, leaving `mtime.tv_sec` at roughly *now*, so atime comes out **older** than mtime rather than newer. Its tests pass regardless, because atime being more than 24 hours old makes relatime update it either way — the right answer for the wrong reason. The new tests confirm this: it fails all three node types before this change.

Both nanosecond adjustments were also unnormalised: `+1` on `999999999` yields an out-of-range `tv_nsec` of `1000000000`, and `-1` on `0` yields `-1`.

## The change

Each helper now derives one timestamp from the other as a whole timespec, via `plusOneNanosecond`/`minusOneNanosecond`, which carry into `tv_sec`.

## Tests

Three regression tests pin exactly the case that used to come out backwards, by putting atime and mtime a second apart *before* calling the helper. They run for file, directory and symlink nodes.

Verified both directions rather than assumed:

| | Before the fix | After |
|---|---|---|
| The 9 new tests (3 × file/dir/symlink) | **9 failed** | **9 passed** |
| `givenAtime*` suite | passes (the race is timing-dependent) | passes |
| `cryfs-test` overall | 723 passed | **732 passed** |

The "before" figure comes from building with the new tests against the *unmodified* helpers, so they are demonstrably capable of failing.

## No ChangeLog entry

This is test-only, and I checked rather than assumed:

- `src/fspp/fstest/` contains **zero `.cpp` files** — header-only fixtures.
- `src/fspp/CMakeLists.txt` builds only `fs_interface` and `fuse`; `fstest` is never added.
- The only thing that includes these headers anywhere is `test/cryfs/impl/filesystem/FileSystemTest.cpp`.
- The `tv_nsec`-only pattern appears nowhere outside `fstest/`.

No shipped binary can contain this code, so no released version can exhibit the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_