### PR TITLE
CI: Add clang 21

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,13 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: gcc
+            version: 16
+            libcxx: libstdc++11
+            cc: gcc-16
+            cxx: g++-16
+            apt_package: g++-16
+            homebrew_package: gcc@16
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx
@@ -224,6 +231,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           - os: macos-15-intel
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           - os: macos-15-intel
@@ -240,6 +249,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15-intel
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15-intel
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           # MacOS 15-intel fails to build with Clang 14
           - os: macos-15-intel
             compiler: {compiler: clang, version: 14, libcxx: libc++, cc: clang-14, cxx: clang++-14, macos_cc: llvm@14/bin/clang, macos_cxx: llvm@14/bin/clang++, apt_package: "clang-14 libc++-14-dev libc++abi-14-dev libunwind-14-dev libomp-14-dev", homebrew_package: llvm@14}
@@ -265,12 +276,18 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-26
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 22.04 doesn't have gcc 13, 14 yet
+          - os: macos-26
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
+          # Ubuntu 22.04 doesn't have gcc 13, 14 or 16
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 24.04 doesn't have clang 13 anymore
+          - os: ubuntu-22.04
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
+          # Ubuntu 24.04 doesn't have gcc 16, and doesn't have clang 13 anymore
+          - os: ubuntu-24.04
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           - os: ubuntu-24.04
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           # Ubuntu 26.04 has neither clang 13 to 16 nor gcc 9 and 10 anymore

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,15 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: clang
+            version: 21
+            libcxx: libc++
+            cc: clang-21
+            cxx: clang++-21
+            macos_cc: llvm@21/bin/clang
+            macos_cxx: llvm@21/bin/clang++
+            apt_package: clang-21 libc++-21-dev libc++abi-21-dev libunwind-21-dev libomp-21-dev
+            homebrew_package: llvm@21
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,15 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: clang
+            version: 20
+            libcxx: libc++
+            cc: clang-20
+            cxx: clang++-20
+            macos_cc: llvm@20/bin/clang
+            macos_cxx: llvm@20/bin/clang++
+            apt_package: clang-20 libc++-20-dev libc++abi-20-dev libunwind-20-dev libomp-20-dev
+            homebrew_package: llvm@20
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx


### PR DESCRIPTION
Both apt.llvm.org and Homebrew package LLVM 21, and conan accepts it — #596 moved us to conan 2.32, whose `default_settings.py` lists clang up to 22.

It needs no exclusions anywhere: it builds and tests clean on every image in the matrix. **One new job per image**, each building and testing all three build types.

## Where each job gets its packages

| image | source | version |
|---|---|---|
| ubuntu-22.04 | apt.llvm.org, `llvm-toolchain-jammy-21` | 1:21.1.8~++20251221… |
| ubuntu-24.04 | apt.llvm.org, `llvm-toolchain-noble-21` | 1:21.1.8~++20251221… |
| ubuntu-26.04 | Ubuntu's own archive | 1:21.1.8-6ubuntu1 |
| macOS | Homebrew `llvm@21` | |

`libunwind-21-dev` is listed explicitly, the same way it is for every other clang since #598 — and here it is load-bearing rather than redundant. Neither apt.llvm.org's `libc++-21-dev` nor Ubuntu 26.04's depends on it:

```
Package: libc++-21-dev
Depends: libc++1 (>= 1:21.1.8…), libc++abi-21-dev (= 1:21.1.8…)
```

libc++abi's unwinder is LLVM's libunwind, so without naming it the link fails on `-lunwind`. (For clang ≤ 19 apt.llvm.org's `libc++-<v>-dev` does depend on it, which is why nothing noticed before.)

## Verification

Two runs, because the matrix moved underneath this branch while it was waiting. Both predate the matrix being refolded, so each build type was still a separate job at the time; all three now run inside one job per image, and the evidence carries over unchanged.

**[Run 34150490690](https://github.com/cryfs/cryfs/actions/runs/34150490690) — 18/18 green**, restricted to the new clang 21 jobs:

| image | Debug | Release | RelWithDebInfo |
|---|---|---|---|
| ubuntu-22.04 | ✅ | ✅ | ✅ |
| ubuntu-24.04 | ✅ | ✅ | ✅ |
| macos-14 | ✅ | ✅ | ✅ |
| macos-15 | ✅ | ✅ | ✅ |
| macos-15-intel | ✅ | ✅ | ✅ |
| macos-26 | ✅ | ✅ | ✅ |

Worth noting that `macos-15-intel` passes, since that image excludes clang 14, 16 and 18 for reasons of its own. `macos-14` has since been dropped from the matrix by #596, so that row no longer corresponds to a job. Unlike #603, macOS here rests on an actual green run rather than on the exclusion list.

That run predates both `ubuntu-26.04` joining the matrix and #598's package-list change, so it does **not** cover what this PR actually ships — it used the older `libomp5` spelling and never touched `ubuntu-26.04`.

**[Run 34223915282](https://github.com/cryfs/cryfs/actions/runs/34223915282) — 6/6 green** is what covers the shipped package list: clang 20 and clang 21, three build types each, on `ubuntu-26.04`, installing from Ubuntu's archive with `libunwind-21-dev` named explicitly.

Matrix resolved before and after, against `release/1.0` as it stands with gcc 15 (#600), gcc 16 (#629) and clang 20 (#603) already landed. The os axis became event-dependent in #639, so there are two numbers:

| event | before | after | jobs added |
|---|---|---|---|
| pull request | 52 | 56 | macos-15, ubuntu-22.04, ubuntu-24.04, ubuntu-26.04 |
| push to a release branch, tag | 61 | 67 | the four above plus macos-15-intel and macos-26 |

The added jobs are exactly the clang 21 ones, none removed, and no `exclude` entry is left matching nothing.

## Ordering

Depends on #599, already merged. From LLVM 20 on, apt.llvm.org ships the runtimes under unversioned names, so two such repositories cannot be enabled at once; #599 is what makes each job enable only the one repository it needs. Without it, adding clang 21 alongside clang 20 breaks clang 20's install.

This is now the bottom of the compiler stack: #601 (macos-26-intel) sits on this branch and #645 on top of that, so they should land in that order. clang 20 (#603) landed underneath it and was merged back in, which is why the branch carries a merge commit — that squash merge shares no ancestry with the stack, so it left this branch's merge base behind and briefly inflated the diff to re-show gcc 16 and clang 20 as well. The merge had one conflict, in the compiler list where clang 20 and clang 21 both follow clang 19; it was resolved by keeping both in ascending order, and the resolved matrix was checked to be identical to this branch before the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu