### PR TITLE
CI: Add gcc 16

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -190,6 +190,13 @@ jobs:
             macos_cxx: llvm@19/bin/clang++
             apt_package: clang-19 libc++-19-dev libc++abi-19-dev libunwind-19-dev libomp-19-dev
             homebrew_package: llvm@19
+          - compiler: gcc
+            version: 16
+            libcxx: libstdc++11
+            cc: gcc-16
+            cxx: g++-16
+            apt_package: g++-16
+            homebrew_package: gcc@16
           # Apple Clang
 #           - compiler: apple-clang
 #             version: xxx
@@ -224,6 +231,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           - os: macos-15-intel
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           - os: macos-15-intel
@@ -240,6 +249,8 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-15-intel
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
+          - os: macos-15-intel
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           # MacOS 15-intel fails to build with Clang 14
           - os: macos-15-intel
             compiler: {compiler: clang, version: 14, libcxx: libc++, cc: clang-14, cxx: clang++-14, macos_cc: llvm@14/bin/clang, macos_cxx: llvm@14/bin/clang++, apt_package: "clang-14 libc++-14-dev libc++abi-14-dev libunwind-14-dev libomp-14-dev", homebrew_package: llvm@14}
@@ -265,12 +276,18 @@ jobs:
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: macos-26
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 22.04 doesn't have gcc 13, 14 yet
+          - os: macos-26
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
+          # Ubuntu 22.04 doesn't have gcc 13, 14 or 16
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 13, libcxx: libstdc++11, cc: gcc-13, cxx: g++-13, homebrew_package: gcc@13, apt_package: g++-13}
           - os: ubuntu-22.04
             compiler: {compiler: gcc, version: 14, libcxx: libstdc++11, cc: gcc-14, cxx: g++-14, homebrew_package: gcc@14, apt_package: g++-14}
-          # Ubuntu 24.04 doesn't have clang 13 anymore
+          - os: ubuntu-22.04
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
+          # Ubuntu 24.04 doesn't have gcc 16, and doesn't have clang 13 anymore
+          - os: ubuntu-24.04
+            compiler: {compiler: gcc, version: 16, libcxx: libstdc++11, cc: gcc-16, cxx: g++-16, homebrew_package: gcc@16, apt_package: g++-16}
           - os: ubuntu-24.04
             compiler: {compiler: clang, version: 13, libcxx: libc++, cc: clang-13, cxx: clang++-13, macos_cc: llvm@13/bin/clang, macos_cxx: llvm@13/bin/clang++, apt_package: "clang-13 libc++-13-dev libc++abi-13-dev libunwind-13-dev libomp-13-dev", homebrew_package: llvm@13}
           # Ubuntu 26.04 has neither clang 13 to 16 nor gcc 9 and 10 anymore


### PR DESCRIPTION
gcc 16 is the newest GCC in the archives of any image we build on, and `ubuntu-26.04` (added in #598) is the only one that carries it. It only became usable once #596 moved us to conan 2.32, whose `default_settings.py` lists gcc up to 16.2 — the previously pinned 2.23 stopped at 15.2 and rejected 16 outright as a compiler version.

It runs on `ubuntu-26.04` only. `g++-16` is not in the 22.04 or 24.04 archives and would need the `ubuntu-toolchain-r` PPA there, which is not worth pulling in for one compiler, so both are excluded. The macOS exclusions are the same as for every other GCC version: the Homebrew formulas are often incompatible there, so we don't support them officially. There is also no `gcc@16` formula at all, so nothing is lost.

That is **one new job**, on `ubuntu-26.04`, building and testing all three build types inside it.

## Verification

[Run 34416012010](https://github.com/cryfs/cryfs/actions/runs/34416012010) — **green**, on a branch state restricted to exactly this one job so the check cost one job rather than a full matrix. It installed `g++-16` from Ubuntu's archive, then built and tested Debug, Release and RelWithDebInfo in turn:

| step | outcome |
|---|---|
| Setup Linux (`g++-16` from the archive) | ✅ |
| Install dependencies + Build — Debug | ✅ |
| Install dependencies + Build — Release | ✅ |
| Install dependencies + Build — RelWithDebInfo | ✅ |
| Test — Debug, Release, RelWithDebInfo | ✅ |

The restriction commit is not part of this PR; the branch was rebuilt as just the workflow change once that run came back green.

Matrix resolved before and after. The os axis became event-dependent in #639, so there are two numbers now:

| event | before | after |
|---|---|---|
| pull request | 46 | 47 |
| push to a release branch, tag | 53 | 54 |

The one added is exactly the gcc 16 job on `ubuntu-26.04` in both cases, none removed, and no `exclude` entry is left matching nothing.

## Ordering

Depends on #596 (conan 2.32) and #598 (ubuntu-26.04), both already merged. Independent of the other compiler additions — #600 (gcc 15), #601 (macos-26-intel), #602 (clang 21) and #603 (clang 20) touch different matrix entries and can land in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu


---
_Generated by [Claude Code](https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu)_