### PR TITLE
Update GoogleTest to 1.17.0

### DIFF
--- a/.github/workflows/actions/install_local_dependencies/action.yaml
+++ b/.github/workflows/actions/install_local_dependencies/action.yaml
@@ -81,8 +81,8 @@ runs:
 
         echo Install googletest
         cd ~
-        wget https://github.com/google/googletest/releases/download/v1.15.0/googletest-1.15.0.tar.gz -O gtest.tar.gz
-        if [ $(sha512sum gtest.tar.gz | awk '{print $1;}') == "1a623022f932925b7dc3e557c14cc81c5edc0631ca92cc94b5f80968c5ad38003880282129b71a99e4ee56d7204db71a156f5af12d79021cfad4417c2f80cc4b" ]; then
+        wget https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz -O gtest.tar.gz
+        if [ $(sha512sum gtest.tar.gz | awk '{print $1;}') == "0f57e9ef06925e5b7722df1eb92ef5850e8dce79220ea16a8aaff586a71c0b01460ef1713649ee24ffedb2e6ad5a51e9198c5a5ae1b2789e43feb1f494e7d45c" ]; then
           echo Correct sha512sum
         else
           echo Wrong sha512sum
@@ -90,7 +90,7 @@ runs:
           exit 1
         fi
         tar -xvf gtest.tar.gz
-        cd googletest-1.15.0
+        cd googletest-1.17.0
         mkdir build
         cd build
         cmake .. -GNinja

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -50,6 +50,7 @@ Version 1.1.0 (unreleased)
 Dependency Updates
 * Fuse 3.9 on Linux and macOS (was: Fuse 2.9), still Fuse 2.7 via DokanY on Windows
 * spdlog 1.17.0 (was: 1.14.1)
+* gtest 1.17.0 (was: 1.15.0), test-only dependency
 
 
 Version 1.0.3

--- a/conanfile.py
+++ b/conanfile.py
@@ -135,7 +135,7 @@ class CryFSConan(ConanFile):
         if self.options.update_checks:
             self.requires("libcurl/8.9.1")
         if self.options.build_tests:
-            self.requires("gtest/1.15.0")
+            self.requires("gtest/1.17.0")
 
     def layout(self):
         cmake_layout(self)


### PR DESCRIPTION
Bumps GoogleTest from 1.15.0 to **1.17.0**, in `conanfile.py` and in the local-dependencies CI path (which the two must be kept in sync).

`gtest/1.15.0` is no longer in conan-center-index at all — its `config.yml` now lists only 1.16.0, 1.17.0 and 1.18.0. Published recipe revisions stay downloadable, so CI has kept working, but we are pinned to a version the index has dropped.

## Why 1.17.0 and not 1.18.0

1.18.0 deprecates the single-argument form of `Invoke()`:

```
error: 'testing::Invoke(FunctionImpl&&)' is deprecated: Actions can now be
implicitly constructed from callables. No need to create wrapper objects
using Invoke(). [-Werror=deprecated-declarations]
```

`GTEST_INTERNAL_DEPRECATE_AND_INLINE` expands to a plain `[[deprecated]]` there, ungated. We call single-argument `Invoke()` **42 times across 20 test files**, and two CI jobs build with `use_werror=True`, so 1.18.0 would turn every one of those into a hard error.

Adopting 1.18.0 means rewriting all 42 call sites — a change to the tests rather than a dependency bump, so it belongs in its own commit if we want it at all. This was verified by compiling a probe against 1.16.0, 1.17.0 and 1.18.0 with our exact warning flags: clean on the first two, failing on 1.18.0 under both g++ and clang++.

## C++ standard floor is fine

`gtest-port.h` raised its minimum from C++14 to C++17 in 1.17.0 (`#error C++ versions less than C++17 are not supported`), and the conan recipe enforces the same via `check_min_cppstd(17)` for `>= 1.17.0`. We are already C++17 everywhere — `conanfile.py`'s `validate()` calls `check_min_cppstd("17")` and `cmake-utils/utils.cmake` sets `CXX_STANDARD 17`, despite the function still being named `target_activate_cpp14()`.

**No version of GoogleTest requires C++20**, so that is not what rules out 1.18.0.

## Nothing else in the range reaches us

| Change | Applies? |
| --- | --- |
| C++14 → C++17 minimum (1.17.0) | No — already C++17 |
| `[[nodiscard]]` replaces `GTEST_MUST_USE_RESULT_` | No — was already `warn_unused_result` on GCC/Clang |
| Deprecated `*_TEST_CASE_*` macro names | No — zero uses; we are on `*_TEST_SUITE_*` already |
| `testing::internal::Capture{Stdout,Stderr}` | No — signatures byte-identical across the range |
| Legacy `FLAGS_gtest_death_test_style` form | No — still supported; our death tests compile and run |
| gmock: `MOCK_METHOD`, `NiceMock`, `ON_CALL`, `EXPECT_CALL`, matchers | No — all 73 `MOCK_METHOD` uses are new-style |
| `AllOf` short-circuit removal, `DeleteArg` deprecation, absl polyfill removal | No — 1.18.0 only, not reached here |

The custom main in `test/my-gtest-main` is 28 lines and calls only `InitGoogleMock` and `RUN_ALL_TESTS`, both stable public API.

**No CryFS source or test changes are required.**

## Verification

- sha512 recomputed from the downloaded 1.17.0 tarball (885,595 bytes); the same method reproduces the recorded 1.15.0 hash exactly, so the pin is verified rather than assumed
- Tarball URL pattern unchanged; extracted directory confirmed as `googletest-1.17.0/`
- `cmake .. -GNinja && ninja && ninja install` executed successfully, producing the `GTest::gtest` / `GTest::gmock` targets that `cmake-utils/Dependencies.cmake` expects. No new required CMake options.

## Worth watching in CI

Google's support floor is now GCC >= 10 and Clang >= 14, while our matrix still builds **gcc 9 and clang 13 on ubuntu-22.04**. That is a support policy rather than an `#error`, and 1.17.0 uses only C++17 attributes those compilers accept — but if anything surprises us, that is where it will show up first.

Secondary: the recipe adds `tool_requires("cmake/[>=3.16]")` for `>= 1.17.0`, so profiles without a prebuilt gtest binary will now also pull a cmake tool package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj

---
_Generated by [Claude Code](https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj)_