### PR TITLE
CI: save the S3 caches from pull request runs of this repository's branches

### DIFF
--- a/.github/workflows/actions/s3_cache/action.yaml
+++ b/.github/workflows/actions/s3_cache/action.yaml
@@ -19,8 +19,16 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Saving needs the write-capable key, which the workflow passes in from
+    # the repository secrets. GitHub gives those to push runs and to pull
+    # request runs whose head branch is in this repository, and withholds
+    # them from pull requests coming from forks, so the condition below
+    # matches exactly the runs that can save. Pull request runs used to be
+    # excluded altogether; since a push to a branch with an open pull request
+    # no longer gets a run of its own, they are now the only runs that can
+    # refresh the caches while a dependency change is under review.
     - name: Zip cache files
-      if: ${{ inputs.action == 'save' && github.event_name == 'push' }}
+      if: ${{ inputs.action == 'save' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
       shell: bash
       run: |
         set -e
@@ -30,8 +38,8 @@ runs:
         echo "Zipped cache:"
         ls -lh "/tmp/s3_cache/${{inputs.cache_key}}"
     - name: Store cache
-      # note: this access key has write access to the cache. This can't run on PRs.
-      if: ${{ inputs.action == 'save' && github.event_name == 'push' }}
+      # note: this access key has write access to the cache. See above for which runs have it.
+      if: ${{ inputs.action == 'save' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
       # Cache things sometimes indeterministically fail (roughly 1% of times this is run), let's not fail the job for it
       continue-on-error: true
       uses: leroy-merlin-br/action-s3-cache@7fad0a81b31884660211f24b62e29b4777a6ac4c # v1.0.6
@@ -44,11 +52,11 @@ runs:
         s3-class: ONEZONE_IA
         key: v2-${{ inputs.cache_key }}
         artifacts: "/tmp/s3_cache/${{inputs.cache_key}}"
-    - name: Not saving cache on PRs
-      if: ${{ inputs.action == 'save' && github.event_name != 'push' }}
+    - name: Not saving cache on pull requests from forks
+      if: ${{ inputs.action == 'save' && !(github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
       shell: bash
       run: |
-        echo "Not saving cache because this is a PR"
+        echo "Not saving cache because this is a pull request from a fork"
 
 
     - name: Retrieve cache


### PR DESCRIPTION
## Problem

The ccache and conan caches on S3 were saved only by `push` runs. Their keys carry no branch, so a push run on a feature branch refreshed the caches for every job that followed, including the pull request's own later runs. Since #616, a push to a branch with an open pull request no longer gets a run of its own, and pull request runs never saved, so nothing refreshed the caches any more: a pull request that bumps Boost or gtest rebuilt them from source in every job on every push until it merged. The gtest bump's run showed builds of up to 13 minutes on Linux for that reason. This is a side effect of #616 that I should have caught there.

## Change

`s3_cache/action.yaml` also saves from pull request runs whose head branch is in this repository. GitHub gives repository secrets, and with them the write-capable key the workflow passes in, to exactly those runs and to push runs, and withholds them from pull requests from forks, so the new condition matches the runs that can save and nothing else. Fork pull requests are still excluded and the step that says so now names them.

Three `if` conditions change, nothing else.

## Verification

The action parses. The condition itself is only exercised by a pull request run of this repository: this PR's own run should show `Zip cache files` and `Store cache` running instead of `Not saving cache on PRs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_