### PR TITLE
CI: skip push runs of branches that have an open pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,49 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  should_run:
+    # A push to a branch that has an open pull request is already built by that
+    # pull request's run (the merge with the base), so the push run would build
+    # the same commit a second time. This job checks for such a pull request,
+    # and every other job skips when it finds one. It decides only for push
+    # events on branches; tag pushes and pull_request events always run.
+    name: Skip pushes already built by a pull request
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      run: ${{ steps.check.outputs.run }}
+    steps:
+      - name: Look for an open pull request from this branch
+        id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          OWNER: ${{ github.repository_owner }}
+          EVENT: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          if [[ "$EVENT" != "push" || "$REF_TYPE" != "branch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Only pull requests whose head lives in this repository count: a
+          # fork could carry a branch of the same name, and its pull request
+          # builds the fork's commit, not ours.
+          prs=$(gh pr list --repo "$REPO" --head "$BRANCH" --state open \
+            --json number,headRepositoryOwner \
+            --jq "[.[] | select(.headRepositoryOwner.login == \"$OWNER\")] | length")
+          if [[ "$prs" == "0" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Branch $BRANCH has an open pull request; its run builds this commit."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
   test:
     name: test
+    needs: should_run
+    if: needs.should_run.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -103,6 +144,8 @@ jobs:
     # This job tests that each crate can be built and tested individually.
     # We don't actually run any tests because those are being run as part of other CI jobs already.
     name: check
+    needs: should_run
+    if: needs.should_run.outputs.run == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -145,6 +188,8 @@ jobs:
   #     - run: cargo clippy --all-features --all-targets -- -D warnings
   code_format:
     name: Code Formatter (rustfmt)
+    needs: should_run
+    if: needs.should_run.outputs.run == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -166,6 +211,8 @@ jobs:
   #   - run: git diff --exit-code
   dead_doc_links:
     name: Find dead doc links
+    needs: should_run
+    if: needs.should_run.outputs.run == 'true'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
@@ -177,6 +224,8 @@ jobs:
     - run: RUSTDOCFLAGS="-Dwarnings" cargo doc
   coverage:
     name: Code Coverage
+    needs: should_run
+    if: needs.should_run.outputs.run == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)


### PR DESCRIPTION
## Problem

A push to a branch with an open pull request triggers the workflow twice for the same commit: the `push` run on the branch head and the `pull_request` run on the merge with the base. The push trigger is limited to `main` and `feature/**`, but `feature/**` is where pull requests come from, so every push to a PR branch queued the whole matrix twice. Run 1121 (push) and run 1122 (pull_request) for `feature/ci-ubuntu-26-04` are the same commit, 72 macOS jobs where 36 would do, against an account-wide limit of 5 concurrent macOS runners.

## Change

A new first job (`should_run`) asks the API whether the pushed branch has an open pull request whose head is in this repository. Every other job takes `needs: should_run` and skips when it finds one.

Unaffected: tag pushes, `pull_request` events, `main`, and branches without a pull request, so a branch pushed to try something out (like the TEMP validation branches) still builds. A push that lands before its PR is opened still builds twice, that once.

The check is limited to heads in this repository because a fork can carry a branch of the same name, and its PR builds the fork's commit, not ours.

## Verification

- The step's script was run locally with a stub `gh` for the push-with-PR (`run=false`), push-without-PR, tag-push and pull_request cases (`run=true`).
- The workflow passes actionlint (its only complaints are runner labels newer than its label list).

The same change for the C++ workflow on `release/1.0` is in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_