### PR TITLE
ci: add ubuntu-26.04 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,8 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
         run: |
-          full='{"os":["macos-15","macos-15-intel","macos-26","ubuntu-22.04","ubuntu-24.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"]}'
-          pr='{"os":["macos-15","ubuntu-22.04","ubuntu-24.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"],"exclude":[{"os":"macos-15","toolchain":"nightly"},{"os":"macos-15","toolchain":"1.95"}]}'
+          full='{"os":["macos-15","macos-15-intel","macos-26","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"]}'
+          pr='{"os":["macos-15","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"],"exclude":[{"os":"macos-15","toolchain":"nightly"},{"os":"macos-15","toolchain":"1.95"}]}'
           if [[ "$EVENT" == "pull_request" ]]; then
             matrix="$pr"
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,27 @@ jobs:
         # one fails, so a job reports all broken feature sets, not just the
         # first.
         run: |
+          # crates/cli-utils/tests/arguments.rs builds a throwaway cargo project
+          # per test case (via the tempproject crate), and each of those compiles
+          # the full dependency tree, including OpenSSL vendored from source.
+          # That is tens of gigabytes across the suite, and tempfile puts those
+          # projects under $TMPDIR.
+          #
+          # On ubuntu-26.04 /tmp is a tmpfs sized at half of RAM -- about 7.8 GiB
+          # on a standard runner -- because systemd mounts it that way by default
+          # since Ubuntu 25.04. The temp projects fill it and the builds die with
+          # "No space left on device" while the runner's real disk still has tens
+          # of GiB free. ubuntu-22.04 and ubuntu-24.04 keep /tmp on the root
+          # filesystem, which is why they never hit this.
+          #
+          # $RUNNER_TEMP is on that root filesystem, so pointing TMPDIR at it puts
+          # the temp projects back on real disk. Linux only, deliberately: the
+          # macOS runners already put TMPDIR on disk, and redirecting them at
+          # $RUNNER_TEMP made the vendored OpenSSL install fail there with
+          # "cp: ... fcopyfile failed: Input/output error".
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            export TMPDIR="$RUNNER_TEMP"
+          fi
           skip=()
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             skip=(-- --skip tests::mkdir:: --skip tests::rename:: --skip tests::utils::fuser_runner:: --skip version::http_client::tests::reqwest_http_client::test_get_valid_)


### PR DESCRIPTION
Adds `ubuntu-26.04`, the newest Ubuntu LTS runner image, to the `test` job. The matrix covered 22.04 and 24.04 but nothing newer.

One of three independent CI-version additions, each on its own branch so they can be taken or dropped separately.

## Why

Ubuntu 26.04 ships a substantially different toolchain from 24.04 — clang 21 as the default C compiler (which matters for the `-sys` crates we build from source, e.g. `openssl-sys` and `libsodium`), a newer glibc, and fuse3 from a newer release. Building there now means we find out about breakage on our own schedule rather than when 24.04 goes away.

## What changed

Rebased onto current main, so this now edits the two JSON matrices #635 introduced rather than a YAML list:

- **`full`** (push to main, tags): 30 → 36 jobs.
- **`pr`** (pull requests): 14 → 20 jobs.

It goes into the pull-request matrix too. That matrix runs every Linux combination by design, and 26.04 is a Linux combination; leaving it out would mean the image is only ever built *after* a merge, which is the opposite of the early warning this is for. Six jobs each — two profiles × three toolchains, the feature sets being a loop rather than an axis.

## The second commit

Adding the runner surfaced a real problem. `test (ubuntu-26.04, --no-default-features, 1.95)` failed 138 of 212 cases with:

```
ranlib: .../libcrypto.a.new: error reading libdefault-lib-eddsa_sig.o: No space left on device
make: *** [Makefile:2827: install_dev] Error 1
```

`crates/cli-utils/tests/arguments.rs` builds a throwaway cargo project per test case through the `tempproject` crate, and each of those compiles the full dependency tree including OpenSSL vendored from source. `tempfile` puts those projects under `$TMPDIR`, so the suite needs tens of gigabytes there.

Ubuntu 26.04 mounts `/tmp` as a **tmpfs sized at half of RAM** — about 7.8 GiB on a standard runner — which has been systemd's default since Ubuntu 25.04. The temp projects exhaust it while `df` on the same runner still reports plenty free on `/`:

```
tmpfs        8182844     38820    8144024   1% /tmp
/dev/root  151361008  28618352  122726272  19% /
```

22.04 and 24.04 keep `/tmp` on the root filesystem, which is why this has never come up.

The second commit points `TMPDIR` at `$RUNNER_TEMP` **on Linux only**. Those runners' own `df` shows no tmpfs on `/tmp`, so it is a no-op on 22.04 and 24.04. It is deliberately not applied to macOS: an earlier unscoped version moved the macOS temp projects to `$RUNNER_TEMP` too, and there the vendored OpenSSL install died with `cp: .../libcrypto.a.new: fcopyfile failed: Input/output error` on a job that passes with the default macOS `TMPDIR`.

Worth knowing for #619 (which dropped `free-disk-space` from the Linux test jobs): the Linux test jobs write far more to disk than the workspace `target/` dir, because of these nested builds.

## Testing

**All six `ubuntu-26.04` jobs passed** — `stable`, `nightly` and `1.95`, each in debug and release — on [run 34438271302](https://github.com/cryfs/cryfs/actions/runs/34438271302), against head `bc72c80`. That run also had every other Linux test job green and every check job green (coverage, rustfmt, dead doc links, all 14 per-crate checks): 39 of 55 jobs concluded, zero failures. The only jobs it did not reach were macOS ones on pre-existing configurations, which this change does not affect.

So the thing this PR asserts — that `ubuntu-26.04` builds and tests clean, and that the `No space left on device` failure is gone on a runner that no longer has `free-disk-space` either — is confirmed.

The current head `89512b2` is that verified tree rebased onto main `ba3b61b`, with the matrix change re-derived for the new JSON form. I re-validated it locally: both matrices parse as JSON (the same check the workflow runs on itself), the YAML parses, the matrices expand to 36 and 20 jobs with 6 on `ubuntu-26.04` in each, and the `TMPDIR` export is present, Linux-scoped, and ahead of the `cargo test` invocation. Its CI run was cancelled deliberately to save runner capacity, since the change since `bc72c80` is a rebase plus the mechanical matrix re-derivation.

## AI disclosure

Per `AI_POLICY.md`: drafted with AI assistance (Claude Code). The disk-exhaustion failure was diagnosed from the CI logs; the macOS regression from the unscoped first version was caught by CI and corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kjjwx5NLxkKfB84jN6aYi7