### PR TITLE
CI: use thin LTO for the release test builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,16 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - name: cargo ${{ matrix.command }}
         shell: bash
+        env:
+          # Cargo.toml asks for fat LTO, and release binaries built anywhere
+          # else still get it. For the release test builds here, thin LTO
+          # keeps the optimisation level and the checks that differ between
+          # profiles (overflow, debug_assertions) while roughly halving the
+          # workspace's release build: rebuilding the workspace's test binaries
+          # after a change takes 8m18s with thin LTO and 17m19s with fat on a
+          # 4-core machine, and every release job pays that for each feature
+          # set.
+          CARGO_PROFILE_RELEASE_LTO: thin
         # On GitHub-hosted macOS runners we have to skip the cryfs-rustfs
         # tests that mount real FUSE sessions via fuser → macFUSE: the
         # runner image won't approve macFUSE's kernel extension


### PR DESCRIPTION
`[profile.release]` in `Cargo.toml` asks for fat LTO and keeps doing so: release binaries built anywhere else are unchanged. This sets `CARGO_PROFILE_RELEASE_LTO=thin` on the `cargo test --release` step in CI only.

Fat LTO re-optimises the whole dependency graph for each of the ~30 test binaries. Measured on a 4-core machine:

| Release test build of the workspace | fat LTO | thin LTO |
|---|---|---|
| From scratch | 21m30s | 14m28s |
| Rebuilding the workspace's test binaries after a change (what a job with cached dependencies does) | 17m19s | 8m18s |

Every release job pays that once per feature set, on 3-core macOS runners.

What the release jobs test is unchanged in every way a test can observe: optimisation level, overflow checks, `debug_assertions`, and every feature and toolchain combination. What changes is how much cross-crate inlining the linker does.

Verification: the workflow passes actionlint (its only complaints are runner labels newer than its label list); the timings above come from `cargo build --tests --release` with and without `CARGO_PROFILE_RELEASE_LTO=thin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_