### PR TITLE
Update CI dependencies: checkout/upload-artifact v7, conan 2.32, drop macos-14

### DIFF
--- a/.github/workflows/actions/conan/setup/action.yaml
+++ b/.github/workflows/actions/conan/setup/action.yaml
@@ -32,7 +32,7 @@ runs:
     - name: Install conan
       uses: ./.github/workflows/actions/pipx/install
       with:
-        packages: conan~=2.23.0 --force
+        packages: conan~=2.32.0 --force
     - name: Configure conan profile
       uses: ./.github/workflows/actions/conan/configure_profile
       with:

--- a/.github/workflows/actions/cpack/action.yaml
+++ b/.github/workflows/actions/cpack/action.yaml
@@ -92,21 +92,21 @@ runs:
         /usr/bin/cryfs --version
     - name: Upload .deb as artifact
       if: runner.os == 'Linux' || runner.os == 'macOS'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cryfs-${{inputs.build_type}}.deb
         path: build/${{inputs.build_type}}/cryfs-*.deb
         if-no-files-found: error
     - name: Upload .rpm as artifact
       if: runner.os == 'Linux' || runner.os == 'macOS'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cryfs-${{inputs.build_type}}.rpm
         path: build/${{inputs.build_type}}/cryfs-*.rpm
         if-no-files-found: error
     - name: Upload .tar.gz as artifact
       if: runner.os == 'Linux' || runner.os == 'macOS'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cryfs-${{inputs.build_type}}.tar.gz
         path: build/${{inputs.build_type}}/cryfs-*.tar.gz
@@ -123,7 +123,7 @@ runs:
         cpack -C . --verbose -G WIX
     - name: Upload installers as artifact
       if: runner.os == 'Windows'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: cryfs-${{inputs.build_type}}.msi
         path: build/${{inputs.build_type}}/cryfs-*.msi

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -462,7 +462,7 @@ jobs:
       CONAN_HOME: "${{ github.workspace }}/conan-cache/"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Fetch all history because we need that to determine our version number
           fetch-depth: 0
@@ -548,7 +548,7 @@ jobs:
           fi
       - name: Upload fixes as artifact
         if: ${{ always() && matrix.run_clang_tidy }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: clang-tidy-fixes
           path: /tmp/clang-tidy-fixes
@@ -600,7 +600,7 @@ jobs:
       CONAN_HOME: "D:/.conan/"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           # Fetch all history because we need that to determine our version number
           fetch-depth: 0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -499,7 +499,7 @@ jobs:
         uses: ./.github/workflows/actions/conan/cache
         with:
           action: load
-          cache_key: v8-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.compiler.compiler}}__${{matrix.compiler.version}}__${{matrix.build_type}}__${{matrix.install_dependencies_manually}}__${{steps.hash_flags.outputs.hash_flags}}__
+          cache_key: v10-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.compiler.compiler}}__${{matrix.compiler.version}}__${{matrix.build_type}}__${{matrix.install_dependencies_manually}}__${{steps.hash_flags.outputs.hash_flags}}__
       # Setup conan is after restoring the cache so the cache doesn't overwrite the conan profile
       - name: Setup conan
         uses: ./.github/workflows/actions/conan/setup
@@ -567,7 +567,7 @@ jobs:
           action: save
           secret_aws_access_key_id: ${{ secrets.CACHE_AWS_ACCESS_KEY_ID }}
           secret_aws_secret_access_key: ${{ secrets.CACHE_AWS_SECRET_ACCESS_KEY }}
-          cache_key: v8-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.compiler.compiler}}__${{matrix.compiler.version}}__${{matrix.build_type}}__${{matrix.install_dependencies_manually}}__${{steps.hash_flags.outputs.hash_flags}}__
+          cache_key: v10-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.compiler.compiler}}__${{matrix.compiler.version}}__${{matrix.build_type}}__${{matrix.install_dependencies_manually}}__${{steps.hash_flags.outputs.hash_flags}}__
       - name: Test
         if: ${{ matrix.run_tests }}
         uses: ./.github/workflows/actions/run_tests
@@ -624,7 +624,7 @@ jobs:
         uses: ./.github/workflows/actions/conan/cache
         with:
           action: load
-          cache_key: v9-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.build_type}}__
+          cache_key: v10-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.build_type}}__
       # Setup conan is after restoring the conan cache so that the cache doesn't overwrite the conan profile
       - name: Setup conan
         uses: ./.github/workflows/actions/conan/setup
@@ -655,7 +655,7 @@ jobs:
           action: save
           secret_aws_access_key_id: ${{ secrets.CACHE_AWS_ACCESS_KEY_ID }}
           secret_aws_secret_access_key: ${{ secrets.CACHE_AWS_SECRET_ACCESS_KEY }}
-          cache_key: v9-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.build_type}}__
+          cache_key: v10-${{ runner.os }}-${{ matrix.os }}-conancache__${{matrix.build_type}}__
       - name: Test
         shell: bash
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -30,7 +30,6 @@ jobs:
       matrix:
         name: [""]
         os:
-          - macos-14
           - macos-15
           - macos-15-intel
           - macos-26
@@ -161,25 +160,6 @@ jobs:
         run_clang_tidy: [false]
         gtest_args: [""]
         exclude:
-          # MacOS 14 doesn't have Clang 13 anymore. Clang 18, 19 seems broken (maybe https://github.com/llvm/llvm-project/issues/92121), and GCC versions are often incompatible, so we don't support them officially.
-          - os: macos-14
-            compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
-          - os: macos-14
-            compiler: {compiler: clang, version: 18, libcxx: libc++, cc: clang-18, cxx: clang++-18, macos_cc: llvm@18/bin/clang, macos_cxx: llvm@18/bin/clang++, apt_package: "clang-18 libc++-18-dev libc++abi-18-dev libunwind-18-dev libomp-18-dev", homebrew_package: llvm@18}
-          - os: macos-14
-            compiler: {compiler: clang, version: 19, libcxx: libc++, cc: clang-19, cxx: clang++-19, macos_cc: llvm@19/bin/clang, macos_cxx: llvm@19/bin/clang++, apt_package: "clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev", homebrew_package: llvm@19}
-          - os: macos-14
-            compiler: {compiler: gcc, version: 9, libcxx: libstdc++11, cc: gcc-9, cxx: g++-9, homebrew_package: gcc@9, apt_package: g++-9}
-          - os: macos-14
-            compiler: {compiler: gcc, version: 10, libcxx: libstdc++11, cc: gcc-10, cxx: g++-10, homebrew_package: gcc@10, apt_package: g++-10}
-          - os: macos-14
-            compiler: {compiler: gcc, version: 11, libcxx: libstdc++11, cc: gcc-11, cxx: g++-11, homebrew_package: gcc@11, apt_package: g++-11}
-          - os: macos-14
-            compiler: {compiler: gcc, version: 12, libcxx: libstdc++11, cc: gcc-12, cxx: g++-12, homebrew_package: gcc@12, apt_package: g++-12}
-          - os: macos-14
-            compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
-          - os: macos-14
-            compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
           # MacOS 15 doesn't have Clang 13 anymore. And GCC versions are often incompatible, so we don't support them officially.
           - os: macos-15
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
@@ -236,12 +216,6 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-26
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Clang 14, 16 on macos-14 builds fine but tests fail with "line 9: 55242 Trace/BPT trap: 5       ./cpp-utils/cpp-utils-test"
-          # TODO Can we fix this? Not sure what's causing it
-          - os: macos-14
-            compiler: {compiler: clang, version: 14, libcxx: libc++, cc: clang-14, cxx: clang++-14, macos_cc: llvm@14/bin/clang, macos_cxx: llvm@14/bin/clang++, apt_package: "clang-14 libc++-14-dev libc++abi-14-dev libunwind-14-dev libomp-14-dev", homebrew_package: llvm@14}
-          - os: macos-14
-            compiler: {compiler: clang, version: 16, libcxx: libc++, cc: clang-16, cxx: clang++-16, macos_cc: llvm@16/bin/clang, macos_cxx: llvm@16/bin/clang++, apt_package: "clang-16 libc++-16-dev libc++abi-16-dev libunwind-16-dev libomp-16-dev", homebrew_package: llvm@16}
           # Ubuntu 22.04 doesn't have gcc 13, 14 yet
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
@@ -504,7 +478,7 @@ jobs:
       - name: Setup conan
         uses: ./.github/workflows/actions/conan/setup
         with:
-          arch: ${{ (matrix.os == 'macos-14' || matrix.os == 'macos-15' || matrix.os == 'macos-26') && 'armv8' || 'x86_64' }}
+          arch: ${{ (matrix.os == 'macos-15' || matrix.os == 'macos-26') && 'armv8' || 'x86_64' }}
           compiler: ${{ matrix.compiler.compiler }}
           compiler_version: ${{ matrix.compiler.version }}
           compiler_libcxx: ${{ matrix.compiler.libcxx }}

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ You can use the following commands to install these requirements
 To install conan, follow the [official installation instructions](https://docs.conan.io/2/installation.html). The following steps should work on Ubuntu/Debian based systems:
 
     $ sudo apt install pipx
-    $ pipx install conan~=2.7.0
+    $ pipx install conan~=2.32.0
     $ pipx ensurepath
 
 Restart your shell so that conan is on your PATH, and then let it find your compiler


### PR DESCRIPTION
Brings the CI dependencies up to date. Four commits, one concern each.

| Dependency | Was | Now |
| --- | --- | --- |
| `actions/checkout` | v4 (Node 20) | **v7** |
| `actions/upload-artifact` | v4 (Node 20) | **v7** |
| `conan` (CI + README) | `~=2.23.0` / `~=2.7.0` | **`~=2.32.0`** |
| `macos-14` runner | in the matrix | **dropped** |

### actions/checkout and actions/upload-artifact to v7

Both sat on v4, which runs on Node 20 — end of life since April 2026. v6 of each moved to the Node 24 runtime and v7 is the current major.

Neither jump changes anything this workflow relies on:

* **checkout** — v5 is the Node 24 move, v6 writes the credential to a separate file instead of `.git/config`, v7 refuses to check out a fork PR under `pull_request_target` and `workflow_run`. We only trigger on `push` and `pull_request`, so the v7 restriction does not apply, and nothing runs an authenticated git operation after the checkout, so where the credential lives does not matter to us. Both jobs only need history, via `fetch-depth: 0` for gitversion.
* **upload-artifact** — v5 is packaging, v6 is the Node 24 move, v7 adds direct uploads and an `archive` input that defaults to `true`, i.e. to the existing v4 behaviour. All five call sites pass only `name`, `path` and `if-no-files-found`, none of which changed.

`leroy-merlin-br/action-s3-cache` stays at v1.0.6 and stays SHA-pinned: v1.0.7-rc.0 is a release candidate, and it is a composite shell action, so it has no Node runtime to age out.

### conan 2.23 → 2.32, and a new conan cache key

The pin was `conan~=2.23.0`, nine minor releases behind. Nothing in `conanfile.py` touches what the newer releases removed — 2.32 drops the `system_tools` profile section, `detect_api`'s `detect_compiler`, the deprecated deploy folder, some `PackagesList` methods, `cmake_set_interface_link_directories`, `Node::dependencies`, and the `deprecated_build_order_args` / `deprecated_empty_version_range` policies. We use none of those, and every `requires()` is an exact version rather than a range. Conan 2.32 still supports Python 3.7+, so every runner image can install it.

**The cache key bump is not cosmetic.** The S3 cache is shared across branches, and conan migrates its cache database in place when a newer version opens an older one. Had the key stayed put, the first push on this branch would have written a 2.32-migrated cache back under the old key, and CI on branches still installing 2.23 would then load a cache their conan cannot read — conan migrates a cache forward, not backward. A new key gives 2.32 its own namespace and leaves the old one untouched. The cost is one cold run.

Linux/macOS was on v8 and Windows on v9, bumped at different times; both go to v10 so the two are back in step. The keys also contain `runner.os`, so neither can collide with anything stored earlier.

### Drop the deprecated macos-14 runner

GitHub deprecated the macOS 14 images on 2026-07-06 and retires them on 2026-11-02, with brownouts — windows where jobs on the label are failed deliberately — starting **2026-10-05** (actions/runner-images#13518). The recommended migration is macos-15 or macos-26, both of which the matrix already covers, along with macos-15-intel. Same reasoning as dropping windows-2019 in #587.

macos-14 contributed only 6 of the 124 jobs. Everything else there was already excluded: Clang 13, 18 and 19 for the reasons noted in the comments, all the GCC versions as unsupported on macOS, and Clang 14 and 16 because they built but trapped in `cpp-utils-test`. Only Clang 15 and 17 still ran, across the three build types, and both are covered on the remaining macOS runners. The TODO about the Clang 14/16 trap goes with them — it was specific to that image. macos-14 also leaves the `armv8` arm of the conan arch expression, since it was an Apple-silicon image.

### README conan pin

`README.md` told contributors to install `conan~=2.7.0`. That was already wrong before this branch — CI had been installing 2.23.x, so anyone following the README built against a conan sixteen minor releases older than anything we test. Bumping CI widened the same gap rather than creating it, but this is the change that should close it. The pin now matches `conan/setup/action.yaml` exactly.

The requirements list a few lines up still says "Conan package manager (version 2.x)", which is the real compatibility statement; the pipx line is the narrower "this is what we test with".

## Validation

Matrix expanded before and after, on this base: **130 → 124 jobs**, the 6 removed are exactly the macos-14 ones, none added, and no `exclude` entry is left matching nothing. All 20 workflow and action files parse.

An earlier run of these same changes on the pre-rebase base reached **81 jobs green with zero failures** — ubuntu-22.04 33/33, windows-2022 3/3, ubuntu-24.04 45/46 — covering dependency resolution, build, test and cpack under conan 2.32, and both Windows `.msi` artifacts uploaded through `upload-artifact@v7` with valid digests. The macOS jobs never left the queue in two hours, so **macOS is validated by this PR's run rather than by that one.**

## Not included

Deliberately out of scope, flagged for a separate decision:

* **Dokany 2.3.1.1000 is available** (we pin 2.2.0.1000), but `README.md` tells users to install the matching version and warns others may not work — a user-facing compatibility decision, not a CI bump.
* **boost 1.84.0 / spdlog 1.14.1 / gtest 1.15.0** are pinned identically in `conanfile.py` and `install_local_dependencies`, deliberately in sync. Bumping them is a project-dependency change.
* **No `dependabot.yml` exists.** One scoped to `github-actions` would automate this class of update, at the cost of ongoing PR noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj

---
_Generated by [Claude Code](https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj)_