### PR TITLE
CI: cache the compiled dependencies of the check jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
+      - name: Cache compiled dependencies
+        # Same as in the test job: the dependency artifacts from the last
+        # main build, keyed by job, crate, rustc version and lockfile. One
+        # cache per crate rather than one shared by all fifteen jobs, because
+        # a shared key would be saved by whichever job finishes first, which
+        # is the crate with the fewest dependencies, and every other job
+        # would then miss most of its own. cargo check keeps only metadata,
+        # so these caches are small next to the test jobs' ones, but the
+        # build scripts still run in full, and that includes compiling the
+        # vendored OpenSSL, libsodium, aws-lc and libgit2.
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          key: ${{ matrix.crate }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
       - name: cargo check
         working-directory: ./crates/${{ matrix.crate }}
         shell: bash


### PR DESCRIPTION
Based on #607 (this PR's base is that branch, so the diff here is only the cache step; GitHub retargets it to `main` when #607 merges).

## Problem

Each check job compiles the metadata of its crate's dependencies from scratch and runs their build scripts in full, which includes compiling the vendored OpenSSL, libsodium, aws-lc and libgit2. That is most of the 2 to 6 minutes a check job takes before the crate's own twelve checks start; after #607 it is paid once per crate, 15 times per run.

## Change

The same `Swatinem/rust-cache` step the test jobs use, keyed by crate on top of the job, rustc version and lockfile. Only `main` saves, for the reason given on the test job.

One cache per crate rather than one shared key: a shared key would be saved by whichever job finishes first, which is the crate with the fewest dependencies, and every other job would then miss most of its own. `cargo check` keeps only metadata, so the fifteen caches are small next to the test jobs' ones; I expect about 0.3 GB each, so about 4.5 GB in total. Together with the 12 GB of test caches and the coverage and doc caches this gets close to the 20 GB limit, so raising it to around 30 GB is advisable before this merges; the cache usage job on `main` will warn at 90% either way.

Verification: the workflow passes actionlint (its only complaints are runner labels newer than its label list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_