### PR TITLE
CI: run both feature sets in one test job instead of two

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,8 @@ jobs:
           - ubuntu-24.04
         command: ["test"]
         profile: ["", "--release"]
-        # TODO Add --all-features (but that takes too long). Maybe instead add --all-features for some crates, but use separate jobs for the different slow-test-features of blockstore.
-        features: ["", "--no-default-features"]
         toolchain: ["stable", "nightly", "1.95"]
+        # The feature sets are not a matrix axis; see the cargo step below.
     runs-on: ${{matrix.os}}
     steps:
       - name: Free Disk Space (Ubuntu)
@@ -84,20 +83,43 @@ jobs:
         #   3. Refactor these tests so they don't actually mount — they
         #      already run against a MockAsyncFilesystemLL, so in principle
         #      the FUSE session/mountpoint plumbing could be stubbed.
+        #
+        # Also on macOS, skip http_client::test_get_valid_{http,https}: they hit
+        # http://example.com / https://example.com over the real network,
+        # so they fail whenever the runner's DNS resolver hiccups
+        # (observed on macos-15-intel: getaddrinfo returned EAI_NONAME
+        # for example.com mid-job even though DNS had worked at job
+        # start — macOS runners have a history of flaky resolver
+        # behavior, e.g. actions/runner-images#12562, #8649). They're
+        # reqwest smoke tests, not cryfs unit tests, and still run on
+        # Linux CI and locally.
+        #
+        # The feature sets are a loop here rather than a matrix axis: both
+        # `cargo test` invocations share one target directory, so the second
+        # only rebuilds the crates whose features differ instead of compiling
+        # every dependency again on a fresh runner. Same configurations
+        # tested, half the jobs. The loop runs every feature set even after
+        # one fails, so a job reports all broken feature sets, not just the
+        # first.
+        # TODO Add --all-features (but that takes too long). Maybe instead add --all-features for some crates, but use separate jobs for the different slow-test-features of blockstore.
         run: |
+          skip=()
           if [[ "${{ runner.os }}" == "macOS" ]]; then
-            # Also skip http_client::test_get_valid_{http,https}: they hit
-            # http://example.com / https://example.com over the real network,
-            # so they fail whenever the runner's DNS resolver hiccups
-            # (observed on macos-15-intel: getaddrinfo returned EAI_NONAME
-            # for example.com mid-job even though DNS had worked at job
-            # start — macOS runners have a history of flaky resolver
-            # behavior, e.g. actions/runner-images#12562, #8649). They're
-            # reqwest smoke tests, not cryfs unit tests, and still run on
-            # Linux CI and locally.
-            cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }} -- --skip tests::mkdir:: --skip tests::rename:: --skip tests::utils::fuser_runner:: --skip version::http_client::tests::reqwest_http_client::test_get_valid_
-          else
-            cargo ${{ matrix.command }} ${{ matrix.features }} ${{ matrix.profile }}
+            skip=(-- --skip tests::mkdir:: --skip tests::rename:: --skip tests::utils::fuser_runner:: --skip version::http_client::tests::reqwest_http_client::test_get_valid_)
+          fi
+          failed=()
+          for features in "" "--no-default-features"; do
+            label="cargo ${{ matrix.command }} ${features:-(default features)} ${{ matrix.profile }}"
+            echo "::group::$label"
+            if ! cargo ${{ matrix.command }} $features ${{ matrix.profile }} "${skip[@]}"; then
+              failed+=("$label")
+              echo "::error::$label failed"
+            fi
+            echo "::endgroup::"
+          done
+          if (( ${#failed[@]} > 0 )); then
+            printf 'Failed: %s\n' "${failed[@]}"
+            exit 1
           fi
   crates_individually_testable:
     # This job tests that each crate can be built and tested individually.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,13 +101,13 @@ jobs:
         # tested, half the jobs. The loop runs every feature set even after
         # one fails, so a job reports all broken feature sets, not just the
         # first.
-        # TODO Add --all-features (but that takes too long). Maybe instead add --all-features for some crates, but use separate jobs for the different slow-test-features of blockstore.
         run: |
           skip=()
           if [[ "${{ runner.os }}" == "macOS" ]]; then
             skip=(-- --skip tests::mkdir:: --skip tests::rename:: --skip tests::utils::fuser_runner:: --skip version::http_client::tests::reqwest_http_client::test_get_valid_)
           fi
           failed=()
+          # TODO Add --all-features (but that takes too long). Maybe instead add --all-features for some crates, but use separate jobs for the different slow-test-features of blockstore.
           for features in "" "--no-default-features"; do
             label="cargo ${{ matrix.command }} ${features:-(default features)} ${{ matrix.profile }}"
             echo "::group::$label"


### PR DESCRIPTION
## Problem

The `features` axis of the test matrix doubled the job count: each of the two feature sets got its own runner and compiled every dependency from scratch. 60 test jobs per run, 36 of them macOS, against an account-wide limit of 5 concurrent macOS runners.

## Change

The two `cargo test` invocations run one after the other in the same job, sharing one target directory, so the second one only rebuilds the crates whose features differ.

Measured on a 4-core machine: a debug test build of the workspace takes 7m40s, and the `--no-default-features` build on top of it 3m52s instead of another 7m40s.

Same configurations tested. 30 test jobs per run instead of 60, 18 on macOS instead of 36.

The loop keeps going after a failing feature set and exits non-zero at the end, so a job still reports every broken feature set, which is what the separate jobs gave. Each feature set gets its own log group and an `::error::` line naming it.

The `command` axis stays single-valued so the job names keep their shape. Only the features component disappears, e.g. `test (macos-15, test, --release, stable)` stays and `test (macos-15, test, --release, --no-default-features, stable)` is folded into it. If a required status check is named after a `--no-default-features` job it needs updating.

## Verification

- The step's script was run locally with a stub `cargo` for the no-failure, first-set-fails and second-set-fails cases, on both the macOS and the Linux path of the script: exit 0 / 1 / 1, and the second set still runs after the first fails.
- The workflow passes actionlint (its only complaints are runner labels newer than its label list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_