### PR TITLE
CI: cache the compiled dependencies of the coverage and doc-link jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,6 +317,14 @@ jobs:
     - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
       with:
         toolchain: stable
+    - name: Cache compiled dependencies
+      # Same as in the test job: the dependency artifacts and the generated
+      # documentation of the dependencies from the last main build of this
+      # job, keyed by job, rustc version and lockfile.
+      uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+        cache-on-failure: true
     - run: RUSTDOCFLAGS="-Dwarnings" cargo doc
   coverage:
     name: Code Coverage
@@ -331,6 +339,15 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
+      - name: Cache compiled dependencies
+        # Same as in the test job: the dependency artifacts from the last
+        # main build of this job, keyed by job, rustc version and lockfile.
+        # cargo-llvm-cov builds into target/llvm-cov-target, a nested target
+        # directory that rust-cache handles like the top-level one.
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: true
       # Setup inspired by instructions at https://github.com/taiki-e/cargo-llvm-cov/blob/9b93f70f4c5a06d6ee221d3537067bc8d3f5b7c6/README.md
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
The same `Swatinem/rust-cache` step the test jobs use, one cache each, keyed by job so neither collides with the test caches. Only `main` saves, for the reason given on the test job.

- **Code Coverage** (59 minutes on the last full run) spends its first minutes compiling every dependency with coverage instrumentation before it gets to the workspace. cargo-llvm-cov builds into `target/llvm-cov-target`, a nested target directory that rust-cache treats like the top-level one.
- **Find dead doc links** (9 minutes) documents all dependencies before it documents the workspace. `target/doc` is kept in the cache along with the dependency metadata, so a warm run only documents the workspace crates.

Two more cache entries, roughly 0.5 GB and 0.3 GB.

Verification: the workflow passes actionlint (its only complaints are runner labels newer than its label list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_