### PR TITLE
Update CI action dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,11 +142,6 @@ jobs:
   #       with:
   #         toolchain: stable
   #         components: clippy
-  #     # This used to be actions-rs/clippy-check, which posted the warnings as a
-  #     # check run. The actions-rs org was archived in October 2023 and its
-  #     # actions still run on node12, so plain `cargo clippy` it is: the
-  #     # warnings show up in the job log, and no `checks: write` permission is
-  #     # needed to write them there.
   #     - run: cargo clippy --all-features --all-targets -- -D warnings
   code_format:
     name: Code Formatter (rustfmt)
@@ -206,10 +201,10 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
-          # Required since codecov-action v4: tokenless uploading only remains
-          # supported for pull requests from forks of a public repo, not for the
-          # pushes and same-repo pull requests this job runs on. It also avoids
-          # the rate limits we used to hit on Codecov's API without it.
+          # Tokenless uploading only works for pull requests from forks of a
+          # public repo, not for the pushes and same-repo pull requests this job
+          # runs on, so the token is required here. It also keeps us clear of
+          # rate limits on Codecov's API.
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-14
           - macos-15
           - macos-15-intel
           - macos-26
@@ -48,7 +47,7 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         if: ${{ runner.os == 'Linux' }}
         uses: jlumbroso/free-disk-space@v1.3.1
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install Dependencies (Linux)
         if: ${{ runner.os == 'Linux' }}
         # TODO We may be able to remove libfuse3-dev here because rust fuser doesn't use libfuse anymore (on Linux at least)
@@ -56,7 +55,7 @@ jobs:
       - name: Install Dependencies (MacOS)
         if: ${{ runner.os == 'macOS' }}
         run: brew install pkg-config macfuse
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: cargo ${{ matrix.command }}
@@ -123,10 +122,10 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         if: ${{ runner.os == 'Linux' }}
         uses: jlumbroso/free-disk-space@v1.3.1
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Install Dependencies
         run: sudo apt-get install -y fuse3 libfuse3-dev
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
       - name: cargo check
@@ -135,38 +134,37 @@ jobs:
   # clippy_check:
   #   name: Linter (clippy)
   #   runs-on: ubuntu-latest
-  #   permissions:
-  #     checks: write
   #   steps:
-  #     - uses: actions/checkout@v6
+  #     - uses: actions/checkout@v7
   #     - name: Install Dependencies
   #       run: sudo apt-get install -y fuse3 libfuse3-dev
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
   #       with:
   #         toolchain: stable
   #         components: clippy
-  #         default: true
-  #     - uses: actions-rs/clippy-check@v1
-  #       with:
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         args: --all-features --all-targets -- -D warnings
+  #     # This used to be actions-rs/clippy-check, which posted the warnings as a
+  #     # check run. The actions-rs org was archived in October 2023 and its
+  #     # actions still run on node12, so plain `cargo clippy` it is: the
+  #     # warnings show up in the job log, and no `checks: write` permission is
+  #     # needed to write them there.
+  #     - run: cargo clippy --all-features --all-targets -- -D warnings
   code_format:
     name: Code Formatter (rustfmt)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
           components: rustfmt
-      - uses: mbrobbel/rustfmt-check@0.5.0
+      - uses: mbrobbel/rustfmt-check@0.23.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
   # sync_readme:
   #   name: Sync README.md (cargo sync-readme)
   #   runs-on: ubuntu-latest
   #   steps:
-  #   - uses: actions/checkout@v6
+  #   - uses: actions/checkout@v7
   #   - run: cargo install cargo-rdme
   #   - run: ./gen_readme.sh
   #   # Fail job if gen_readme.sh introduced changes. If this fails, then we need to run gen_readme.sh locally and add it to the commit.
@@ -175,10 +173,10 @@ jobs:
     name: Find dead doc links
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Install Dependencies
       run: sudo apt-get install -y fuse3 libfuse3-dev
-    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+    - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: stable
     - run: RUSTDOCFLAGS="-Dwarnings" cargo doc
@@ -189,8 +187,8 @@ jobs:
       - name: Free Disk Space (Ubuntu)
         if: ${{ runner.os == 'Linux' }}
         uses: jlumbroso/free-disk-space@v1.3.1
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
       # Setup inspired by instructions at https://github.com/taiki-e/cargo-llvm-cov/blob/9b93f70f4c5a06d6ee221d3537067bc8d3f5b7c6/README.md
@@ -206,9 +204,13 @@ jobs:
         # uses its default features and llvm-cov can finish.
         run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v7
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}  # not required for public repos, but leaving it here because it seems we run into rate limit issues on Codecov's API without it.
+          # Required since codecov-action v4: tokenless uploading only remains
+          # supported for pull requests from forks of a public repo, not for the
+          # pushes and same-repo pull requests this job runs on. It also avoids
+          # the rate limits we used to hit on Codecov's API without it.
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
Audited every action referenced by `.github/workflows/ci.yml` against its upstream repository. Four were behind, one runner image is on its way out, and two were already current.

## Actions

| Action | Was | Now | Why |
|---|---|---|---|
| `actions/checkout` | v6 | **v7** | Latest is v7.0.1 |
| `codecov/codecov-action` | v3 | **v7** | v3 is v3.1.6 from January 2024 and still declares `using: node16`, a runtime GitHub has retired |
| `mbrobbel/rustfmt-check` | 0.5.0 | **0.23.0** | Also a node16 action; 0.23.0 runs on node24 |
| `dtolnay/rust-toolchain` | `3c5f7ea` | **`6c977a6` # v1** | Repinned from an unnamed master commit to the commit the repo's `v1` tag points at, with the tag in a trailing comment so the pin is reviewable |
| `jlumbroso/free-disk-space` | v1.3.1 | *unchanged* | v1.3.1 **is** the head of its default branch — no commits since October 2023 |
| `taiki-e/install-action` | `@cargo-llvm-cov` | *unchanged* | Shorthand tag the author re-points at every release, so it already tracks the latest |

After this, no action in the workflow declares a retired Node runtime: checkout and rustfmt-check are on node24, the other four are composite actions with no Node runtime at all.

## Compatibility, checked upstream rather than assumed

- **checkout v7**'s breaking change blocks checking out fork pull request code from workflows triggered by `pull_request_target` or `workflow_run` unless the new `allow-unsafe-pr-checkout` input is set. This workflow triggers on `pull_request`, so it is unaffected.
- **codecov v5** replaced the JavaScript action with a composite one wrapping the Codecov CLI. All four inputs we pass — `token`, `files`, `fail_ci_if_error`, `verbose` — still exist in v7's `action.yml`. The comment on the token no longer held and is corrected: v4 dropped tokenless uploading except for pull requests from forks, so the token is now *required* for the pushes and same-repo pull requests this job runs on, not merely useful against rate limits.
- **rustfmt-check 0.23.0** gained a `mode` input whose default, `commit`, is exactly what 0.5.0 did unconditionally: run `rustfmt -l`, and if any file needs formatting, build a tree/commit/ref update through the API. Same code path (diffed both `src/main.ts`), so the job keeps behaving as it does today — including failing the run when the token may not write. This workflow grants `contents: read`, which is what turns the "push a fix-up commit" action into a formatting check.
- **rust-toolchain**'s `action.yml` is byte-identical between `v1` and current master; the two commits after `v1` only touch `scripts/update-revs.sh`, which is release tooling and not part of the action. It is a self-contained composite action, so this is the newest code either way.

## Runner images

Dropped `macos-14` from the test matrix. GitHub deprecated the image on 2026-07-06 and retires it on 2026-11-02, with brownouts from 2026-10-05 during which jobs requesting it are terminated with an error (actions/runner-images#13518). The replacements it names, `macos-15` and `macos-26`, are both already in the matrix, so both arm64 (`macos-15`, `macos-26`) and x64 (`macos-15-intel`) coverage survive. The test job goes from 72 to 60 configurations and the workflow from 255 to 243, which also buys back a little headroom under the 256-configuration matrix cap noted in the `crates_individually_testable` TODO.

Ubuntu 26.04 runners exist but are still preview images outside the Actions SLA, so the matrix does not pick them up yet. `ubuntu-22.04` and `ubuntu-24.04` are both GA and undeprecated.

## Also

Refreshed the commented-out `clippy_check` job. It referenced `actions-rs/toolchain` and `actions-rs/clippy-check`; that org was archived in October 2023 and its actions run on node12, so uncommenting the block as written would not have worked. It now uses `dtolnay/rust-toolchain` and a plain `cargo clippy`, which also drops the `checks: write` permission the block granted itself solely for clippy-check's check-run annotations.

## Verification

None of this is verifiable by running it locally — the workflow only really runs on GitHub. What was checked: the workflow still parses as YAML, and every version, commit SHA, runtime declaration and input name above was read out of the upstream repository rather than assumed. The CI run on this pull request is the real test.

## AI disclosure

Per `AI_POLICY.md`: this change was drafted by Claude Code. The upstream version checks, changelogs and `action.yml` comparisons behind each claim above were done as part of that work and are stated so they can be re-checked during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013PuV6jUp25jQqSeXLHFQvn

---
_Generated by [Claude Code](https://claude.ai/code/session_013PuV6jUp25jQqSeXLHFQvn)_