### PR TITLE
Skip the rustfs rename tests on macOS CI too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,8 @@ jobs:
         # (https://github.com/actions/runner-images/issues/4731), so the
         # mount() syscall hangs forever and the job runs out the 6h clock.
         # That's all tests under crates/rustfs/src/tests/ — currently the
-        # `tests::mkdir::` module and the fuser_runner self-tests in
-        # `tests::utils::fuser_runner::`. The tests still work on a local
+        # `tests::mkdir::` and `tests::rename::` modules and the fuser_runner
+        # self-tests in `tests::utils::fuser_runner::`. The tests still work on a local
         # macOS where the operator has approved the kext, so we
         # deliberately don't cfg-gate them out at compile time — only this
         # CI invocation skips them. The --skip filters match by substring;
@@ -96,7 +96,7 @@ jobs:
             # behavior, e.g. actions/runner-images#12562, #8649). They're
             # reqwest smoke tests, not cryfs unit tests, and still run on
             # Linux CI and locally.
-            cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }} -- --skip tests::mkdir:: --skip tests::utils::fuser_runner:: --skip version::http_client::tests::reqwest_http_client::test_get_valid_
+            cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }} -- --skip tests::mkdir:: --skip tests::rename:: --skip tests::utils::fuser_runner:: --skip version::http_client::tests::reqwest_http_client::test_get_valid_
           else
             cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }}
           fi


### PR DESCRIPTION
## What's broken

`main` is red. On 6eeaeed, [run 1107](https://github.com/cryfs/cryfs/actions/runs/34073789694) has `test (macos-14, test, stable)` failing:

```
test tests::rename::plain_rename_passes_no_flags ... FAILED
panicked at crates/rustfs/src/tests/utils/fuser_runner.rs:49:10:
Failed to spawn filesystem: Os { code: 25, kind: Uncategorized,
                                 message: "Inappropriate ioctl for device" }
```

That is the only failing job so far only because the rest of the macOS matrix is still queued — every macOS test job runs the same command, so they all fail this way as the queue lets them start. The Linux matrix is green.

## Cause

The tests under `crates/rustfs/src/tests/` mount a real FUSE session through `fuser`, which GitHub-hosted macOS runners cannot do: the image won't approve macFUSE's kernel extension ([actions/runner-images#4731](https://github.com/actions/runner-images/issues/4731)). The macOS branch of the test step therefore skips them *by module path* rather than cfg-gating them out, so they still run on a local macOS where the operator has approved the kext. The comment above that step says so, and says to keep the `--skip` list in sync with the module paths under `crates/rustfs/src/tests/`.

#580 added a third module there, `tests::rename::`, without adding it to the skip list — exactly the drift the comment warns about. So those tests ran on macOS and hit the kext wall.

It escaped #580's own CI because this repository's macOS jobs routinely sit in the runner queue until GitHub times them out at 24h, so they never ran on that pull request.

## Fix

Add `--skip tests::rename::`, and name the module in the comment so the documentation stays accurate.

This closes the whole gap rather than just the one failing test. `mkdir.rs`, `rename.rs` and `utils/fuser_runner.rs` are the only test-bearing files under `crates/rustfs/src/tests/`, and the other two were already skipped.

Nothing changes on Linux, which mounts FUSE fine and keeps running all of them, and nothing changes for a local `cargo test` on either platform.

## Verification

`cargo test -p cryfs-rustfs --lib -- --list`, with and without the new skip list:

| | without skips | with skips |
| --- | --- | --- |
| tests listed | 39 | 2 |
| FUSE-mounting tests (`tests::mkdir::`, `tests::rename::`, `tests::utils::fuser_runner::`) | 37 | 0 |

All four `tests::rename::` tests are present unskipped and gone when skipped, and the 2 tests that do not mount anything still run — so the filter is neither missing its target nor over-skipping. The workflow file still parses as YAML, with the `--skip` flags present on the macOS invocation.

(On macOS only `plain_rename_passes_no_flags` would run in the first place: the three `renameat2_flags` tests are `#[cfg(all(target_os = "linux", target_env = "gnu"))]`. The skip covers it either way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rvim5Wko3GoV2kTiEJnhsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvim5Wko3GoV2kTiEJnhsJ)_