### PR TITLE
Update spdlog to 1.17.0

### DIFF
--- a/.github/workflows/actions/install_local_dependencies/action.yaml
+++ b/.github/workflows/actions/install_local_dependencies/action.yaml
@@ -41,8 +41,8 @@ runs:
 
         echo Download spdlog
         cd ~
-        wget https://github.com/gabime/spdlog/archive/refs/tags/v1.14.1.tar.gz -O spdlog.tar.gz
-        if [ $(sha512sum spdlog.tar.gz | awk '{print $1;}') == "d8f36a3d65a43d8c64900e46137827aadb05559948b2f5a389bea16ed1bfac07d113ee11cf47970913298d6c37400355fe6895cda8fa6dcf6abd9da0d8f199e9" ]; then
+        wget https://github.com/gabime/spdlog/archive/refs/tags/v1.17.0.tar.gz -O spdlog.tar.gz
+        if [ $(sha512sum spdlog.tar.gz | awk '{print $1;}') == "8df117055d19ff21c9c9951881c7bdf27cc0866ea3a4aa0614b2c3939cedceab94ac9abaa63dc4312b51562b27d708cb2f014c68c603fd1c1051d3ed5c1c3087" ]; then
           echo Correct sha512sum
         else
           echo Wrong sha512sum
@@ -51,7 +51,7 @@ runs:
         fi
         tar -xvf spdlog.tar.gz
         rm spdlog.tar.gz
-        cd spdlog-1.14.1
+        cd spdlog-1.17.0
 
         echo Install spdlog
         mkdir build

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -49,6 +49,7 @@ Version 1.1.0 (unreleased)
 
 Dependency Updates
 * Fuse 3.9 on Linux and macOS (was: Fuse 2.9), still Fuse 2.7 via DokanY on Windows
+* spdlog 1.17.0 (was: 1.14.1)
 
 
 Version 1.0.3

--- a/conanfile.py
+++ b/conanfile.py
@@ -130,7 +130,7 @@ class CryFSConan(ConanFile):
      
     def requirements(self):
         self.requires("range-v3/cci.20240905")
-        self.requires("spdlog/1.14.1")
+        self.requires("spdlog/1.17.0")
         self.requires("boost/1.84.0")
         if self.options.update_checks:
             self.requires("libcurl/8.9.1")


### PR DESCRIPTION
Bumps spdlog from 1.14.1 to **1.17.0** in `conanfile.py`, the local-dependencies CI path, and the ChangeLog.

1.17.0 is both the newest upstream tag and the conan-center ceiling, so there is no gap between what we can pin and what exists.

## The fmt jump is the only real question

The recipe's `fmt_version_mapping` goes 1.14.1 → **fmt 10.2.1** and 1.17.0 → **fmt 12.1.0**. Two majors. It does not reach us, for two specific reasons:

**Every format argument is natively formattable.** All LOG call sites pass `std::string`, `const char*`, `int`, `double`, `bool` or `mode_t`. There are **no `fmt::formatter` specializations anywhere in the tree**, so there is nothing for fmt's stricter rules to break.

**The consteval path is never entered.** `logging.h` takes a runtime `const char* fmt`, which would be the classic breakage against fmt's compile-time format-string checking — but `FMT_USE_CONSTEVAL` is gated off below C++20 (`FMT_CPLUSPLUS < 201709L` in `base.h`) and we build as C++17. Verified by compiling, not by reading the guard.

## Verified empirically, not just from changelogs

A faithful repro of `Logger.h` / `logging.h` plus every call shape in `LoggingTest.cpp`:

| Test | Result |
| --- | --- |
| g++ 13 / clang++ 18, C++17, 1.17.0 | compiles, runs, output identical in shape to 1.14.1 |
| **g++ 9** — oldest compiler in our matrix | compiles and runs correctly |
| g++ 9 + our exact `-Werror` flag set | clean, zero warnings |
| `find_package(spdlog)` → `spdlog::spdlog` → link → run | passes |
| CI local-deps recipe replay (tar, cmake, make) | builds clean |

Output matched every regex asserted in `test/cpp-utils/logging/LoggingTest.cpp`.

## Nothing else in the range applies

| Change | Applies? |
| --- | --- |
| `stderr_logger_mt`, `syslog_logger_mt`, `ostream_sink.h` | No — byte-identical between the tags |
| `level::level_enum` and level name strings | No — unchanged |
| pattern_formatter: `"Sept"`→`"Sep"`, `%D` width, `%z` UTC fix | No — we never call `set_pattern`/`set_formatter` |
| `to_string_view(fmt::basic_format_string)` removal (1.15.1) | No — never called |
| MSVC `/utf-8` added PUBLIC (1.15.0) | No — not propagated by the recipe's `package_info` |
| CMake minimum / target names | Unchanged (`spdlog::spdlog`, same install layout) |

**No CryFS source changes required.**

## One thing found along the way, deliberately not fixed here

`logging.h` includes `<spdlog/fmt/ostr.h>` and `Fuse.cpp` passes `boost::filesystem::path` straight to `LOG` in ~60 places. All of those are inside `#ifdef FSPP_LOG`, and **`FSPP_LOG` is commented out** at `Fuse.cpp:85` and defined nowhere else.

Compiling an `operator<<`-only type through spdlog fails **today on 1.14.1** with the same "Cannot format an argument" static assert it gives on 1.17.0. That code is already broken before this change and the upgrade does not make it worse. Fixing it means adding formatter specializations — its own change, not this one.

## On the sha512

The proxy in this environment returns 403 for GitHub *source tarballs* (it allows release assets), so the hash could not be fetched directly. It was derived with `git archive --format=tar --prefix=spdlog-<ver>/ | gzip -n -6`, and the method is validated two ways: it reproduces the **currently pinned 1.14.1 hash byte-for-byte**, and the resulting 1.17.0 sha256 matches the one conan-center independently records for the same URL. CI's own `sha512sum` gate is the final confirmation.

## Risk

Low, but the first CI run will be slow: a new `fmt/12.1.0` package invalidates conan cache keys, so spdlog+fmt rebuild across the matrix.

Untested surfaces: **MSVC** (no Windows toolchain available here — `msvc_sink.h` changed only by a stray `;` removal) and **clang 13 / older Apple Clang**. g++ 9 passing is the relevant reassurance for the old-compiler end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj

---
_Generated by [Claude Code](https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj)_