### PR TITLE
Update Boost to 1.91.0

### DIFF
--- a/.github/workflows/actions/install_local_dependencies/action.yaml
+++ b/.github/workflows/actions/install_local_dependencies/action.yaml
@@ -62,8 +62,8 @@ runs:
 
         echo Download boost
         cd ~
-        wget -O boost.tar.bz2 https://archives.boost.io/release/1.84.0/source/boost_1_84_0.tar.bz2
-        if [ $(sha512sum boost.tar.bz2 | awk '{print $1;}') == "5dfeb35198bb096e46cf9e131ef0334cb95bc0bf09f343f291b860b112598b3c36111bd8c232439c401a2b2fb832fa0c399a8d5b96afc60bd359dff070154497" ]; then
+        wget -O boost.tar.bz2 https://archives.boost.io/release/1.91.0/source/boost_1_91_0.tar.bz2
+        if [ $(sha512sum boost.tar.bz2 | awk '{print $1;}') == "25b3c1434d4c561ff568581356d1f240ef12218be62281f34fe7482487c5328ee6902ef158b7cf8daafe84943cf6f46485a8710a6da74475f11da023ec7b5559" ]; then
           echo Correct sha512sum
         else
           echo Wrong sha512sum
@@ -73,10 +73,10 @@ runs:
         echo Extracting boost
         tar -xf boost.tar.bz2
         rm boost.tar.bz2
-        cd boost_1_84_0
+        cd boost_1_91_0
 
         echo Install boost
-        ./bootstrap.sh --with-libraries=filesystem,system,thread,chrono,program_options
+        ./bootstrap.sh --with-libraries=filesystem,thread,chrono,program_options
         sudo ./b2 link=shared cxxflags=-fPIC --prefix=/usr -d0 -j$NUMCORES install
 
         echo Install googletest

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -51,6 +51,7 @@ Dependency Updates
 * Fuse 3.9 on Linux and macOS (was: Fuse 2.9), still Fuse 2.7 via DokanY on Windows
 * spdlog 1.17.0 (was: 1.14.1)
 * gtest 1.17.0 (was: 1.15.0), test-only dependency
+* boost 1.91.0 (was: 1.84.0)
 
 
 Version 1.0.3

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,6 +42,7 @@ class CryFSConan(ConanFile):
         "boost/*:asio_no_deprecated": True,
         "boost/*:filesystem_no_deprecated": True,
         "boost/*:without_atomic": False,  # needed by boost thread
+        "boost/*:without_charconv": True,
         "boost/*:without_chrono": False,  # needed by CryFS
         "boost/*:without_cobalt": True,
         "boost/*:without_container": False,  # needed by boost thread
@@ -61,6 +62,9 @@ class CryFSConan(ConanFile):
         "boost/*:without_math": True,
         "boost/*:without_mpi": True,
         "boost/*:without_nowide": True,
+        # We use Boost.Process v1, which is header-only. The compiled boost_process
+        # library is v2 only, and v2 needs Boost.Context, which we switch off above.
+        "boost/*:without_process": True,
         "boost/*:without_program_options": False,  # needed by CryFS
         "boost/*:without_python": True,
         "boost/*:without_random": True,
@@ -70,7 +74,6 @@ class CryFSConan(ConanFile):
         # see https://www.boost.org/doc/libs/1_65_0/doc/html/stacktrace/getting_started.html#stacktrace.getting_started.enabling_and_disabling_stacktrac
         # This is why we need to **not** link against the static version of stacktrace.
         "boost/*:without_stacktrace": True,
-        "boost/*:without_system": False,  # needed by CryFS
         "boost/*:without_test": True,
         "boost/*:without_thread": False,  # needed by CryFS
         "boost/*:without_timer": True,
@@ -131,7 +134,7 @@ class CryFSConan(ConanFile):
     def requirements(self):
         self.requires("range-v3/cci.20240905")
         self.requires("spdlog/1.17.0")
-        self.requires("boost/1.84.0")
+        self.requires("boost/1.91.0")
         if self.options.update_checks:
             self.requires("libcurl/8.9.1")
         if self.options.build_tests:


### PR DESCRIPTION
Bumps Boost from 1.84.0 to **1.91.0**. This is the largest of the four dependency updates and the only one that needed changes beyond a version number and a hash.

1.91.0 is the **conan-center ceiling** — upstream 1.92.0 exists but has no recipe in conan-center-index, and `conanfile.py` resolves from conancenter. 1.91 is also the better target among those available: 1.89 and 1.90 shipped without an installed CMake config for the now header-only Boost.System, breaking `find_package(Boost COMPONENTS system)` for distro builds. 1.91 restored it.

## Two changes the build fails hard without

**1. `without_process: True` is now required.**

Boost.Process became a configure option in 1.86 and defaults to being built. The compiled library is **Process v2 only**, and v2 requires Boost.Context — which we disable. Conan rejects the graph outright:

```
boost/1.91.0: Invalid: process requires ['context', 'filesystem']: context is disabled
```

We only use Process **v1**, which stays header-only and is unaffected by that option (`libs/process/build/Jamfile` builds `boost_process` from v2 sources alone).

Verified rather than assumed: the real conan-center recipe was exported into a scratch cache and `conan graph info` run against our option set. Our current options are **invalid** against 1.91.0, valid again with `without_process` added, and the corrected set is **still valid against 1.84.0** — so the change is safely revertible.

**2. The from-source CI path must drop `system` from `bootstrap.sh --with-libraries`.**

Boost.System has had no `libs/system/build/` directory since 1.89. b2 builds its list of valid `--with` names by globbing `libs/*/build/Jamfile*` and then hard-exits on anything not in that set:

```
EXIT error: wrong library name 'system' in the --with-<library> option.
```

Nothing is lost: System is header-only now, and its headers install regardless because every library's install target pulls in `/boost//headers`.

## Also changed

- **Dropped `without_system`** — the recipe no longer defines it from 1.89. Conan 2 silently ignores pattern-scoped options that don't exist, so this was dead config rather than an error.
- **Added `without_charconv: True`** — not required, but avoids building a compiled library we never link. `charconv` is only a dependency of `locale`, which we already disable.

## No source changes

`src/cpp-utils/process/subprocess.cpp` already carries the `#if BOOST_VERSION < 108800` guard added in `91e2c9b8`, and all six headers it selects still exist at `boost-1.91.0`.

## Nothing else in 1.85–1.91 reaches us

| Change | Applies? |
| --- | --- |
| 1.85 Filesystem removed deprecated APIs (`is_regular`, `copy_directory`, `copy_option`, `convenience.hpp`, …) | No — zero hits in the tree |
| 1.85 Filesystem v4 changes to `canonical`/`absolute`/`generic_string` | No — we use v3 (never set `filesystem_version`) and only `path`, `exists`, `string()` |
| 1.86–1.88 Process v1 → `v1/` namespace, `process.hpp` becomes v2-only | Already handled by the existing guard |
| 1.89 System compiled stub removed | Yes — that's the b2 change above |
| 1.91 Filesystem macro-desync compile error | No — we define neither `BOOST_FILESYSTEM_POSIX_API` nor `BOOST_WINDOWS_API` |
| 1.91 Cygwin now treated as POSIX | No — not a target |
| 1.91 StaticAssert merged into Config | No — `boost/static_assert.hpp` still exists and works |
| **Thread / Chrono / Program_options** | **No API entries at all** across the whole range — only build-system commits |
| Compiler floor | No — Boost still lists GCC 7.3 / Clang 6.0.1 for C++17, below everything in our matrix |

`cmake-utils/Dependencies.cmake` still asks for 1.84.0. That's a **floor, not a pin**, and 1.91 satisfies it; raising it would gratuitously break distro builds on 1.84–1.90, so it's left alone deliberately.

## sha512 — verified against the real tarball

An earlier revision of this description flagged the hash as the one value that could not be measured here. **It has since been measured, and it matches.**

The environment's proxy blocks `archives.boost.io`, but Boost's SourceForge mirror is reachable. Downloading `boost_1_91_0.tar.bz2` from there produces an exact match on the pinned sha512 and on the 204,579,466-byte size — which in turn agrees with Gentoo's Manifest, FreeBSD's distinfo and conan-center's conandata.

Two further assumptions of the from-source path were checked against that same tarball rather than reasoned about:

- its single top-level directory is `boost_1_91_0/`, which is what the action `cd`s into; and
- `libs/system/build/` is **empty** in 1.91.0, while `filesystem`, `thread`, `chrono` and `program_options` each have one — confirming both that dropping `system` from `--with-libraries` was necessary and that the four names left in it are valid.

The CI step still prints the actual hash and `exit 1`s on mismatch, so a wrong value would fail loudly rather than silently.

## Risk

Assessed before CI ran; see the status section below for what has since been settled.

1. **Highest — the `install_dependencies_manually` job** (`main.yaml:256`, ubuntu-24.04 / clang-19 / libc++ / Debug). It's the only entry exercising the from-source Boost path, so it's the only place a b2/bootstrap regression can surface, and it builds Boost with libc++ — the least-tested Boost configuration.
2. **Second — every conan job**, all platforms, would fail immediately at `conan install` if `without_process` were missing. Fast and unambiguous.
3. **Third — cold rebuild cost.** The option-list change alters the package ID, so expect a full Boost rebuild on every runner on the first run. Windows/MSVC slowest.
4. **Residual unknown:** I could not build Boost 1.91 here, so I have not *observed* that `boost/process/v1/*.hpp` lands in the conan package when `without_process=True`. The mechanism says it will (headers come from the version-independent `/boost//headers` target; `package()` prunes only `lib/cmake`, `*.pdb` and stray shared libs), and it's the same mechanism that makes the current 1.84 build work. **`src/cpp-utils/process/subprocess.cpp` compiling is the canary for this.**

## Status of those risks

- **Risk 2 (conan option set) — cleared.** Over 40 conan jobs have passed, including all six Windows jobs across `windows-2022` and `windows-2025`. A missing or wrong `without_process` would have failed every one of them at `conan install`.
- **Risk 4 (Process v1 headers) — cleared.** Those same jobs compile `src/cpp-utils/process/subprocess.cpp`, the canary named above. The v1 headers do ship when `without_process=True`.
- **Risk 1 (the from-source job) — still to run.** It is queued behind the repository-wide macOS backlog. The hash, the top-level directory and the `--with-libraries` names are now all verified against the real tarball, so the only remaining unknown there is the b2 build itself under libc++.
- **Risk 3 (cold rebuild cost) — as expected**, and the reason this PR's jobs run slower than its siblings'.

No failures anywhere on this branch so far.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj

---
_Generated by [Claude Code](https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj)_