### PR TITLE
CI: stop freeing disk space before the Linux test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,9 +96,6 @@ jobs:
       # from 7m40s to 5m02s and the target directory from 20 GB to 4 GB.
       CARGO_PROFILE_DEV_DEBUG: line-tables-only
     steps:
-      - name: Free Disk Space (Ubuntu)
-        if: ${{ runner.os == 'Linux' }}
-        uses: jlumbroso/free-disk-space@v1.3.1
       - uses: actions/checkout@v7
       - name: Install Dependencies (Linux)
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
The `Free Disk Space` step takes 72 to 154 seconds per Linux test job to make room the jobs no longer need.

From the step's own before/after report on a recent job (run 34161026441, `check (blobstore)`): a Linux runner starts with **87 GB available** on a 145 GB disk, and the step reclaims 26 GB of that in 93 seconds. A test job now needs about 10 GB: the debug target directory of the workspace is 4 GB per feature set since tests are built with line tables only, the release one is smaller, plus about 2 GB of cargo registry.

Only the test job loses the step. The check and coverage jobs keep theirs; they could lose it on the same numbers, but that is a separate decision.

Verification: the workflow passes actionlint (its only complaints are runner labels newer than its label list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_