### PR TITLE
CI: Add clang 20

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,13 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: gcc
+            version: 16
+            libcxx: libstdc++11
+            cc: gcc-16
+            cxx: g++-16
+            apt_package: g++-16
+            homebrew_package: gcc@16
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx
@@ -224,6 +231,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           - os: macos-15-intel
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           - os: macos-15-intel
@@ -240,6 +249,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15-intel
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15-intel
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           # MacOS 15-intel fails to build with Clang 14
           - os: macos-15-intel
             compiler: {compiler: clang, version: 14, libcxx: libc++, cc: clang-14, cxx: clang++-14, macos_cc: llvm@14/bin/clang, macos_cxx: llvm@14/bin/clang++, apt_package: "clang-14 libc++-14-dev libc++abi-14-dev libunwind-14-dev libomp-14-dev", homebrew_package: llvm@14}
@@ -265,12 +276,18 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-26
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 22.04 doesn't have gcc 13, 14 yet
+          - os: macos-26
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
+          # Ubuntu 22.04 doesn't have gcc 13, 14 or 16
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 24.04 doesn't have clang 13 anymore
+          - os: ubuntu-22.04
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
+          # Ubuntu 24.04 doesn't have gcc 16, and doesn't have clang 13 anymore
+          - os: ubuntu-24.04
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           - os: ubuntu-24.04
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           # Ubuntu 26.04 has neither clang 13 to 16 nor gcc 9 and 10 anymore

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,15 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: clang
+            version: 20
+            libcxx: libc++
+            cc: clang-20
+            cxx: clang++-20
+            macos_cc: llvm@20/bin/clang
+            macos_cxx: llvm@20/bin/clang++
+            apt_package: clang-20 libc++-20-dev libc++abi-20-dev libunwind-20-dev libomp-20-dev
+            homebrew_package: llvm@20
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx


### PR DESCRIPTION
LLVM 20 has been out for a while and both apt.llvm.org and Homebrew package it, so we can build and test against it.

**One new job per image**, each building and testing all three build types. No exclusions.

## Where each job gets its packages

| image | source | version |
|---|---|---|
| ubuntu-22.04 | apt.llvm.org, `llvm-toolchain-jammy-20` | 1:20.1.8~++20250708… |
| ubuntu-24.04 | apt.llvm.org, `llvm-toolchain-noble-20` | 1:20.1.8~++20250708… |
| ubuntu-26.04 | Ubuntu's own archive | 1:20.1.8-2ubuntu8 |
| macOS | Homebrew `llvm@20` | |

`libunwind-20-dev` is listed explicitly, as it is for every other clang since #598. apt.llvm.org's `libc++-20-dev` happens to depend on it, but Ubuntu 26.04's does not:

```
# apt.llvm.org
Package: libc++-20-dev
Depends: libc++1 (= 1:20.1.8…), libc++abi-20-dev (= 1:20.1.8…), libunwind-20-dev

# ubuntu-26.04 archive
Package: libc++-20-dev
Depends: libc++1 (>= 1:20.1.8-2ubuntu8), libc++abi-20-dev (= 1:20.1.8-2ubuntu8)
```

libc++abi's unwinder is LLVM's libunwind, so the link needs `-lunwind` either way.

## Why this needs #599 first

This is the change that surfaced the apt.llvm.org problem in the first place. From LLVM 20 on, apt.llvm.org ships the runtimes under unversioned names (`libc++1`, `libc++abi1`, `libunwind`) rather than `libc++1-<version>`. With the LLVM 20 and 21 repositories both enabled — which is what `setup_linux` used to do unconditionally — all the Ubuntu clang 20 jobs died in `Setup Linux`:

```
libc++-20-dev : Depends: libc++1 (= 1:20.1.8~++2025...) but 1:21.1.8~++2025... is to be installed
E: Unable to correct problems, you have held broken packages.
```

#599 (merged) makes each job enable only the one repository it needs, which is what makes clang 20 installable at all.

## Verification

Both runs predate the matrix being refolded, so each build type was still a separate job at the time; all three now run inside one job per image, and the evidence carries over unchanged.

- **[Run 34175073896](https://github.com/cryfs/cryfs/actions/runs/34175073896) — 6/6 green.** The Linux clang 20 jobs on `ubuntu-22.04` and `ubuntu-24.04`, all three build types each. This is the run that confirms #599 fixed the install failure above.
- **[Run 34223915282](https://github.com/cryfs/cryfs/actions/runs/34223915282) — 6/6 green.** clang 20 and clang 21 on `ubuntu-26.04`, all three build types each. That image was not in the matrix when the run above happened, and it installs from Ubuntu's archive rather than apt.llvm.org, so it needed checking separately. This run also covers the shipped package list, including the explicit `libunwind-20-dev`.

**macOS clang 20 is still unobserved, and I would rather say so than imply otherwise.** A run restricted to the macOS clang 20 jobs was pushed and, ~14 hours later, not one of its jobs had been assigned a runner — `runner_id: 0` across all four labels — while both older and newer runs in this repository were served and completed. The most recent full run on this branch ([34708445609](https://github.com/cryfs/cryfs/actions/runs/34708445609)) told the same story from the other side: 53 of 59 jobs green, and the only six outstanding were the `macos-15` clang jobs, still queued twelve hours in. So every Linux and Windows job passes and the macOS side rests on the exclusion list being right rather than on a green run. If a macOS image turns out to need an exclusion, it will show up here and I will add it.

Matrix resolved before and after, against `release/1.0` as it stands with gcc 15 (#600) and gcc 16 (#629) already landed. The os axis became event-dependent in #639, so there are two numbers:

| event | before | after | jobs added |
|---|---|---|---|
| pull request | 48 | 52 | macos-15, ubuntu-22.04, ubuntu-24.04, ubuntu-26.04 |
| push to a release branch, tag | 55 | 61 | the four above plus macos-15-intel and macos-26 |

The added jobs are exactly the clang 20 ones, none removed, and no `exclude` entry is left matching nothing.

## Ordering

Depends on #599, already merged. This is now the bottom of the compiler stack: #602 (clang 21) sits on this branch, #601 (macos-26-intel) on that, and #645 on top, so they should land in that order. gcc 16 (#629) landed underneath it and was merged back in, which is why the branch carries a merge commit — that squash merge left this branch's merge base behind and briefly inflated the diff to re-show the whole gcc 16 change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu