### PR TITLE
Add the windows-2025 runner and build the installer there

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -658,6 +658,7 @@ jobs:
           # ./cryfs-cli/cryfs-cli-test.exe
       - name: CPack
         uses: ./.github/workflows/actions/cpack
-        if: ${{ matrix.os == 'windows-2022' }}
+        # Release installers are built with Visual Studio 2026, which windows-2025 ships.
+        if: ${{ matrix.os == 'windows-2025' }}
         with:
           build_type: ${{matrix.build_type}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -616,9 +616,9 @@ jobs:
         with:
           arch: "x86_64"
           compiler: "msvc"
-          # 194 is the MSVC toolset of Visual Studio 2022, which is what both
-          # windows-2022 and windows-2025 ship.
-          compiler_version: "194"
+          # windows-2022 ships Visual Studio 2022, which conan calls msvc 194 (toolset v143).
+          # windows-2025 ships Visual Studio 2026, which conan calls msvc 195 (toolset v145).
+          compiler_version: ${{ matrix.os == 'windows-2025' && '195' || '194' }}
           build_type: ${{ matrix.build_type }}
       - name: Install dependencies
         uses: ./.github/workflows/actions/conan/install_dependencies

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -574,6 +574,7 @@ jobs:
         name: [""]
         os:
           - windows-2022
+          - windows-2025
         build_type:
           - Debug
           - Release
@@ -615,7 +616,8 @@ jobs:
         with:
           arch: "x86_64"
           compiler: "msvc"
-          # 194 is the MSVC toolset of Visual Studio 2022, which is what windows-2022 ships.
+          # 194 is the MSVC toolset of Visual Studio 2022, which is what both
+          # windows-2022 and windows-2025 ship.
           compiler_version: "194"
           build_type: ${{ matrix.build_type }}
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,7 +427,8 @@ Configuration in `.clang-tidy`:
   Visual Studio 2026 (toolset v145, conan `195`)
 - CI builds Windows on two runner images: `windows-2022`, which ships Visual Studio 2022, and
   `windows-2025`, which ships Visual Studio 2026. The workflow selects the conan compiler
-  version per image. Release packages are built on `windows-2022`.
+  version per image. Release packages are built on `windows-2025`, so they are compiled with
+  Visual Studio 2026.
 - Some tests are disabled on Windows (see CI config)
 
 ### macOS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,10 +423,11 @@ Configuration in `.clang-tidy`:
   build compiles the FUSE 2 code path. Everything that differs between the two APIs is behind
   `#if FUSE_MAJOR_VERSION >= 3` in `src/fspp/fuse/Fuse.h` and `Fuse.cpp`, and `params.h` picks the
   API. The `fspp` interface itself is FUSE 3 shaped on both; only the wrappers differ.
-- Requires Visual Studio 2022 (MSVC toolset v143, which conan calls `msvc` version `194`)
-- CI builds Windows on the `windows-2022` and `windows-2025` runner images; both ship
-  Visual Studio 2022, so they use the same toolset. Release packages are built on
-  `windows-2022`.
+- Builds with Visual Studio 2022 (toolset v143, which conan calls `msvc` version `194`) and
+  Visual Studio 2026 (toolset v145, conan `195`)
+- CI builds Windows on two runner images: `windows-2022`, which ships Visual Studio 2022, and
+  `windows-2025`, which ships Visual Studio 2026. The workflow selects the conan compiler
+  version per image. Release packages are built on `windows-2022`.
 - Some tests are disabled on Windows (see CI config)
 
 ### macOS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,7 +423,10 @@ Configuration in `.clang-tidy`:
   build compiles the FUSE 2 code path. Everything that differs between the two APIs is behind
   `#if FUSE_MAJOR_VERSION >= 3` in `src/fspp/fuse/Fuse.h` and `Fuse.cpp`, and `params.h` picks the
   API. The `fspp` interface itself is FUSE 3 shaped on both; only the wrappers differ.
-- Requires Visual Studio 2019/2022
+- Requires Visual Studio 2022 (MSVC toolset v143, which conan calls `msvc` version `194`)
+- CI builds Windows on the `windows-2022` and `windows-2025` runner images; both ship
+  Visual Studio 2022, so they use the same toolset. Release packages are built on
+  `windows-2022`.
 - Some tests are disabled on Windows (see CI config)
 
 ### macOS

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -42,6 +42,10 @@ Version 1.1.0 (unreleased)
 * Fixed: Undefined behavior while parsing mount options. After removing an option that libFUSE
   doesn't know, the parser kept using a reference into the vector it had just erased from. It
   happened to do the right thing in practice, but it was undefined behavior.
+* The Windows installer is now built with Visual Studio 2026 instead of Visual Studio 2022. You
+  need the Microsoft Visual C++ Redistributable from Visual Studio 2026 or newer to run it, an
+  older one is not enough. Only one Redistributable is installed at a time and a newer one
+  replaces an older one, so installing the latest is all that is needed.
 
 Dependency Updates
 * Fuse 3.9 on Linux and macOS (was: Fuse 2.9), still Fuse 2.7 via DokanY on Windows

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ CryFS has experimental Windows support since the 0.10 release series. To install
    It's recommended to install the matching version DokanY a given CryFS version was built with. Other versions may work but we have seen issues.
    * CryFS 1.0: DokanY 2.2.0.1000
    * CryFS 0.11: DokanY 1.2.2.1001
-2. Install the latest [Microsoft Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
+2. Install the [Microsoft Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) from Visual Studio 2026 or newer
 4. Install [CryFS](https://www.cryfs.org/#download)
 
 GUI

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ CryFS has experimental Windows support since the 0.10 release series. To install
    It's recommended to install the matching version DokanY a given CryFS version was built with. Other versions may work but we have seen issues.
    * CryFS 1.0: DokanY 2.2.0.1000
    * CryFS 0.11: DokanY 1.2.2.1001
-2. Install [Microsoft Visual C++ Redistributable for Visual Studio 2022](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
+2. Install the latest [Microsoft Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads)
 4. Install [CryFS](https://www.cryfs.org/#download)
 
 GUI

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Building on Windows (experimental)
 
         $ conan build . --build=missing -o "&:windows_dokany_path=C:/Program Files/Dokan/DokanLibrary-2.2.0"
 
+The Windows build is tested with Visual Studio 2022 on Windows Server 2022 and Windows Server 2025.
+
 Using local dependencies
 -------------------------------
 Starting with CryFS 0.11, Conan is used for dependency management.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,8 @@ Building on Windows (experimental)
 
         $ conan build . --build=missing -o "&:windows_dokany_path=C:/Program Files/Dokan/DokanLibrary-2.2.0"
 
-The Windows build is tested with Visual Studio 2022 on Windows Server 2022 and Windows Server 2025.
+The Windows build is tested with Visual Studio 2022 on Windows Server 2022, and with
+Visual Studio 2026 on Windows Server 2025.
 
 Using local dependencies
 -------------------------------

--- a/test/cpp-utils/logging/LoggingTest.cpp
+++ b/test/cpp-utils/logging/LoggingTest.cpp
@@ -9,31 +9,44 @@
 using namespace cpputils::logging;
 using std::string;
 
-// Disable the next tests for MSVC debug builds since writing to stderr doesn't seem to work well there
-#if !defined(_MSC_VER) || NDEBUG
+void logAndExit(const string &message) {
+    LOG(INFO, message);
+    cpputils::logging::flush();
+    exit(1);
+}
 
+void setLoggerAndLogAndExit(const string &message) {
+    setLogger(spdlog::stderr_logger_mt("MyTestLog2"));
+    LOG(INFO, message);
+    cpputils::logging::flush();
+    exit(1);
+}
+
+// The next two tests log in a child process instead of capturing stderr in
+// this one. On Windows, spdlog's stderr sink looks up the Win32 handle behind
+// the stderr file descriptor once, when the sink is created, and then writes
+// to that handle with WriteFile(). Redirecting the stderr file descriptor
+// afterwards - which is all gtest's stderr capture does - therefore doesn't
+// reach the sink. A child process starts with its stderr already pointing at
+// the pipe the death test reads, so the handle the sink caches is the one we
+// are looking at.
 TEST_F(LoggingTest, DefaultLoggerIsStderr) {
-    const string output = captureStderr([]{
-        LOG(INFO, "My log message");
-        cpputils::logging::flush();
-    });
-	// For some reason, the following doesn't seem to work in MSVC. Possibly because of the multiline string?
-    //EXPECT_THAT(output, MatchesRegex(".*\\[Log\\].*\\[info\\].*My log message.*"));
-	EXPECT_TRUE(std::regex_search(output, std::regex(".*\\[Log\\].*\\[info\\].*My log message.*")));
+    testing::FLAGS_gtest_death_test_style = "threadsafe";
+    EXPECT_EXIT(
+        logAndExit("My log message"),
+        ::testing::ExitedWithCode(1),
+        ::testing::HasSubstr("[Log] [info] My log message")
+    );
 }
 
 TEST_F(LoggingTest, SetLogger_NewLoggerIsUsed) {
-    setLogger(spdlog::stderr_logger_mt("MyTestLog2"));
-    const string output = captureStderr([]{
-        LOG(INFO, "My log message");
-        cpputils::logging::flush();
-    });
-	// For some reason, the following doesn't seem to work in MSVC. Possibly because of the multiline string?
-	//EXPECT_THAT(output, MatchesRegex(".*\\[MyTestLog2\\].*\\[info\\].*My log message.*"));
-	EXPECT_TRUE(std::regex_search(output, std::regex(".*\\[MyTestLog2\\].*\\[info\\].*My log message.*")));
+    testing::FLAGS_gtest_death_test_style = "threadsafe";
+    EXPECT_EXIT(
+        setLoggerAndLogAndExit("My log message"),
+        ::testing::ExitedWithCode(1),
+        ::testing::HasSubstr("[MyTestLog2] [info] My log message")
+    );
 }
-
-#endif
 
 TEST_F(LoggingTest, SetNonStderrLogger_LogsToNewLogger) {
     setLogger(mockLogger.get());
@@ -88,12 +101,6 @@ TEST_F(LoggingTest, ErrorLog) {
 	// For some reason, the following doesn't seem to work in MSVC. Possibly because of the multiline string?
 	//EXPECT_THAT(mockLogger.capturedLog(), MatchesRegex(".*\\[MockLogger\\].*\\[error\\].*My log message.*"));
 	EXPECT_TRUE(std::regex_search(mockLogger.capturedLog(), std::regex(".*\\[MockLogger\\].*\\[error\\].*My log message.*")));
-}
-
-void logAndExit(const string &message) {
-    LOG(INFO, message);
-    cpputils::logging::flush();
-    exit(1);
 }
 
 // fork() only forks the main thread. This test ensures that logging doesn't depend on threads that suddenly aren't

--- a/vendor/README
+++ b/vendor/README
@@ -1,6 +1,12 @@
 This directory contains external projects, taken from the following locations:
 cryptopp:
  - vendor_cryptopp: https://github.com/weidai11/cryptopp/tree/CRYPTOPP_8_9_0
+   - Stop using stdext::make_checked_array_iterator and stdext::make_unchecked_array_iterator
+     on MSVC 19.38 and newer. They are non-Standard Microsoft extensions that were removed in
+     the Visual Studio 2026 standard library, so the build broke there. This is upstream's own
+     fix, already on their master branch but not in the 8.9.0 release: it adds the same
+     CRYPTOPP_MSC_VERSION < 1938 upper bound to both guards. Drop this patch when updating to
+     a release that contains it.
  - vendor_cryptopp_cmake: https://github.com/abdes/cryptopp-cmake/tree/CRYPTOPP_8_9_0
    - Added workaround to find OpenMP on MacOS: https://github.com/abdes/cryptopp-cmake/pull/126
    - Fix building on PowerPC: https://github.com/cryfs/cryfs/pull/506

--- a/vendor/cryptopp/vendor_cryptopp/integer.cpp
+++ b/vendor/cryptopp/vendor_cryptopp/integer.cpp
@@ -3056,7 +3056,7 @@ Integer::Integer(const byte *encodedInteger, size_t byteCount, Signedness s, Byt
 	else
 	{
 		SecByteBlock block(byteCount);
-#if (CRYPTOPP_MSC_VERSION >= 1500)
+#if (CRYPTOPP_MSC_VERSION >= 1500) && (CRYPTOPP_MSC_VERSION < 1938)
 		std::reverse_copy(encodedInteger, encodedInteger+byteCount,
 			stdext::make_checked_array_iterator(block.begin(), block.size()));
 #else

--- a/vendor/cryptopp/vendor_cryptopp/zdeflate.cpp
+++ b/vendor/cryptopp/vendor_cryptopp/zdeflate.cpp
@@ -418,7 +418,7 @@ unsigned int Deflator::LongestMatch(unsigned int &bestMatch) const
 #else
 				std::mismatch
 #endif
-#if CRYPTOPP_MSC_VERSION >= 1600
+#if (CRYPTOPP_MSC_VERSION >= 1600) && (CRYPTOPP_MSC_VERSION < 1938)
 				(stdext::make_unchecked_array_iterator(scan)+3, stdext::make_unchecked_array_iterator(scanEnd), stdext::make_unchecked_array_iterator(match)+3).first - stdext::make_unchecked_array_iterator(scan));
 #else
 				(scan+3, scanEnd, match+3).first - scan);


### PR DESCRIPTION
Adds `windows-2025` to the Windows CI matrix alongside `windows-2022`, and moves release packaging to it.

After #587 dropped the retired `windows-2019`, `windows-2022` was the only Windows image left, so a single image deprecation would have left the project with no Windows coverage at all.

## This is a second toolchain, not a second machine

GitHub's per-image readme for `windows-2025` still lists *Visual Studio Enterprise 2022 17.14*. That is stale — the image ships **Visual Studio 2026**, which the first trial established in 92 seconds:

```
ConanException: VS non-existing installation: Visual Studio 17.
```

conan resolves `msvc 194` to Visual Studio 17 (2022), which isn't there. So the compiler version is now selected per image:

| Image | Visual Studio | Toolset | conan `msvc` |
|---|---|---|---|
| `windows-2022` | 2022 | v143 | `194` |
| `windows-2025` | 2026 | v145 | `195` |

conan 2.23, which CI pins, knows `195` and maps it to VS 18 / v145.

## One vendored fix was needed

The build then stopped at file 7 of 543, in vendored Crypto++ 8.9.0:

```
integer.cpp(3061): error C2653: 'stdext': is not a class or namespace name
```

`stdext::checked_array_iterator` and friends were non-Standard MSVC extensions, deprecated under STL4043 and **removed** in the VS2026 STL with no opt-in macro. Upstream Crypto++ already fixed both sites by adding an upper bound, `&& (CRYPTOPP_MSC_VERSION < 1938)`, but that fix is not in any release. Those two one-line guards are backported here verbatim and recorded in `vendor/README` so they can be dropped at the next Crypto++ update. The `#else` branches beside them are plain standard C++ doing the same work, so newer compilers simply take those. Nothing outside MSVC is affected — `CRYPTOPP_MSC_VERSION` is undefined elsewhere.

## Two logging tests were relying on undefined behaviour

With the toolchain and Crypto++ sorted, `windows-2025` still failed two tests that `windows-2022` passed on the identical commit: `LoggingTest.DefaultLoggerIsStderr` and `LoggingTest.SetLogger_NewLoggerIsUsed`.

Neither failure is a property of the toolchain. On Windows, spdlog's stderr sink resolves the Win32 handle once, in the sink's constructor, and then writes to that cached handle rather than through the file descriptor:

```cpp
// spdlog/sinks/stdout_sinks-inl.h
handle_ = reinterpret_cast<HANDLE>(::_get_osfhandle(::_fileno(file_)));   // constructor
...
::WriteFile(handle_, formatted.data(), size, &bytes_written, nullptr);    // log()
```

gtest's stderr capture works by `dup2()`ing a temporary file over file descriptor 2. That never reaches the cached handle — and it closes it. A temporary probe on windows-2022 Debug showed exactly that:

```
stdio(12)=[PROBE_STDIO]  stream(13)=[PROBE_STREAM]
logged(110)=[[*** LOG ERROR #0001 ***] ... stdout_sink_base: WriteFile() failed. GetLastError(): 6
```

`GetLastError() == 6` is `ERROR_INVALID_HANDLE`. Raw stdio and `std::cerr` writes land in the capture normally, so the capture itself works; the log line never goes through the file descriptor at all, and the only thing that reached the capture was spdlog's own error handler, which does write through `stderr` as a `FILE*`.

So these tests passing on Windows was an accident of handle reuse: `dup2()` frees the handle value the sink cached, and the capture file could be handed the same value immediately after. That also explains the `#if !defined(_MSC_VER) || NDEBUG` guard they carried and its note that "writing to stderr doesn't seem to work well" in MSVC debug builds — there the accident did not happen, so the tests were excluded rather than fixed.

Both now log in a child process. Its stderr is the pipe the death test reads before any sink exists, so the handle the sink caches is the one the assertion looks at, on every platform. `LoggingAlsoWorksAfterFork` in the same file already worked this way. The guard is gone with its cause, so both tests now run on MSVC debug builds too.

## Proven in stages, one job at a time

Rather than spend a 128-job matrix on an unproven image, each step was trialled with the rest of CI disabled:

| Stage | Result |
|---|---|
| **A** — does it build and pass tests under v145? | ✅ `723 tests from 49 test suites ran. [ PASSED ] 723 tests` |
| **B** — does WiX packaging work there? | ✅ `Artifact cryfs-Debug.msi ... successfully uploaded! Final size is 3743595 bytes` |
| **C** — full matrix | ❌ the two `LoggingTest` failures above, on `windows-2025` only |
| **D** — both toolchains × Debug/RelWithDebInfo, `LoggingTest.*` only | ✅ 15/16, the one failure being the deliberate probe |
| **E** — full matrix again | ✅ all six Windows jobs, and every ubuntu-24.04 job including ASAN, TSAN, UBSAN, Werror and clang-tidy |

That caught the toolchain surprise, the Crypto++ breakage and the logging bug for the cost of a handful of jobs.

## Release packaging moves to windows-2025

CPack was already conditioned on a single image; it now names `windows-2025`, so installers are built with VS2026. `windows-2022` stays in the matrix as a second configuration.

This changes what users need. The MSI does not carry the C runtime, and Microsoft's rule is that the Redistributable must be at least as new as the newest build tools used by any component — so an installer built with VS2026 needs the VS2026 Redistributable; the 2022 one is not enough. Since only one Redistributable exists at a time and a newer one replaces an older one, the instruction is simply to install that version or newer, which is what the README now says. There's a `ChangeLog.txt` entry under 1.1.0 for the same reason.

Bundling the CRT into the MSI would remove the requirement entirely, but Microsoft recommends against it — app-local CRT copies never receive Windows Update servicing, which is a poor trade for an encryption tool. Left as separate future work.

## Documentation

- `README.md` — the redistributable step now states a floor ("from Visual Studio 2026 or newer") rather than a bare version, matching how the DokanY entry above it reads.
- `AGENTS.md` — records both supported toolchains, which image uses which, and where packages are built.
- `ChangeLog.txt` — the redistributable requirement change, under 1.1.0.

## Not included

`windows-11-arm` and `windows-2025-vs2026` — ARM64 and a further VS jump are each new coverage in their own direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP