### PR TITLE
CI: run the test binaries at the same time instead of one after another

### DIFF
--- a/.github/workflows/actions/run_tests/action.yaml
+++ b/.github/workflows/actions/run_tests/action.yaml
@@ -15,6 +15,11 @@ runs:
   steps:
     - name: Run tests
       shell: bash
+      # The test binaries are independent of each other, so they run at the
+      # same time, each into its own log. The logs are printed once all of
+      # them have finished, in the order the binaries used to run in, each in
+      # its own group, so the job log reads as before. A failure in any
+      # binary fails the step after every log has been printed.
       run: |
         set -v
         set -e
@@ -23,20 +28,44 @@ runs:
 
         export ${{ inputs.extra_env_vars }}
 
-        ./gitversion/gitversion-test ${{inputs.gtest_args}}
-        ./cpp-utils/cpp-utils-test ${{inputs.gtest_args}}
-        ./parallelaccessstore/parallelaccessstore-test ${{inputs.gtest_args}}
-        ./blockstore/blockstore-test ${{inputs.gtest_args}}
-        ./blobstore/blobstore-test ${{inputs.gtest_args}}
-        ./cryfs/cryfs-test ${{inputs.gtest_args}}
-
+        tests=(
+          gitversion/gitversion-test
+          cpp-utils/cpp-utils-test
+          parallelaccessstore/parallelaccessstore-test
+          blockstore/blockstore-test
+          blobstore/blobstore-test
+          cryfs/cryfs-test
+        )
         # TODO Also run on macOS once fixed
         if [[ "${{runner.os}}" == "macOS" ]]; then
           echo Skipping some tests because they are not fixed for macOS yet
         else
           # TODO Also run with TSAN once fixed
           if [[ "${{matrix.name}}" != "TSAN" ]]; then
-            ./fspp/fspp-test ${{inputs.gtest_args}}
+            tests+=(fspp/fspp-test)
           fi
-          ./cryfs-cli/cryfs-cli-test ${{inputs.gtest_args}}
+          tests+=(cryfs-cli/cryfs-cli-test)
+        fi
+
+        logdir=$(mktemp -d)
+        pids=()
+        for t in "${tests[@]}"; do
+          "./$t" ${{inputs.gtest_args}} > "$logdir/$(basename "$t").log" 2>&1 &
+          pids+=($!)
+        done
+        failed=()
+        for i in "${!tests[@]}"; do
+          if wait "${pids[$i]}"; then
+            status=passed
+          else
+            status=FAILED
+            failed+=("${tests[$i]}")
+          fi
+          echo "::group::${tests[$i]} ($status)"
+          cat "$logdir/$(basename "${tests[$i]}").log"
+          echo "::endgroup::"
+        done
+        if (( ${#failed[@]} > 0 )); then
+          echo "Failed test binaries: ${failed[*]}"
+          exit 1
         fi


### PR DESCRIPTION
The eight gtest binaries (six on macOS) are independent of each other, but the test step ran them one after another, and gtest runs the tests inside a binary sequentially, so the step used one core. The Test step takes a median of 2 minutes on Linux and up to 11 for the sanitizer configurations.

## Change

`run_tests/action.yaml` starts all binaries at once, each writing to its own log, and waits for all of them. The logs are printed afterwards in the order the binaries used to run in, one `::group::` per binary with its result in the title, so the job log reads as it did before. A failure in any binary fails the step after every log has been printed, instead of stopping at the first failing binary. The macOS and TSAN exclusions are unchanged.

## Verification

The step's script was run locally with stub binaries that sleep one second each, on the Linux path (eight binaries) and the macOS path (six): eight binaries finished in one second of wall time; a failing binary is reported by name with its log still printed and the step exits 1; with none failing it exits 0.

What this cannot verify locally is whether any of the real test binaries interfere with each other when they run concurrently (shared temp paths, mount points, ports). This PR's own run is the test for that; if something does interfere, the fix is to give that test its own path rather than to go back to serial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_