### PR TITLE
CI: keep the default SIGINT handling for the test binaries running in the background

### DIFF
--- a/.github/workflows/actions/run_tests/action.yaml
+++ b/.github/workflows/actions/run_tests/action.yaml
@@ -23,6 +23,12 @@ runs:
       run: |
         set -v
         set -e
+        # Job control is on so that the background test binaries below keep the
+        # default SIGINT and SIGQUIT handling. Without it, bash starts
+        # asynchronous commands with both signals ignored, which the death
+        # tests in cpp-utils-test that raise SIGINT on themselves and expect
+        # to die then fail.
+        set -m
         echo Running on ${{runner.os}}
         cd build/${{inputs.build_type}}/test
 


### PR DESCRIPTION
## What broke

The first run on `release/1.0` after #622 (run the test binaries at the same time) fails `cpp-utils/cpp-utils-test` on every Linux job whose Test step has finished so far (`Local dependencies`, `No update checks`; the others are still running). The other test binaries pass.

## Why

#622 starts the test binaries as asynchronous bash commands (`... &`). When job control is off, which it is in a non-interactive `run` step, bash starts asynchronous commands with **SIGINT and SIGQUIT ignored**. The death tests in cpp-utils-test (`SignalCatcherTest.*_thenDies`, `SignalHandlerTest.*_thenDies`) raise SIGINT on themselves and expect to die; the death-test child inherits the ignored signal, survives, and the binary fails.

Reproduced outside CI: a stand-in test binary that raises SIGINT on a child survives under the #622 script (`Failed test binaries: cpp-utils/cpp-utils-test`, exactly the line in the job logs) and dies as expected once job control is on.

## Fix

`set -m` in the step, so bash keeps the default signal handling for the background test binaries. Failure propagation through `wait` is unchanged: a stand-in binary exiting non-zero still fails the step.

The macOS jobs also run cpp-utils-test and would fail the same way; the pull request run of this PR covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_