### PR TITLE
Fix accessing an open file after it was moved to a different directory (#565)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -42,6 +42,13 @@ Version 1.1.0 (unreleased)
 * Fixed: Undefined behavior while parsing mount options. After removing an option that libFUSE
   doesn't know, the parser kept using a reference into the vector it had just erased from. It
   happened to do the right thing in practice, but it was undefined behavior.
+* Fixed: Reading from, writing to or truncating a file failed with an error (ENOENT, which Linux can
+  surface as EIO) if the file was moved to a different directory while it was open
+  (see https://github.com/cryfs/cryfs/issues/565 ). An open file remembered the directory it was in
+  when it was opened and looked up its own directory entry (which stores the timestamps) there, so
+  it didn't find it anymore once the file had been moved somewhere else. Flushing an open file also
+  flushed the old directory instead of the new one. Open files now reload their parent directory
+  when the file was moved.
 * The Windows installer is now built with Visual Studio 2026 instead of Visual Studio 2022. You
   need the Microsoft Visual C++ Redistributable from Visual Studio 2026 or newer to run it, an
   older one is not enough. Only one Redistributable is installed at a time and a newer one

--- a/src/cryfs/impl/filesystem/CryOpenFile.cpp
+++ b/src/cryfs/impl/filesystem/CryOpenFile.cpp
@@ -4,36 +4,59 @@
 #include <fcntl.h>
 
 #include "CryDevice.h"
+#include <cpp-utils/logging/logging.h>
+#include <cpp-utils/pointer/cast.h>
 #include <fspp/fs_interface/FuseErrnoException.h>
 #include "entry_helper.h"
 
 
 using std::shared_ptr;
+using boost::none;
 using cpputils::unique_ref;
+using cpputils::dynamic_pointer_move;
 using cryfs::parallelaccessfsblobstore::FileBlobRef;
 using cryfs::parallelaccessfsblobstore::DirBlobRef;
+using namespace cpputils::logging;
 
 //TODO Get rid of this in favor of a exception hierarchy
 
 namespace cryfs {
 
-CryOpenFile::CryOpenFile(const CryDevice *device, shared_ptr<DirBlobRef> parent, unique_ref<FileBlobRef> fileBlob)
-: _device(device), _parent(parent), _fileBlob(std::move(fileBlob)) {
+CryOpenFile::CryOpenFile(CryDevice *device, shared_ptr<DirBlobRef> parent, unique_ref<FileBlobRef> fileBlob)
+: _device(device), _parentMutex(), _parent(std::move(parent)), _fileBlob(std::move(fileBlob)) {
 }
 
 CryOpenFile::~CryOpenFile() {
   //TODO
 } // NOLINT (workaround https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82481 )
 
+shared_ptr<DirBlobRef> CryOpenFile::_parentBlob() const {
+  const std::unique_lock<std::mutex> lock(_parentMutex);
+  const blockstore::BlockId &currentParentId = _fileBlob->parentPointer();
+  if (currentParentId != _parent->blockId()) {
+    // The file was moved into a different directory while it was open. Load the new parent,
+    // otherwise we wouldn't find our dir entry anymore.
+    auto newParent = _device->LoadBlob(currentParentId);
+    auto newParentDir = dynamic_pointer_move<DirBlobRef>(newParent);
+    if (newParentDir == none) {
+      LOG(ERR, "Parent of an open file is not a directory");
+      throw fspp::fuse::FuseErrnoException(EIO);
+    }
+    _parent = std::move(*newParentDir);
+  }
+  return _parent;
+}
+
 void CryOpenFile::flush() {
   _device->callFsActionCallbacks();
   _fileBlob->flush();
-  _parent->flush();
+  _parentBlob()->flush();
 }
 
 fspp::Node::stat_info CryOpenFile::stat() const {
   _device->callFsActionCallbacks();
-  auto childOpt = _parent->GetChild(_fileBlob->blockId());
+  auto parent = _parentBlob();
+  auto childOpt = parent->GetChild(_fileBlob->blockId());
   if (childOpt == boost::none) {
     throw fspp::fuse::FuseErrnoException(ENOENT);
   }
@@ -43,25 +66,25 @@ fspp::Node::stat_info CryOpenFile::stat() const {
 void CryOpenFile::truncate(fspp::num_bytes_t size) const {
   _device->callFsActionCallbacks();
   _fileBlob->resize(size);
-  _parent->updateModificationTimestampForChild(_fileBlob->blockId());
+  _parentBlob()->updateModificationTimestampForChild(_fileBlob->blockId());
 }
 
 fspp::num_bytes_t CryOpenFile::read(void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) const {
   _device->callFsActionCallbacks();
-  _parent->updateAccessTimestampForChild(_fileBlob->blockId(), timestampUpdateBehavior());
+  _parentBlob()->updateAccessTimestampForChild(_fileBlob->blockId(), timestampUpdateBehavior());
   return _fileBlob->read(buf, offset, count);
 }
 
 void CryOpenFile::write(const void *buf, fspp::num_bytes_t count, fspp::num_bytes_t offset) {
   _device->callFsActionCallbacks();
-  _parent->updateModificationTimestampForChild(_fileBlob->blockId());
+  _parentBlob()->updateModificationTimestampForChild(_fileBlob->blockId());
   _fileBlob->write(buf, offset, count);
 }
 
 void CryOpenFile::fsync() {
   _device->callFsActionCallbacks();
   _fileBlob->flush();
-  _parent->flush();
+  _parentBlob()->flush();
 }
 
 void CryOpenFile::fdatasync() {

--- a/src/cryfs/impl/filesystem/CryOpenFile.h
+++ b/src/cryfs/impl/filesystem/CryOpenFile.h
@@ -3,6 +3,8 @@
 #define MESSMER_CRYFS_FILESYSTEM_CRYOPENFILE_H_
 
 #include <fspp/fs_interface/OpenFile.h>
+#include <memory>
+#include <mutex>
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/FileBlobRef.h"
 #include "cryfs/impl/filesystem/parallelaccessfsblobstore/DirBlobRef.h"
 
@@ -11,7 +13,7 @@ class CryDevice;
 
 class CryOpenFile final: public fspp::OpenFile {
 public:
-  explicit CryOpenFile(const CryDevice *device, std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> parent, cpputils::unique_ref<parallelaccessfsblobstore::FileBlobRef> fileBlob);
+  explicit CryOpenFile(CryDevice *device, std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> parent, cpputils::unique_ref<parallelaccessfsblobstore::FileBlobRef> fileBlob);
   ~CryOpenFile() override;
 
   stat_info stat() const override;
@@ -24,8 +26,15 @@ public:
   fspp::TimestampUpdateBehavior timestampUpdateBehavior() const;
 
 private:
-  const CryDevice *_device;
-  std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> _parent;
+  // The file can be moved into a different directory while it is open. Our dir entry (which stores
+  // for example the timestamps) then lives in the new parent directory blob and the parent we
+  // remembered when the file was opened is stale. This returns the directory blob that currently
+  // holds our dir entry, reloading it if the file was moved.
+  std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> _parentBlob() const;
+
+  CryDevice *_device;
+  mutable std::mutex _parentMutex;
+  mutable std::shared_ptr<parallelaccessfsblobstore::DirBlobRef> _parent;
   cpputils::unique_ref<parallelaccessfsblobstore::FileBlobRef> _fileBlob;
 
   DISALLOW_COPY_AND_ASSIGN(CryOpenFile);

--- a/src/fspp/fstest/FsppOpenFileTest.h
+++ b/src/fspp/fstest/FsppOpenFileTest.h
@@ -4,6 +4,8 @@
 
 #include "testutils/FileTest.h"
 
+#include <cstring>
+
 template<class ConcreteFileSystemTestFixture>
 class FsppOpenFileTest: public FileSystemTest<ConcreteFileSystemTestFixture> {
 public:
@@ -27,7 +29,24 @@ public:
         //and check that it only read the expected size (but also not less)
         EXPECT_EQ(expectedSize, readBytes);
     }
+
+    static constexpr const char *CONTENT = "content";
+    static constexpr fspp::num_bytes_t CONTENT_SIZE = fspp::num_bytes_t(7);
+
+    cpputils::unique_ref<fspp::OpenFile> CreateFileWithContent(const boost::filesystem::path &path) {
+        auto openFile = this->CreateFile(path)->open(fspp::openflags_t::RDWR());
+        openFile->write(CONTENT, CONTENT_SIZE, fspp::num_bytes_t(0));
+        return openFile;
+    }
+
+    void EXPECT_CONTENT_READABLE(fspp::OpenFile *openFile) {
+        cpputils::Data data(CONTENT_SIZE.value());
+        EXPECT_EQ(CONTENT_SIZE, openFile->read(data.data(), CONTENT_SIZE, fspp::num_bytes_t(0)));
+        EXPECT_EQ(0, std::memcmp(CONTENT, data.data(), CONTENT_SIZE.value()));
+    }
 };
+template<class ConcreteFileSystemTestFixture> constexpr const char *FsppOpenFileTest<ConcreteFileSystemTestFixture>::CONTENT;
+template<class ConcreteFileSystemTestFixture> constexpr fspp::num_bytes_t FsppOpenFileTest<ConcreteFileSystemTestFixture>::CONTENT_SIZE;
 
 TYPED_TEST_SUITE_P(FsppOpenFileTest);
 
@@ -45,9 +64,113 @@ TYPED_TEST_P(FsppOpenFileTest, FileIsFile) {
     });
 }
 
+// Renaming a file doesn't invalidate file descriptors that are already open for it,
+// so all operations have to keep working on an open file that was moved to a different directory.
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToOtherDir_Read) {
+    this->CreateDir("/mydir");
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/mydir/myfile");
+
+    this->EXPECT_CONTENT_READABLE(openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToOtherDir_Write) {
+    this->CreateDir("/mydir");
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/mydir/myfile");
+
+    openFile->write(this->CONTENT, this->CONTENT_SIZE, this->CONTENT_SIZE);
+    this->EXPECT_SIZE(this->CONTENT_SIZE + this->CONTENT_SIZE, openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToOtherDir_Stat) {
+    this->CreateDir("/mydir");
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/mydir/myfile");
+
+    this->IN_STAT(openFile.get(), [this] (const fspp::OpenFile::stat_info& st) {
+        EXPECT_TRUE(st.mode.hasFileFlag());
+        EXPECT_EQ(this->CONTENT_SIZE, st.size);
+    });
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToOtherDir_Truncate) {
+    this->CreateDir("/mydir");
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/mydir/myfile");
+
+    openFile->truncate(fspp::num_bytes_t(3));
+    this->EXPECT_SIZE(fspp::num_bytes_t(3), openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToOtherDir_Flush) {
+    this->CreateDir("/mydir");
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/mydir/myfile");
+
+    openFile->flush();
+    openFile->fsync();
+    openFile->fdatasync();
+    this->EXPECT_CONTENT_READABLE(openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToSameDir_Read) {
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/myrenamedfile");
+
+    this->EXPECT_CONTENT_READABLE(openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToParentDir_Read) {
+    this->CreateDir("/mydir");
+    auto openFile = this->CreateFileWithContent("/mydir/myfile");
+    this->Load("/mydir/myfile")->rename("/myfile");
+
+    this->EXPECT_CONTENT_READABLE(openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToNestedDir_Read) {
+    this->CreateDir("/mydir");
+    this->CreateDir("/mydir/mynesteddir");
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/mydir/mynesteddir/myfile");
+
+    this->EXPECT_CONTENT_READABLE(openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToOtherDirTwice_Read) {
+    this->CreateDir("/mydir");
+    this->CreateDir("/myotherdir");
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/mydir/myfile");
+    this->Load("/mydir/myfile")->rename("/myotherdir/myfile");
+
+    this->EXPECT_CONTENT_READABLE(openFile.get());
+}
+
+TYPED_TEST_P(FsppOpenFileTest, RenameToOtherDirOverwritingExistingFile_Read) {
+    this->CreateDir("/mydir");
+    this->CreateFile("/mydir/myfile");
+    auto openFile = this->CreateFileWithContent("/myfile");
+    this->Load("/myfile")->rename("/mydir/myfile");
+
+    this->EXPECT_CONTENT_READABLE(openFile.get());
+}
+
 REGISTER_TYPED_TEST_SUITE_P(FsppOpenFileTest,
     CreatedFileIsEmpty,
-    FileIsFile
+    FileIsFile,
+    RenameToOtherDir_Read,
+    RenameToOtherDir_Write,
+    RenameToOtherDir_Stat,
+    RenameToOtherDir_Truncate,
+    RenameToOtherDir_Flush,
+    RenameToSameDir_Read,
+    RenameToParentDir_Read,
+    RenameToNestedDir_Read,
+    RenameToOtherDirTwice_Read,
+    RenameToOtherDirOverwritingExistingFile_Read
 );
 
 //TODO Test stat


### PR DESCRIPTION
Fixes #565.

## Reproduction

Built this branch's base commit (b568b13) and mounted a fresh filesystem, then ran the C program from the issue at the mount root:

```
CREAT: 3
MKDIR: 0
TRUNCATE: 0
OPEN: 3
RENAME: 0
READ: -1 (No such file or directory)
```

The read fails. The reporter saw `EIO`; on the kernel here (6.18) the same failure surfaces as `ENOENT`. CryFS returns `-ENOENT` from the FUSE `read` in both cases — whether the page-cache read path passes that errno through or replaces it with `EIO` is up to the kernel version, so the two reports are the same bug.

Probing further, every cross-directory rename of an open file is affected, and it is not only `read`:

| operation on the open fd after the rename | before |
| --- | --- |
| `read` | fails |
| `write` | fails |
| `ftruncate` | fails |
| `fsync` | flushes the old directory |
| rename *within the same* directory | already worked |

## Does #592 already fix it?

No. #592 is a CI-only change on `main`: it adds `--skip tests::rename::` to the macOS `cargo test` invocation in `.github/workflows/ci.yml`. It touches one workflow file, no filesystem code, and it is against the Rust rewrite on `main` rather than the C++ 1.0 series the issue is reported against. Nothing in it changes this behaviour.

## Cause

`CryOpenFile` stores the `DirBlobRef` of the directory the file was in when it was opened, and looks up its own dir entry in it:

```cpp
fspp::num_bytes_t CryOpenFile::read(...) const {
  _parent->updateAccessTimestampForChild(_fileBlob->blockId(), timestampUpdateBehavior());
  return _fileBlob->read(buf, offset, count);
}
```

The dir entry holds the timestamps, so `read`, `write`, `truncate` and `stat` all go through the parent. `DirEntryList::updateAccessTimestampForChild` throws `FuseErrnoException(ENOENT)` when the entry isn't there.

`CryNode::rename` moving a node into a *different* directory removes the entry from the old parent, adds it to the new one, and updates the file blob's parent pointer. It fixes up its own `_parent`, but an already-open `CryOpenFile` is a separate object holding its own `shared_ptr` to the old parent — that one is now stale and no longer contains the entry.

A rename within the same directory goes through `DirBlobRef::RenameChild` instead, which leaves the entry in the same dir blob. That is why only cross-directory moves broke.

## Fix

`CryOpenFile::_parentBlob()` compares the file blob's parent pointer against the cached parent's block id and reloads the parent directory blob when they differ. Both refs go through the same `ParallelAccessStore` entry, so the pointer the rename wrote is visible immediately. In the common case this is a block-id comparison and no I/O.

Access is guarded by a mutex because `FuseOpenFileList::load` releases its lock before invoking the callback, so several FUSE threads can be inside one `CryOpenFile` at the same time; the helper returns a `shared_ptr` copy so the caller keeps the blob alive while using the dir entry reference it returns. `_device` had to become non-const to load the blob.

## Verification

Same mount, this branch:

```
CREAT: 3
MKDIR: 0
TRUNCATE: 0
OPEN: 3
RENAME: 0
READ: 10 (Success)
```

which is exactly the issue's `::Expected::` block. Also checked on a real mount that `read`, `write`, `fstat`, `ftruncate` and `fsync` on the moved descriptor all succeed, for a move into a subdirectory, out of a subdirectory into the root, into a nested directory, and onto an existing file; that data written through the moved descriptor lands in the file at its new path with the right size and mtime; and that it is still there after unmount and remount.

10 regression tests were added to the generic fspp filesystem test suite (`FsppOpenFileTest`), covering read/write/stat/truncate/flush after a move to another directory, plus moves out to the root, into a nested directory, twice in a row, onto an existing file, and the same-directory rename that already worked. On the unfixed code 9 of them fail and `RenameToSameDir_Read` passes; with the fix all 10 pass.

Test suites run locally (gcc 13, RelWithDebInfo, libfuse 2.9.9): `cryfs-test` 733/733, `fspp-test` 1020/1020, `parallelaccessstore-test` and `gitversion-test` green. `cryfs-cli-test` passes 241/241 with the `*NoReadPermission*`/`*NoWritePermission*`/`*NoExePermission*`/`*NoPermission*` cases filtered out — those expect permission bits to deny access and cannot pass as root in this container; they are unrelated to this change and run as a normal user in CI. The two changed translation units were also recompiled with `-Werror` on top of the project's warning flags, with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013tWxNy368caFZnjrbQUJgH

---
_Generated by [Claude Code](https://claude.ai/code/session_013tWxNy368caFZnjrbQUJgH)_