### PR TITLE
Stop wall-clock cache pruning in the e2e-perf-tests counter tests

### DIFF
--- a/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
@@ -25,9 +25,9 @@ pub use entry::{BlockBaseStoreState, BlockCacheEntry, CacheEntryState};
 pub use guard::BlockCacheEntryGuard;
 
 // How often to run the task to prune old blocks
-const PRUNE_BLOCKS_INTERVAL: Duration = Duration::from_millis(500);
+pub(super) const PRUNE_BLOCKS_INTERVAL: Duration = Duration::from_millis(500);
 // The cutoff age of blocks. Each time the task runs, blocks older than this will be pruned.
-const PRUNE_BLOCKS_OLDER_THAN: Duration = Duration::from_millis(500);
+pub(super) const PRUNE_BLOCKS_OLDER_THAN: Duration = Duration::from_millis(500);
 
 pub struct BlockCache<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> {
     // Always Some except during destruction

--- a/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
@@ -32,7 +32,9 @@ const PRUNE_BLOCKS_OLDER_THAN: Duration = Duration::from_millis(500);
 pub struct BlockCache<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> {
     // Always Some except during destruction
     cache: Option<Arc<BlockCacheImpl<B>>>,
-    // Always Some except during destruction
+    // The background task evicting blocks nobody has touched for a while. `None` after
+    // destruction, and also after [Self::stop_periodic_pruning] (tests only) turned the
+    // wall-clock driven eviction off.
     prune_task: Option<AsyncDropGuard<PeriodicTask>>,
 }
 
@@ -134,6 +136,26 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
         Self::_prune_blocks(cache, to_prune).await
     }
 
+    /// Stop the background task that periodically evicts blocks which haven't been
+    /// accessed for `PRUNE_BLOCKS_OLDER_THAN`.
+    ///
+    /// That task runs on wall-clock time, so whether it fires in the middle of an
+    /// operation depends on how fast the machine is. Tests that assert exact operation
+    /// counts can't live with that: a prune landing mid-operation evicts blocks the
+    /// operation then has to load again, and the count changes with the runner's speed.
+    /// After this call blocks are only evicted when a test asks for it, through
+    /// [Self::prune_unloaded_blocks] or [Self::prune_all_blocks], so the write-backs
+    /// pruning causes still happen and are still counted, at a point the test controls.
+    ///
+    /// Only meant for tests; production keeps the periodic task.
+    #[cfg(any(test, feature = "testutils"))]
+    pub async fn stop_periodic_pruning(&mut self) -> Result<()> {
+        if let Some(mut prune_task) = self.prune_task.take() {
+            prune_task.async_drop().await?;
+        }
+        Ok(())
+    }
+
     /// TODO Docs
     /// TODO Test
     #[cfg(any(test, feature = "testutils"))]
@@ -233,11 +255,16 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> AsyncDro
     type Error = anyhow::Error;
 
     async fn async_drop_impl(&mut self) -> Result<()> {
-        let mut prune_task = self
-            .prune_task
-            .take()
-            .expect("Object was already destructed");
-        let stop_prune_task = async move { prune_task.async_drop().await };
+        // `None` means `stop_periodic_pruning` (tests only) already stopped the task.
+        // Destructing twice is caught by the `self.cache.take()` below.
+        let prune_task = self.prune_task.take();
+        let stop_prune_task = async move {
+            if let Some(mut prune_task) = prune_task {
+                prune_task.async_drop().await
+            } else {
+                Ok(())
+            }
+        };
         let drop_entries = async move {
             // The self.cache arc is shared between the prune task and self.
             // Since self is passed in by value, prune task is the only one

--- a/crates/blockstore/src/high_level/implementations/locking/locking_blockstore.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/locking_blockstore.rs
@@ -96,6 +96,13 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> LockingB
     pub fn inner_block_store(&self) -> &AsyncDropGuard<B> {
         self.base_store.as_ref().expect("Already destructed")
     }
+
+    /// See `BlockCache::stop_periodic_pruning`. Only meant for tests that assert exact
+    /// operation counts.
+    #[cfg(any(test, feature = "testutils"))]
+    pub async fn stop_periodic_cache_pruning(&mut self) -> Result<()> {
+        self.cache.stop_periodic_pruning().await
+    }
 }
 
 #[async_trait]

--- a/crates/blockstore/src/high_level/implementations/locking/tests.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/tests.rs
@@ -6,9 +6,10 @@ use byte_unit::Byte;
 use mockall::predicate::{always, function};
 use std::sync::{
     Arc, Mutex,
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
+use super::cache::{PRUNE_BLOCKS_INTERVAL, PRUNE_BLOCKS_OLDER_THAN};
 use super::*;
 use crate::{
     BlockId, InMemoryBlockStore, Overhead, high_level::interface::BlockStore as _,
@@ -228,6 +229,74 @@ async fn test_overhead() {
     let mut store = LockingBlockStore::new(underlying_store);
 
     assert_eq!(expected_overhead, store.overhead());
+
+    store.async_drop().await.unwrap();
+}
+
+/// A mock base store for a store that creates one block: the block doesn't exist yet, and
+/// it is written back exactly once. `stored` records when that write-back happens.
+fn make_mock_block_store_expecting_one_write_back()
+-> (AsyncDropGuard<MockBlockStore>, Arc<AtomicBool>) {
+    let stored = Arc::new(AtomicBool::new(false));
+    let mut underlying_store = make_mock_block_store();
+    underlying_store
+        .expect_exists()
+        .returning(|_| Box::pin(async { Ok(false) }));
+    let _stored = Arc::clone(&stored);
+    underlying_store
+        .expect_store()
+        .once()
+        .returning(move |_, _| {
+            _stored.store(true, Ordering::SeqCst);
+            Box::pin(async { Ok(()) })
+        });
+    (underlying_store, stored)
+}
+
+#[tokio::test]
+async fn test_whenStoppingPeriodicCachePruningTwice_thenSecondCallIsANoop() {
+    let underlying_store = make_mock_block_store();
+    let mut store = LockingBlockStore::new(underlying_store);
+
+    store.stop_periodic_cache_pruning().await.unwrap();
+    store.stop_periodic_cache_pruning().await.unwrap();
+
+    store.async_drop().await.unwrap();
+}
+
+#[tokio::test]
+async fn test_whenPeriodicCachePruningIsStopped_thenDirtyBlockIsNotWrittenBackByTheClock() {
+    let (underlying_store, stored) = make_mock_block_store_expecting_one_write_back();
+    let mut store = LockingBlockStore::new(underlying_store);
+    store.stop_periodic_cache_pruning().await.unwrap();
+
+    store.create(&data(1024, 0)).await.unwrap();
+    // Long enough for the periodic task, were it still running, to find the block
+    // untouched for longer than the threshold and write it back.
+    tokio::time::sleep(2 * (PRUNE_BLOCKS_INTERVAL + PRUNE_BLOCKS_OLDER_THAN)).await;
+    assert!(
+        !stored.load(Ordering::SeqCst),
+        "block was written back although periodic pruning is stopped"
+    );
+
+    // Destructing the store still writes the dirty block back.
+    store.async_drop().await.unwrap();
+    assert!(stored.load(Ordering::SeqCst));
+}
+
+#[tokio::test]
+async fn test_whenPeriodicCachePruningIsStopped_thenExplicitPruningStillWritesBackDirtyBlocks() {
+    let (underlying_store, stored) = make_mock_block_store_expecting_one_write_back();
+    let mut store = LockingBlockStore::new(underlying_store);
+    store.stop_periodic_cache_pruning().await.unwrap();
+
+    store.create(&data(1024, 0)).await.unwrap();
+    assert!(!stored.load(Ordering::SeqCst));
+    store.clear_unloaded_blocks_from_cache().await.unwrap();
+    assert!(
+        stored.load(Ordering::SeqCst),
+        "explicit pruning must still write the dirty block back"
+    );
 
     store.async_drop().await.unwrap();
 }

--- a/crates/e2e-perf-tests/src/filesystem_fixture.rs
+++ b/crates/e2e-perf-tests/src/filesystem_fixture.rs
@@ -152,10 +152,37 @@ where
         )
         .await
         .unwrap();
+        let locking_blockstore = Self::configure_cache_pruning(locking_blockstore).await;
 
         let tracking_block_store = HLTrackingBlockStore::new(locking_blockstore);
         let shared_block_store = HLSharedBlockStore::new(tracking_block_store);
         (local_state_tempdir, shared_block_store)
+    }
+
+    /// The counter tests assert exact operation counts, and the block cache's periodic
+    /// pruning runs on wall-clock time. Left running, it fires in the middle of the
+    /// operation under test on a slow machine, evicts blocks the operation then has to
+    /// load again, and the count depends on the machine's speed. So the counter tests
+    /// turn the timer off and prune only explicitly, in `reset_cache_after_setup` and
+    /// `reset_cache_after_test`. The write-backs pruning causes stay in the counts, at
+    /// points the test controls rather than at whatever moment the clock picks.
+    /// Benchmarks keep the production behavior.
+    #[cfg(not(feature = "benchmark"))]
+    async fn configure_cache_pruning(
+        mut locking_blockstore: AsyncDropGuard<LockingBlockStore<DynBlockStore>>,
+    ) -> AsyncDropGuard<LockingBlockStore<DynBlockStore>> {
+        locking_blockstore
+            .stop_periodic_cache_pruning()
+            .await
+            .unwrap();
+        locking_blockstore
+    }
+
+    #[cfg(feature = "benchmark")]
+    async fn configure_cache_pruning(
+        locking_blockstore: AsyncDropGuard<LockingBlockStore<DynBlockStore>>,
+    ) -> AsyncDropGuard<LockingBlockStore<DynBlockStore>> {
+        locking_blockstore
     }
 
     async fn make_blobstore(


### PR DESCRIPTION
## Problem

The `e2e-perf-tests` job on macos-15-intel fails `readdir::test_large_directory` with `Action counts mismatch expectations`: `low_level.load` comes back as 113 or 114 instead of the expected 111. The same test passes on faster runners.

Root cause: `BlockCache` inside `LockingBlockStore` runs a `PeriodicTask` every 500ms that evicts blocks nobody touched for 500ms. Whether that fires in the middle of the operation under test depends on wall-clock time, i.e. on how fast the machine is. When it lands mid-operation, blocks get evicted and loaded again, and the count grows.

Reproduced on Linux by running the unmodified test binary pinned to one CPU with busy loops competing for it: 14 of the 15 `test_large_directory` variants then fail with the same assertion. Only `load` differs, at 113, 114, 124, 134 and 222 against the expected 111/110. The fixed binary passes all 15 under the same starvation.

## Fix

Pruning itself has to keep running, because the write-backs it causes are operations the tests are meant to count. So only the wall-clock timer goes away:

- `BlockCache::stop_periodic_pruning` (test-only, `cfg(any(test, feature = "testutils"))`) stops the periodic task. `async_drop_impl` now tolerates the task already being stopped; destructing twice is still caught by the `cache` field.
- `LockingBlockStore::stop_periodic_cache_pruning` exposes it.
- The e2e-perf-tests fixture calls it right after building the blockstore stack, under `cfg(not(feature = "benchmark"))`. Blocks are then evicted only in `reset_cache_after_setup` / `reset_cache_after_test` through the existing `prune_unloaded_blocks`, so the write-backs still happen and are still counted, at a point the test controls. Benchmarks keep the production behaviour.

No expected counts change.

## Tests

Three unit tests next to the other `LockingBlockStore` tests: stopping twice is a no-op; once stopped, a dirty block is not written back by the clock but still is on destruction; explicit pruning still writes it back. The middle test sleeps past the point where the periodic task would have evicted the block, and fails at that assertion when the stop call is removed. The prune constants become `pub(super)` so the test derives that sleep from them.

## Verification

- Fixed binary under the same CPU starvation: 15 passed, 0 failed, no load mismatches.
- Full un-starved e2e-perf-tests suite: 4060 passed, 0 failed.
- `cargo test -p cryfs-blockstore`: 3085 passed, 0 failed.
- `--features benchmark` compiles.
- `cargo fmt --all --check` clean. `RUSTDOCFLAGS=-Dwarnings cargo doc` for the touched crates clean (the CI doc job unifies features, so the test-only methods do get documented).

## Follow-up, not in this PR

`crates/blockstore/src/high_level/implementations/locking/tests.rs` carries two TODOs saying the tests there are potentially flaky because the cache might get pruned. `stop_periodic_cache_pruning` could now address those. Left out to keep this PR to the CI failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rvim5Wko3GoV2kTiEJnhsJ