### PR TITLE
CI: Add macos-26-intel

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,13 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: gcc
+            version: 16
+            libcxx: libstdc++11
+            cc: gcc-16
+            cxx: g++-16
+            apt_package: g++-16
+            homebrew_package: gcc@16
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx
@@ -224,6 +231,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           - os: macos-15-intel
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           - os: macos-15-intel
@@ -240,6 +249,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15-intel
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15-intel
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           # MacOS 15-intel fails to build with Clang 14
           - os: macos-15-intel
             compiler: {compiler: clang, version: 14, libcxx: libc++, cc: clang-14, cxx: clang++-14, macos_cc: llvm@14/bin/clang, macos_cxx: llvm@14/bin/clang++, apt_package: "clang-14 libc++-14-dev libc++abi-14-dev libunwind-14-dev libomp-14-dev", homebrew_package: llvm@14}
@@ -265,12 +276,18 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-26
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 22.04 doesn't have gcc 13, 14 yet
+          - os: macos-26
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
+          # Ubuntu 22.04 doesn't have gcc 13, 14 or 16
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 24.04 doesn't have clang 13 anymore
+          - os: ubuntu-22.04
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
+          # Ubuntu 24.04 doesn't have gcc 16, and doesn't have clang 13 anymore
+          - os: ubuntu-24.04
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           - os: ubuntu-24.04
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           # Ubuntu 26.04 has neither clang 13 to 16 nor gcc 9 and 10 anymore

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,15 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: clang
+            version: 21
+            libcxx: libc++
+            cc: clang-21
+            cxx: clang++-21
+            macos_cc: llvm@21/bin/clang
+            macos_cxx: llvm@21/bin/clang++
+            apt_package: clang-21 libc++-21-dev libc++abi-21-dev libunwind-21-dev libomp-21-dev
+            homebrew_package: llvm@21
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,15 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: clang
+            version: 20
+            libcxx: libc++
+            cc: clang-20
+            cxx: clang++-20
+            macos_cc: llvm@20/bin/clang
+            macos_cxx: llvm@20/bin/clang++
+            apt_package: clang-20 libc++-20-dev libc++abi-20-dev libunwind-20-dev libomp-20-dev
+            homebrew_package: llvm@20
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,6 +75,7 @@ jobs:
           - macos-15
           - macos-15-intel
           - macos-26
+          - macos-26-intel
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-26.04
@@ -265,6 +266,36 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-26
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          # MacOS 26-intel is the same OS, so the same compilers are missing there.
+          - os: macos-26-intel
+            compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
+          - os: macos-26-intel
+            compiler: {compiler: clang, version: 14, libcxx: libc++, cc: clang-14, cxx: clang++-14, macos_cc: llvm@14/bin/clang, macos_cxx: llvm@14/bin/clang++, apt_package: "clang-14 libc++-14-dev libc++abi-14-dev libunwind-14-dev libomp-14-dev", homebrew_package: llvm@14}
+          - os: macos-26-intel
+            compiler: {compiler: clang, version: 15, libcxx: libc++, cc: clang-15, cxx: clang++-15, macos_cc: llvm@15/bin/clang, macos_cxx: llvm@15/bin/clang++, apt_package: "clang-15 libc++-15-dev libc++abi-15-dev libunwind-15-dev libomp-15-dev", homebrew_package: llvm@15}
+          - os: macos-26-intel
+            compiler: {compiler: gcc, version: 9, libcxx: libstdc++11, cc: gcc-9, cxx: g++-9, homebrew_package: gcc@9, apt_package: g++-9}
+          - os: macos-26-intel
+            compiler: {compiler: gcc, version: 10, libcxx: libstdc++11, cc: gcc-10, cxx: g++-10, homebrew_package: gcc@10, apt_package: g++-10}
+          - os: macos-26-intel
+            compiler: {compiler: gcc, version: 11, libcxx: libstdc++11, cc: gcc-11, cxx: g++-11, homebrew_package: gcc@11, apt_package: g++-11}
+          - os: macos-26-intel
+            compiler: {compiler: gcc, version: 12, libcxx: libstdc++11, cc: gcc-12, cxx: g++-12, homebrew_package: gcc@12, apt_package: g++-12}
+          - os: macos-26-intel
+            compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
+          - os: macos-26-intel
+            compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          # MacOS 26-intel fails to install Clang 16, as macos-15-intel already did: Homebrew's
+          # llvm@16 depends on python@3.12, and linking that collides with the python.org
+          # framework Python the image ships - "Target /usr/local/bin/2to3-3.12 already exists"
+          # - which makes brew exit non-zero even though llvm@16 itself pours fine.
+          - os: macos-26-intel
+            compiler: {compiler: clang, version: 16, libcxx: libc++, cc: clang-16, cxx: clang++-16, macos_cc: llvm@16/bin/clang, macos_cxx: llvm@16/bin/clang++, apt_package: "clang-16 libc++-16-dev libc++abi-16-dev libunwind-16-dev libomp-16-dev", homebrew_package: llvm@16}
+          # MacOS 26-intel fails to build with Clang 18, which macos-15-intel also excludes:
+          # anything linked with -stdlib=libc++ against the MacOSX26 SDK dies in the very first
+          # CMake compiler check with "ld: library 'c++' not found".
+          - os: macos-26-intel
+            compiler: {compiler: clang, version: 18, libcxx: libc++, cc: clang-18, cxx: clang++-18, macos_cc: llvm@18/bin/clang, macos_cxx: llvm@18/bin/clang++, apt_package: "clang-18 libc++-18-dev libc++abi-18-dev libunwind-18-dev libomp-18-dev", homebrew_package: llvm@18}
           # Ubuntu 22.04 doesn't have gcc 13, 14 yet
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
@@ -552,8 +583,8 @@ jobs:
           compiler: ${{ matrix.compiler.compiler }}
           compiler_version: ${{ matrix.compiler.version }}
           compiler_libcxx: ${{ matrix.compiler.libcxx }}
-          compiler_executable_c: ${{ runner.os == 'macOS' && format('{0}{1}', (matrix.os == 'macos-15-intel' && '/usr/local/opt/' || '/opt/homebrew/opt/'), matrix.compiler.macos_cc) || matrix.compiler.cc }}
-          compiler_executable_cxx: ${{ runner.os == 'macOS' && format('{0}{1}', (matrix.os == 'macos-15-intel' && '/usr/local/opt/' || '/opt/homebrew/opt/'), matrix.compiler.macos_cxx) || matrix.compiler.cxx }}
+          compiler_executable_c: ${{ runner.os == 'macOS' && format('{0}{1}', ((matrix.os == 'macos-15-intel' || matrix.os == 'macos-26-intel') && '/usr/local/opt/' || '/opt/homebrew/opt/'), matrix.compiler.macos_cc) || matrix.compiler.cc }}
+          compiler_executable_cxx: ${{ runner.os == 'macOS' && format('{0}{1}', ((matrix.os == 'macos-15-intel' || matrix.os == 'macos-26-intel') && '/usr/local/opt/' || '/opt/homebrew/opt/'), matrix.compiler.macos_cxx) || matrix.compiler.cxx }}
           build_type: ${{ steps.build_types.outputs.first }}
           extra_cxxflags: ${{ matrix.extra_cxxflags }}
       - name: Install dependencies (Debug)


### PR DESCRIPTION
macOS 26 on Intel is generally available on GitHub Actions. We already build on `macos-26` (Apple Silicon) and on `macos-15-intel`, so this closes the gap — and it matters for continuity: GitHub has `macos-15-intel` scheduled for retirement, the same way `macos-14` has just been dropped, and without this the matrix loses x86_64 macOS coverage entirely when that happens.

Homebrew installs under `/usr/local` rather than `/opt/homebrew` on Intel, so the compiler path expression now covers `macos-26-intel` the same way it already covers `macos-15-intel`.

## Which event builds it

#639 made the os axis depend on the event: a pull request builds `macos-15` plus every Linux runner, and a push to a release branch or a tag builds all of them. `macos-26-intel` joins the second list only.

That follows #639's own reasoning rather than making an exception to it: the images it left off pull requests are `macos-15-intel`, because x86_64 is the architecture the Linux runners cover thoroughly, and `macos-26`, because it is a second Darwin SDK behind the same architecture as `macos-15`. `macos-26-intel` is both of those things at once. Putting it in the pull request list would add four macOS jobs to every pull request, against five concurrent macOS runners, for a combination neither dropped image was considered worth keeping.

The consequence, stated plainly: **this PR's own run does not exercise the jobs it adds**, because they do not exist on a `pull_request` event. What covers them is the restricted `macos-26-intel` run recorded below, which is also what measured the two exclusions. The first push run on `release/1.0` after this merges is where they first appear in a normal run.

## Which compilers run there

Being macOS 26, it inherits the `macos-26` exclusions — no `llvm@13`, `llvm@14` or `llvm@15` bottles, and the GCC formulas are often incompatible on macOS. A full run on the image turned up two more.

**Clang 16 fails to install.** Homebrew's `llvm@16` depends on `python@3.12`, and linking that collides with the python.org framework Python the image ships:

```
==> Installing llvm@16 dependency: python@3.12
==> Pouring python@3.12--3.12.14.tahoe.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/2to3-3.12
Target /usr/local/bin/2to3-3.12
already exists.
...
Possible conflicting files are:
/usr/local/bin/2to3-3.12 -> /Library/Frameworks/Python.framework/Versions/3.12/bin/2to3-3.12
```

`llvm@16` itself pours fine a few lines later, but `brew` has already exited non-zero, so `Setup MacOS` fails. `macos-15-intel` excludes Clang 16 for the same reason.

**Clang 18 fails to build.** Anything linked with `-stdlib=libc++` against the MacOSX26 SDK dies in the very first CMake compiler check, before any of our own code is touched:

```
-- Check for working CXX compiler: /usr/local/opt/llvm@18/bin/clang++ - broken
    /usr/local/opt/llvm@18/bin/clang++ -m64 -stdlib=libc++ -arch x86_64
      -isysroot .../MacOSX26.5.sdk -m64 CMakeFiles/cmTC_3fabd.dir/testCXXCompiler.cxx.o -o cmTC_3fabd
    ld: library 'c++' not found
```

`macos-15-intel` excludes Clang 18 as well.

That leaves Clang 17, 19, 20 and 21 — **four new jobs**, each building and testing all three build types. It was two when this branch was written; clang 20 (#603) and clang 21 (#602) have since landed on `release/1.0` and apply to every image that does not exclude them, this one included.

## Verification

A run restricted to `macos-26-intel` exercised every compiler the image would otherwise get *at the time*, so the exclusions are measured rather than assumed. That run predates the matrix being refolded, so each build type was still a separate job at the time; all three now run inside one job per compiler, and the evidence carries over unchanged:

| compiler | Debug | Release | RelWithDebInfo |
|---|---|---|---|
| Clang 16 | ❌ install | ❌ install | ❌ install |
| Clang 17 | ✅ | ✅ | ✅ |
| Clang 18 | ❌ build | ❌ build | — |
| Clang 19 | ✅ | ✅ | ✅ |

**Clang 20 and 21 on this image are inferred, not observed.** They did not exist in the matrix when that run happened, and they run on no `pull_request` event, so nothing here has built them on `macos-26-intel`. They reach it by not being excluded — the same way they reach `macos-15-intel`, where they are equally unobserved. If either needs an exclusion on this image, the first push run on `release/1.0` is where it will show, and I will add it.

Matrix resolved before and after, against `release/1.0` as it stands with gcc 15 (#600), gcc 16 (#629), clang 20 (#603) and clang 21 (#602) already landed:

| event | before | after |
|---|---|---|
| pull request | 56 | 56 |
| push to a release branch, tag | 67 | 71 |

The pull request count is unchanged **by design** — this PR costs nothing on a pull request. The four added are exactly `macos-26-intel` with Clang 17, 19, 20 and 21, none removed, and no `exclude` entry is left matching nothing.

One thing worth noting for anyone editing this file later: the `exclude:` entries spell out the *entire* compiler dict, `apt_package` included, so they only apply on an exact match. The entries here were regenerated from the current strings after #598 changed every clang package list — copying the pre-#598 ones would have left exclusions that silently match nothing and put every GCC back on macOS.

## Ordering

This is now the bottom of the compiler stack, with #645 sitting on top of it. gcc 16 (#629), clang 20 (#603) and clang 21 (#602) landed underneath and were merged back in, which is why the branch carries a merge commit — each squash merge shares no ancestry with the stack, so it left this branch's merge base behind and inflated the diff to re-show everything below it. The merge had one conflict, the macos-26-intel exclusion block against nothing on `release/1.0`; it was resolved by keeping the block, and the resolved matrix was checked to be identical to this branch before the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu