### PR TITLE
CI: Enable only the apt.llvm.org repository the job actually needs

### DIFF
--- a/.github/workflows/actions/setup_linux/action.yaml
+++ b/.github/workflows/actions/setup_linux/action.yaml
@@ -7,6 +7,9 @@ inputs:
   extra_apt_packages:
     description: "Job-specific apt packages to install (e.g. the compiler)"
     required: true
+  llvm_version:
+    description: "The LLVM version this job builds with, or empty if it doesn't build with clang"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -16,40 +19,25 @@ runs:
         set -v
         set -e
         echo 'Acquire::Retries "20";' | sudo tee -a /etc/apt/apt.conf.d/80-retries
-        if [[ "${{inputs.os}}" == "ubuntu-24.04" ]]; then
-          echo Adding apt repositories for newer clang versions on Ubuntu 22.04
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          sudo touch /etc/apt/sources.list.d/clang.list
-          sudo chmod o+w /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/noble/ llvm-toolchain-noble-21 main" >> /etc/apt/sources.list.d/clang.list
-        elif [[ "${{inputs.os}}" == "ubuntu-22.04" ]]; then
-          echo Adding apt repositories for newer clang versions on Ubuntu 22.04
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-          sudo touch /etc/apt/sources.list.d/clang.list
-          sudo chmod o+w /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" >> /etc/apt/sources.list.d/clang.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-21 main" >> /etc/apt/sources.list.d/clang.list
-          sudo chmod o-w /etc/apt/sources.list.d/clang.list
+
+        # Ubuntu only carries clang up to a certain version, so anything newer than that comes from
+        # apt.llvm.org. At most one of its repositories may be enabled at a time: from LLVM 20 on it
+        # ships the runtime as unversioned libc++1, libc++abi1 and libunwind packages, so with two
+        # of them enabled apt resolves those to the newer LLVM, and libc++-<version>-dev of the
+        # older one, which depends on its own exact version, becomes uninstallable.
+        case "${{inputs.os}}" in
+          # NEWEST_CLANG_IN_ARCHIVE is the newest clang that release ships itself.
+          ubuntu-22.04) LLVM_CODENAME=jammy;    NEWEST_CLANG_IN_ARCHIVE=14 ;;
+          ubuntu-24.04) LLVM_CODENAME=noble;    NEWEST_CLANG_IN_ARCHIVE=19 ;;
+          ubuntu-26.04) LLVM_CODENAME=resolute; NEWEST_CLANG_IN_ARCHIVE=22 ;;
+          *)            LLVM_CODENAME="";       NEWEST_CLANG_IN_ARCHIVE=0  ;;
+        esac
+        if [[ -n "${{inputs.llvm_version}}" && -n "$LLVM_CODENAME" && "${{inputs.llvm_version}}" -gt "$NEWEST_CLANG_IN_ARCHIVE" ]]; then
+          echo "Adding the apt.llvm.org repository for clang ${{inputs.llvm_version}}"
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/apt-llvm-org.gpg
+          echo "deb [signed-by=/usr/share/keyrings/apt-llvm-org.gpg] http://apt.llvm.org/$LLVM_CODENAME/ llvm-toolchain-$LLVM_CODENAME-${{inputs.llvm_version}} main" | sudo tee /etc/apt/sources.list.d/clang.list
         fi
+
         sudo apt-get update
         sudo apt-get install ninja-build libfuse3-dev fuse3 ccache ${{inputs.extra_apt_packages}}
     - name: Speed up random generator
@@ -58,4 +46,3 @@ runs:
         # Use /dev/urandom when /dev/random is accessed to use less entropy
         sudo cp -a /dev/urandom /dev/random
       shell: bash
-

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -465,6 +465,7 @@ jobs:
         with:
           os: ${{ matrix.os }}
           extra_apt_packages: ${{ matrix.compiler.apt_package }}
+          llvm_version: ${{ matrix.compiler.compiler == 'clang' && matrix.compiler.version || '' }}
       - name: Install local dependencies
         if: ${{ matrix.install_dependencies_manually }}
         uses: ./.github/workflows/actions/install_local_dependencies


### PR DESCRIPTION
`setup_linux` adds a fixed list of apt.llvm.org repositories per runner image — noble 19, 20 and 21 on ubuntu-24.04, jammy 15 through 21 on ubuntu-22.04 — no matter which compiler the job builds with. That works only as long as every clang in the matrix is 19 or older, which is why nothing has noticed yet.

## Why it breaks at clang 20

From LLVM 20 on, apt.llvm.org ships the runtimes under unversioned names — `libc++1`, `libc++abi1`, `libunwind` — rather than `libc++1-<version>` and friends. Two such repositories cannot coexist: apt resolves the unversioned name to the highest version available, and `libc++-<version>-dev` depends on the runtime at its own exact version, so everything but the newest becomes uninstallable.

With the 20 and 21 repositories both enabled, all six Ubuntu jobs asking for clang 20 died in `Setup Linux`:

```
libc++-20-dev : Depends: libc++1 (= 1:20.1.8~++2025...) but 1:21.1.8~++2025... is to be installed
libc++abi-20-dev : Depends: libc++abi1 (= 1:20.1.8~++2025...) but 1:21.1.8~++2025... is to be installed
E: Unable to correct problems, you have held broken packages.
```

In the same run, all six clang 21 jobs passed — 21 being the newest repository enabled is the only reason. So clang 20 and clang 21 cannot both be in the matrix as things stand, and neither can any pair of LLVM 20+ versions.

## What this does

Each job now enables the single repository for the clang version it builds with, and only when Ubuntu's own archive doesn't already have that version:

| image | from the archive | from apt.llvm.org |
|---|---|---|
| ubuntu-22.04 | clang ≤ 14 | clang ≥ 15 |
| ubuntu-24.04 | clang ≤ 19 | clang ≥ 20 |
| ubuntu-26.04 | clang ≤ 22 | clang ≥ 23 |

The gcc jobs pass an empty version and get no extra repository at all, which they never needed.

One job changes where its packages come from: clang 19 on ubuntu-24.04 now installs 19.1.1 from noble-updates instead of 19.1.7 from apt.llvm.org. Every other job installs from the same place as before, one repository at a time instead of up to seven — which also makes `apt-get update` noticeably shorter.

The signing key stops going through `apt-key`, which has been deprecated since Ubuntu 20.10 and warns on every `apt-get update`. It is dearmored into `/usr/share/keyrings` and referenced with `signed-by`, which is what apt has wanted since then. `apt-key` is gone entirely on newer Ubuntu, so the old form would not have survived the move to 26.04 anyway.

## Verification

A run restricted to one Debug job per package source came back green on all seven, each having exercised a different path through the new logic:

- ubuntu-22.04 gcc 12 and ubuntu-24.04 gcc 12 — no repository added at all
- ubuntu-22.04 clang 13 — from the jammy archive, no repository added
- ubuntu-22.04 clang 15 and clang 19 — one apt.llvm.org repository each
- ubuntu-24.04 clang 15 and clang 19 — from the noble archive, no repository added

## Why now

This is the prerequisite for adding clang 20, which is proposed separately and cannot install without it. It is also what makes clang 22 and 23 addable later without the same collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu)_