### PR TITLE
CI: check each crate in one job, restoring the test job's dependency cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,16 +234,6 @@ jobs:
       fail-fast: false
       matrix:
         crate: ["blobstore", "blockstore", "check", "cli-utils", "concurrent-store", "cryfs-config", "cryfs-cli", "cryfs-filesystem", "cryfs-version", "crypto", "e2e-perf-tests", "fsblobstore", "rustfs", "tempproject", "utils"]
-        targets: ["", "--tests", "--examples", "--benches"]
-        features: ["", "--no-default-features", "--all-features"]
-        # TODO Re-add at least some release-profile coverage for this job.
-        # The full profile axis (debug vs release) was 16 × 4 × 3 × 2 = 384
-        # configurations (15 × 4 × 3 × 2 = 360 with the current crate list),
-        # which exceeds GitHub Actions' 256-configuration
-        # matrix cap and caused the entire job to fail at matrix-resolution
-        # time. Either find a way to fit release back in (split into a
-        # second job, drop a less-valuable axis, exclude some
-        # crate/target/feature combinations) or accept debug-only here.
     steps:
       - name: Free Disk Space (Ubuntu)
         if: ${{ runner.os == 'Linux' }}
@@ -256,7 +246,30 @@ jobs:
           toolchain: stable
       - name: cargo check
         working-directory: ./crates/${{ matrix.crate }}
-        run: cargo check ${{ matrix.features }} ${{matrix.targets}}
+        shell: bash
+        # One job per crate, with the feature and target combinations as a
+        # loop inside it: they share a target directory, so only the first
+        # combination pays to build the crate's dependencies.
+        #
+        # Every combination runs even when an earlier one fails, and the step
+        # exits non-zero if any did, so one job reports all the broken
+        # combinations rather than stopping at the first.
+        #
+        # TODO Cover the release profile too. It is another dimension of this
+        # loop, costing runner time but no additional jobs.
+        run: |
+          status=0
+          for features in "" --no-default-features --all-features; do
+            for targets in "" --tests --examples --benches; do
+              echo "::group::cargo check $features $targets"
+              if ! cargo check $features $targets; then
+                echo "::error::${{ matrix.crate }}: cargo check $features $targets failed"
+                status=1
+              fi
+              echo "::endgroup::"
+            done
+          done
+          exit $status
   # clippy_check:
   #   name: Linter (clippy)
   #   runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,16 @@ jobs:
     name: check
     needs: should_run
     if: needs.should_run.outputs.run == 'true'
-    runs-on: ubuntu-latest
+    # The same image as the test job whose dependency cache this job restores
+    # (see the cache step), rather than ubuntu-latest, so the two cannot drift
+    # apart when ubuntu-latest moves on.
+    runs-on: ubuntu-24.04
+    env:
+      # Identical to the test job's settings. rust-cache hashes every CARGO_*
+      # variable into the cache key, so the key only matches the test job's
+      # cache if these match too. Neither changes what cargo check does.
+      CARGO_INCREMENTAL: 0
+      CARGO_PROFILE_DEV_DEBUG: line-tables-only
     strategy:
       fail-fast: false
       matrix:
@@ -244,6 +253,25 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # v1
         with:
           toolchain: stable
+      - name: Restore the test job's compiled dependencies
+        # Restores the cache the ubuntu-24.04 / stable / debug test job saves
+        # on main, and never saves one of its own. cargo check cannot reuse
+        # the Rust artifacts in it (check units and build units are distinct
+        # to cargo), but it does reuse the build script outputs, and those are
+        # most of a check job's dependency time: compiling the vendored
+        # OpenSSL, libsodium, aws-lc and libgit2. The metadata check of the
+        # Rust dependencies that remains takes a minute or two. Sharing the
+        # cache rather than keeping fifteen per-crate ones keeps the storage
+        # footprint of this job at zero.
+        #
+        # The key matches the test job's only if this job runs the same
+        # rustc, on the same runner OS, with the same CARGO_* environment;
+        # see the job's env above. If it stops matching, these jobs miss and
+        # compile everything, as they did before.
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: ubuntu-24.04-stable-debug
+          save-if: false
       - name: cargo check
         working-directory: ./crates/${{ matrix.crate }}
         shell: bash


### PR DESCRIPTION
Replacement for #607 with a linear history so it can be rebase-merged. #607's branch carried two merge commits from `main` that resolved conflicts around the job's `needs:` lines; GitHub's rebase merge replays only the non-merge commits, and those no longer apply on their own, hence "This branch cannot be rebased due to conflicts". This branch is the same final tree (byte-identical to #607's head 8d26f0eb) as two commits on top of the current `main`.

## Commit 1: Check each crate in one job instead of twelve

The original #607 change, cherry-picked unchanged: the `crates_individually_testable` matrix keeps its crate axis and runs the twelve target and feature combinations as a loop inside the job. Same 180 `cargo check` invocations, 15 jobs instead of 180. The loop accumulates failures and exits non-zero if any combination failed, with one `::group::` per combination and `::error::` lines naming the crate and flags. See #607 for the full write-up and verification.

## Commit 2: Let the check jobs restore the test job's dependency cache

The check jobs restore the cache the `ubuntu-24.04` / `stable` / debug test job saves on `main`, and never save one of their own. `cargo check` cannot reuse the Rust artifacts in it (check units and build units are distinct to cargo), but it does reuse the build script outputs, and those are most of a check job's dependency time: compiling the vendored OpenSSL, libsodium, aws-lc and libgit2. What remains is the metadata check of the Rust dependencies, a minute or two.

rust-cache drops the job id from the key once `shared-key` is set, and hashes the rustc version, runner OS and every `CARGO_*` variable into it, so the job pins `ubuntu-24.04` instead of `ubuntu-latest` and carries the test job's `CARGO_INCREMENTAL` and `CARGO_PROFILE_DEV_DEBUG` settings, which do not change what `cargo check` does. If the key ever stops matching, the jobs miss and compile everything, which is what they did before. Storage footprint: zero cache entries.

## Verification

The tree is identical to #607's head, whose run had all 15 check jobs green (3 to 8 minutes each) along with every other finished job. The workflow parses and actionlint reports nothing beyond runner labels newer than its label list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_