### PR TITLE
Update DokanY to 2.3.1.1000

### DIFF
--- a/.github/workflows/actions/setup_windows/action.yaml
+++ b/.github/workflows/actions/setup_windows/action.yaml
@@ -9,8 +9,8 @@ runs:
         set -v
         set -e
         choco install -y ninja wget ccache
-        wget https://github.com/dokan-dev/dokany/releases/download/v2.2.0.1000/Dokan_x64.msi
-        if [ $(sha512sum Dokan_x64.msi | awk '{print $1;}') == "018617c4af939e03e0f4e6e0cbe0ef4797f53a285b48d945d194464e510d46f7d6fbace4fc19de71edac36e6d1c76f771282329330292741e6ac83f78c3afe0b" ]; then
+        wget https://github.com/dokan-dev/dokany/releases/download/v2.3.1.1000/Dokan_x64.msi
+        if [ $(sha512sum Dokan_x64.msi | awk '{print $1;}') == "87f3dee76606cddcb60ede11c699fae430194687e10fa4c1c3d76822893020f092fdb8ec7b2de80626886870f789d9bd0b70facc92120a65d4164063e4c56708" ]; then
           echo Correct sha512sum
         else
           echo Wrong sha512sum

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -789,7 +789,7 @@ jobs:
         with:
           build_type: ${{ matrix.build_type }}
           build_tests: "True"
-          extra_conan_flags: "-o '&:windows_dokany_path=C:/Program Files/Dokan/DokanLibrary-2.2.0'"
+          extra_conan_flags: "-o '&:windows_dokany_path=C:/Program Files/Dokan/DokanLibrary-2.3.1'"
       - name: Save ccache
         uses: ./.github/workflows/actions/ccache/cache
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ option(USE_IWYU "build with iwyu checks enabled" OFF)
 option(CLANG_TIDY_WARNINGS_AS_ERRORS "treat clang-tidy warnings as errors" OFF)
 
 if (MSVC)
-  option(DOKAN_PATH "Location of the Dokan library, e.g. C:\\Program Files\\Dokan\\DokanLibrary-2.2.0" "")
+  option(DOKAN_PATH "Location of the Dokan library, e.g. C:\\Program Files\\Dokan\\DokanLibrary-2.3.1" "")
 endif()
 
 # Default value is to build in release mode but with debug symbols

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -7,7 +7,7 @@
       "inheritEnvironments": [ "msvc_x86" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_TESTING=on -DDOKAN_PATH=\"C:\\Program Files\\Dokan\\Dokan Library-2.2.0\"",
+      "cmakeCommandArgs": "-DBUILD_TESTING=on -DDOKAN_PATH=\"C:\\Program Files\\Dokan\\DokanLibrary-2.3.1\"",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
@@ -18,7 +18,7 @@
       "inheritEnvironments": [ "msvc_x86" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_TESTING=on -DDOKAN_PATH=\"C:\\Program Files\\Dokan\\Dokan Library-2.2.0\"",
+      "cmakeCommandArgs": "-DBUILD_TESTING=on -DDOKAN_PATH=\"C:\\Program Files\\Dokan\\DokanLibrary-2.3.1\"",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
@@ -29,7 +29,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_TESTING=on -DDOKAN_PATH=\"C:\\Program Files\\Dokan\\Dokan Library-2.2.0\"",
+      "cmakeCommandArgs": "-DBUILD_TESTING=on -DDOKAN_PATH=\"C:\\Program Files\\Dokan\\DokanLibrary-2.3.1\"",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     },
@@ -40,7 +40,7 @@
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
       "installRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\install\\${name}",
-      "cmakeCommandArgs": "-DBUILD_TESTING=on -DDOKAN_PATH=\"C:\\Program Files\\Dokan\\Dokan Library-2.2.0\"",
+      "cmakeCommandArgs": "-DBUILD_TESTING=on -DDOKAN_PATH=\"C:\\Program Files\\Dokan\\DokanLibrary-2.3.1\"",
       "buildCommandArgs": "-v",
       "ctestCommandArgs": ""
     }

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -52,6 +52,9 @@ Dependency Updates
 * spdlog 1.17.0 (was: 1.14.1)
 * gtest 1.17.0 (was: 1.15.0), test-only dependency
 * boost 1.91.0 (was: 1.84.0)
+* DokanY 2.3.1.1000 on Windows (was: 2.2.0.1000). If you already have DokanY 2.2.0.1000
+  installed, uninstall it and reboot before installing 2.3.1.1000. Since DokanY 2.3.0 the
+  installer refuses to install over an existing DokanY 2.x instead of upgrading in place.
 
 
 Version 1.0.3

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ CryFS has experimental Windows support since the 0.10 release series. To install
 
 1. Install [DokanY](https://github.com/dokan-dev/dokany/releases)
    It's recommended to install the matching version DokanY a given CryFS version was built with. Other versions may work but we have seen issues.
+   * CryFS 1.1: DokanY 2.3.1.1000
    * CryFS 1.0: DokanY 2.2.0.1000
    * CryFS 0.11: DokanY 1.2.2.1001
 2. Install the [Microsoft Visual C++ Redistributable](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) from Visual Studio 2026 or newer
@@ -173,10 +174,10 @@ Then run the tests:
 Building on Windows (experimental)
 ----------------------------------
 1. Install conan2. If you want to use "pip install conan", you may have to install Python first.
-2. Install DokanY 2.2.0.1000. Other versions may not work.
+2. Install DokanY 2.3.1.1000. Other versions may not work.
 3. Build the project
 
-        $ conan build . --build=missing -o "&:windows_dokany_path=C:/Program Files/Dokan/DokanLibrary-2.2.0"
+        $ conan build . --build=missing -o "&:windows_dokany_path=C:/Program Files/Dokan/DokanLibrary-2.3.1"
 
 The Windows build is tested with Visual Studio 2022 on Windows Server 2022, and with
 Visual Studio 2026 on Windows Server 2025.


### PR DESCRIPTION
Bumps DokanY from 2.2.0.1000 to **2.3.1.1000**. Unlike our other dependency pins this one is user-facing — the README asks people to install the exact version CryFS was built against — so it touches CI, docs and the ChangeLog together.

## Compatibility, checked against the ABI rather than the release notes

The FUSE headers we compile against are **byte-identical** between the two tags. `git diff v2.2.0.1000 v2.3.1.1000 -- dokan_fuse/include/` touches only `fusemain.h`, which is not an installed header. `fuse.h`, `fuse_common.h`, `fuse_opt.h` and `fuse_win.h` are untouched.

| Question | Answer |
| --- | --- |
| FUSE API version exposed | Still **2.7** (`fuse_common.h` unchanged) |
| `struct fuse_operations` layout / signatures | Unchanged — all 27 members wired up in `Fuse.cpp:353-397` unaffected |
| `dokan2.dll` / `dokanfuse2.dll` exports | Unchanged (`dokan.def`, `dokanfuse.def` byte-identical) |
| `DOKAN_DRIVER_VERSION` | Still `0x190` = **400** |
| Our hardcoded `!= 400` check (`Fuse.cpp:470`) | **Still passes** — this was the highest-risk item |
| Installed directory layout | Unchanged (`lib/`, `include/`, `x86/`, dev files still gated on `INSTALLDEVFILES=1`) |

The one source-level rename — `DOKAN_FILE_INFO.DeleteOnClose` → `DeletePending` — does not reach us: same type, same struct offset, and we never reference `DOKAN_FILE_INFO` or `DOKAN_OPERATIONS` at all, only `<dokan/dokan.h>` for the version check.

**2.3.1 rather than 2.3.0** because 2.3.0's installer gates `CheckServicePresent` on `DOKANSERVICEALREADYPRESENT` alone, which also fires during uninstall and leaves users unable to remove it. 2.3.1 narrows it to `Not REMOVE="ALL" AND DOKANSERVICEALREADYPRESENT`.

## Sites updated

CI download URL + sha512, the `windows_dokany_path` conan flag, the `CMakeLists.txt` option help text, three README locations, `CMakeSettings.json`, and a ChangeLog entry.

The install directory is `DokanLibrary-2.3.1`, confirmed **twice** — from the WiX source (`Name="DokanLibrary-$(var.BaseVersion)"` with `BaseVersion` 2.3.1) and from the Directory table inside the downloaded MSI. Guessing this wrong would fail the Windows link step rather than anything obvious.

## Two judgement calls

**The README's per-version list gains a row rather than having 2.2.0.1000 replaced.** It maps a CryFS release to the DokanY it was built with, so the `CryFS 1.0:` row is still correct for everyone running 1.0.x today. Rewriting it in place would tell those users to install a DokanY their binary was not built against — the opposite of what the sentence above the list promises. `ChangeLog.txt` line 107 is left alone for the same reason.

**`CMakeSettings.json` said `Dokan Library-2.2.0`, with a space.** That is the DokanY **1.x** directory layout — 2.x has always installed to `DokanLibrary-<ver>` — so the Visual Studio integration has been pointing at a nonexistent path since we moved to DokanY 2. Fixed here as a drive-by, since the line was being touched anyway. Happy to split it out if you would rather keep this PR pure.

## User-facing upgrade note

DokanY 2.3.0 removed in-place major upgrades. The MSI now aborts if any DokanY 2.x is present:

> A previous version of Dokan Library is already installed. Please uninstall the existing version first, reboot the system and start the setup again.

Users on 2.2.0.1000 must uninstall and reboot before installing 2.3.1.1000. That is the part most likely to generate bug reports, so it is called out in the ChangeLog entry rather than left to be discovered.

## What CI proves here, and what it does not

The Windows job installs the MSI and links against `dokan2.lib` and `dokanfuse2.lib`, so a missing export or a wrong install path fails loudly and immediately.

But **`fspp-test` and `cryfs-cli-test` are both commented out on Windows**. Nothing in CI mounts a filesystem, opens a file, deletes one, or exercises a single `fuse_operations` callback through the driver. Green CI here means "it compiles, links, and the DLLs load" — no more.

That matters because 2.3.0 reworked delete semantics: `cleanup()` now keys off `DeletePending`, so deletion fires on the **last** handle close rather than any handle. Semantically more correct for our stateless `unlink`/`rmdir`, but a real runtime change that CI cannot see.

**Suggested manual check before the 1.1.0 release:** install DokanY 2.3.1.1000, build with `-o "&:windows_dokany_path=C:/Program Files/Dokan/DokanLibrary-2.3.1"`, mount, then exercise create / write / read / rename / delete file / delete non-empty directory / delete-while-open, and unmount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj

---
_Generated by [Claude Code](https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj)_