### PR TITLE
Drop the retired windows-2019 runner from CI

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -573,9 +573,6 @@ jobs:
       matrix:
         name: [""]
         os:
-          # windows-2019 was removed here because GitHub retired that runner image. Jobs asking
-          # for it are never picked up: they sit queued until they expire, so every run had three
-          # checks that could never finish and the pull request never showed all checks passed.
           - windows-2022
         build_type:
           - Debug
@@ -619,9 +616,6 @@ jobs:
           arch: "x86_64"
           compiler: "msvc"
           # 194 is the MSVC toolset of Visual Studio 2022, which is what windows-2022 ships.
-          # This used to be a conditional whose other branch selected 192 (Visual Studio 2019) for
-          # windows-2019. With that image gone the condition is always true, and leaving it would
-          # silently hand 192 to any runner image added here later.
           compiler_version: "194"
           build_type: ${{ matrix.build_type }}
       - name: Install dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -573,7 +573,9 @@ jobs:
       matrix:
         name: [""]
         os:
-          - windows-2019
+          # windows-2019 was removed here because GitHub retired that runner image. Jobs asking
+          # for it are never picked up: they sit queued until they expire, so every run had three
+          # checks that could never finish and the pull request never showed all checks passed.
           - windows-2022
         build_type:
           - Debug
@@ -616,7 +618,11 @@ jobs:
         with:
           arch: "x86_64"
           compiler: "msvc"
-          compiler_version: ${{ matrix.os == 'windows-2022' && '194' || '192' }}
+          # 194 is the MSVC toolset of Visual Studio 2022, which is what windows-2022 ships.
+          # This used to be a conditional whose other branch selected 192 (Visual Studio 2019) for
+          # windows-2019. With that image gone the condition is always true, and leaving it would
+          # silently hand 192 to any runner image added here later.
+          compiler_version: "194"
           build_type: ${{ matrix.build_type }}
       - name: Install dependencies
         uses: ./.github/workflows/actions/conan/install_dependencies


### PR DESCRIPTION
Every run in this repository had three checks that could never finish, so **no pull request could ever reach "all checks passed"**.

## What is happening

GitHub retired the `windows-2019` runner image. Jobs asking for it are never picked up — they sit queued until they expire.

Two independent confirmations:

1. **Observed.** On #577's run `34057688741`, the three `windows-2019` jobs were still `queued` more than four hours after being created, while all 127 other jobs in the same run had completed. The three `windows-2022` jobs in that same run finished in about five minutes.
2. **Documented.** GitHub's [`actions/runner-images` README](https://github.com/actions/runner-images) no longer lists `windows-2019` among the available images. The Windows images it offers are `windows-2022`, `windows-2025`, `windows-2025-vs2026`, `windows-11-arm` and `windows-11-vs2026-arm`.

Beyond the wasted checks, this made every red-or-green judgement on a pull request a manual exercise in remembering to ignore three permanently pending checks.

## The change

Two edits, both in `.github/workflows/main.yaml`:

**1. Remove `windows-2019` from the matrix.** The Windows job goes from 6 combinations to 3.

**2. Stop choosing the compiler version per image.** It read:

```yaml
compiler_version: ${{ matrix.os == 'windows-2022' && '194' || '192' }}
```

whose second branch selected the Visual Studio 2019 toolset for `windows-2019`. With one image left the condition is always true — but leaving it in place would **silently hand `192` to any runner image added to this matrix later**, which is a trap rather than dead code. It is now the literal `194`.

`windows-2022` already resolved to `194`, so **nothing changes for the jobs that actually run**.

## Deliberately not included

- **`windows-2025` is not added in its place.** It would be new, never-exercised coverage — Dokany install, MSVC toolset, conan profile — and adding it here risks turning a change that makes CI honest into one that makes it red. Worth doing separately if you want a second Windows image.
- **The `Requires Visual Studio 2019/2022` line in `AGENTS.md` is left alone.** Dropping a runner removes CI *coverage*, not support, and narrowing the claimed support matrix is a project decision rather than a CI repair. Flagging it so the choice is yours: after this, VS2019 is supported-but-untested.
- **The CPack step keeps its `windows-2022` condition.** Redundant with a single image, but it still expresses that packaging happens on that one image and not on any that might be added later.

## Verification

- The workflow still parses as YAML.
- The `windows` matrix resolves to 3 jobs (`Debug`, `Release`, `RelWithDebInfo` on `windows-2022`), down from 6.
- Both job definitions (`linux_macos`, `windows`) and all triggers are unchanged.
- `windows-2019` appears nowhere else in the repository — checked `.github/` and the `setup_windows` action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_