### PR TITLE
CI: stop freeing disk space before the check jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,9 +245,6 @@ jobs:
       matrix:
         crate: ["blobstore", "blockstore", "check", "cli-utils", "concurrent-store", "cryfs-config", "cryfs-cli", "cryfs-filesystem", "cryfs-version", "crypto", "e2e-perf-tests", "fsblobstore", "rustfs", "tempproject", "utils"]
     steps:
-      - name: Free Disk Space (Ubuntu)
-        if: ${{ runner.os == 'Linux' }}
-        uses: jlumbroso/free-disk-space@v1.3.1
       - uses: actions/checkout@v7
       - name: Install Dependencies
         run: sudo apt-get install -y fuse3 libfuse3-dev


### PR DESCRIPTION
With the dependencies restored from the test job's cache and `cargo check` keeping only metadata, the `Free Disk Space` step is the largest fixed cost of a check job: 97 to 154 seconds per job on the run for the #626 merge, ahead of the checks it was making room for.

A Linux runner starts with 87 GB available (from the step's own before/after report). A check job needs a few GB at most: the restored cache is about 0.5 GB and the check artifacts of one crate's twelve combinations are metadata. Same reasoning as #619 for the test jobs.

The coverage job keeps its step; it builds the whole workspace instrumented, with full debuginfo, and runs once per workflow run.

Verification: the workflow parses and actionlint reports nothing beyond runner labels newer than its label list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_