### PR TITLE
CI: Add gcc 15

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,13 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: gcc
+            version: 15
+            libcxx: libstdc++11
+            cc: gcc-15
+            cxx: g++-15
+            apt_package: g++-15
+            homebrew_package: gcc@15
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx
@@ -224,6 +231,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15
+            compiler: {compiler: gcc, version: 15, libcxx: libstdc++11, cc: gcc-15, cxx: g++-15, homebrew_package: gcc@15, apt_package: g++-15}
           - os: macos-15-intel
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           - os: macos-15-intel
@@ -240,6 +249,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15-intel
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15-intel
+            compiler: {compiler: gcc, version: 15, libcxx: libstdc++11, cc: gcc-15, cxx: g++-15, homebrew_package: gcc@15, apt_package: g++-15}
           # MacOS 15-intel fails to build with Clang 14
           - os: macos-15-intel
             compiler: {compiler: clang, version: 14, libcxx: libc++, cc: clang-14, cxx: clang++-14, macos_cc: llvm@14/bin/clang, macos_cxx: llvm@14/bin/clang++, apt_package: "clang-14 libc++-14-dev libc++abi-14-dev libunwind-14-dev libomp-14-dev", homebrew_package: llvm@14}
@@ -265,12 +276,18 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-26
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 22.04 doesn't have gcc 13, 14 yet
+          - os: macos-26
+            compiler: {compiler: gcc, version: 15, libcxx: libstdc++11, cc: gcc-15, cxx: g++-15, homebrew_package: gcc@15, apt_package: g++-15}
+          # Ubuntu 22.04 doesn't have gcc 13, 14 or 15
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 24.04 doesn't have clang 13 anymore
+          - os: ubuntu-22.04
+            compiler: {compiler: gcc, version: 15, libcxx: libstdc++11, cc: gcc-15, cxx: g++-15, homebrew_package: gcc@15, apt_package: g++-15}
+          # Ubuntu 24.04 doesn't have gcc 15, and doesn't have clang 13 anymore
+          - os: ubuntu-24.04
+            compiler: {compiler: gcc, version: 15, libcxx: libstdc++11, cc: gcc-15, cxx: g++-15, homebrew_package: gcc@15, apt_package: g++-15}
           - os: ubuntu-24.04
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           # Ubuntu 26.04 has neither clang 13 to 16 nor gcc 9 and 10 anymore


### PR DESCRIPTION
gcc 15 is the newest GCC in the archives of any image we build on apart from gcc 16, and `ubuntu-26.04`, added in #598, is the first runner image in the matrix that carries either.

It runs on `ubuntu-26.04` only. `g++-15` is not in the 22.04 or 24.04 archives and would need the `ubuntu-toolchain-r` PPA there, which is not worth pulling in for one compiler, so both are excluded. The macOS exclusions are the same as for every other GCC version: the Homebrew formulas are often incompatible there, so we don't support them officially.

That is **one new job**, on `ubuntu-26.04`, building and testing all three build types inside it.

## Verification

A run restricted to exactly this configuration came back green — dependency install, build and the full test suite, in Debug, Release and RelWithDebInfo.

That run was against this branch before it was rebased; the rebase changed nothing in the gcc 15 commit, only the commits beneath it, which are now in `release/1.0` unchanged.

Matrix resolved before and after. The os axis became event-dependent in #639, so there are two numbers now:

| event | before | after |
|---|---|---|
| pull request | 46 | 47 |
| push to a release branch, tag | 53 | 54 |

The one added is exactly the gcc 15 job on `ubuntu-26.04` in both cases, none removed, and no `exclude` entry is left matching nothing.

## Not included

gcc 16, which Ubuntu 26.04 also carries. It is no longer blocked — #596 moved us to conan 2.32, whose `default_settings.py` lists gcc up to 16.2 — and it is coming as its own PR rather than being folded in here.

## Ordering

Depends on #598, already merged. Independent of the other compiler additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu
