### PR TITLE
CI: build pushes to the release branches

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,6 +9,7 @@ on:
       - main
       - master
       - develop
+      - 'release/**'
       - 'feature/**'
     tags:
       - '**'


### PR DESCRIPTION
The push trigger listed `main`, `master`, `develop` and `feature/**`, but not the release branches, and `release/1.0` is where the C++ code lives: nothing ever built a merge into it, and the last workflow run on that branch dates from February. Every merge into a release branch now gets a run of the real branch state and, since only push runs and pull request runs of this repository's branches save the S3 caches, a trusted refresh of the ccache and conan caches per merge.

One line added to the `push.branches` list. Cost: one run per merge into a release branch, 13 macOS jobs each after #623.

Verification: the workflow parses and actionlint reports nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_