### PR TITLE
Revert "CI: use thin LTO for the release test builds"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,16 +132,6 @@ jobs:
           cache-on-failure: true
       - name: cargo ${{ matrix.command }}
         shell: bash
-        env:
-          # Cargo.toml asks for fat LTO, and release binaries built anywhere
-          # else still get it. For the release test builds here, thin LTO
-          # keeps the optimisation level and the checks that differ between
-          # profiles (overflow, debug_assertions) while roughly halving the
-          # workspace's release build: rebuilding the workspace's test binaries
-          # after a change takes 8m18s with thin LTO and 17m19s with fat on a
-          # 4-core machine, and every release job pays that for each feature
-          # set.
-          CARGO_PROFILE_RELEASE_LTO: thin
         # On GitHub-hosted macOS runners we have to skip the cryfs-rustfs
         # tests that mount real FUSE sessions via fuser → macFUSE: the
         # runner image won't approve macFUSE's kernel extension


### PR DESCRIPTION
Reverts #614 (commit ddbecfdc). The release test builds in CI go back to the fat LTO that `Cargo.toml` asks for, so what CI tests is again exactly the configuration release binaries are built with.

The numbers #614 was based on were wrong: they came from builds in a renamed target directory, which the `crabtime` macro used by e2e-perf-tests refuses, so those builds had failed on the largest unit of a release build before finishing (details in [this comment on #614](https://github.com/cryfs/cryfs/pull/614#issuecomment-5595561337)). Measured again in `target/`, complete builds, same machine and session, 4 cores, `cargo build --tests --release`:

| | fat LTO | thin LTO |
|---|---|---|
| Fresh build | 16m44s wall, 50m36s CPU | 15m12s wall, 55m50s CPU |
| Rebuild after touching `utils` | 13m18s wall, 40m32s CPU | 12m23s wall, 47m07s CPU |

Thin LTO is 7 to 9% faster in wall time on 4 cores and uses 10 to 16% more CPU. The gain comes from parallelising the link, so on the 3-core macOS runners it is smaller still. Not worth testing a configuration that differs from the shipped one.

Verification: the workflow passes actionlint (its only complaints are runner labels newer than its label list); the diff is the exact inverse of #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_