### PR TITLE
The next release is 1.1.0, not 1.0.4

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,4 @@
-Version 1.0.4 (unreleased)
+Version 1.1.0 (unreleased)
 ---------------
 * Improved protection and zeroing of encryption key material in CryFS process memory while the
   file system is mounted. Note that this is not a vulnerability in CryFS's threat model, since keys


### PR DESCRIPTION
Renames the unreleased `ChangeLog.txt` heading from `Version 1.0.4 (unreleased)` to `Version 1.1.0 (unreleased)`.

That section carries the switch from libFUSE 2 to libFUSE 3, which changes what users must have installed before CryFS will mount — libFUSE 3 and `fusermount3` on Linux, macFUSE 4.10.0 or newer on macOS. A patch release is the wrong place for a requirement change people have to act on when upgrading.

Only the heading changes; the entries beneath it already describe 1.1.0.

`1.0.4` appears nowhere else in the repository outside `vendor/`, so there is nothing else to update. The build takes its version from git tags rather than a checked-in constant.

## Context

This came out of review on cryfs/cryfs-web-next#238, where 1.1.0 was identified as the next release. The website's download page now says "Starting with CryFS 1.1.0…" for both the macOS and Linux requirements, so this keeps the changelog and the website consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP

---
_Generated by [Claude Code](https://claude.ai/code/session_015ErTwCwE5TPLj5VL3PDKhP)_