### PR TITLE
CI: install the test dependency with the other dependencies, and package without tests

### DIFF
--- a/.github/workflows/actions/conan/build/action.yaml
+++ b/.github/workflows/actions/conan/build/action.yaml
@@ -4,6 +4,9 @@ inputs:
   build_type:
     description: "Which cmake build type to build (e.g. Release, Debug, RelWithDebInfo). Overrides the one in the conan profile; the build goes to build/<build_type>."
     required: true
+  build_tests:
+    description: "Whether to build the tests, as conan's True or False"
+    required: true
   extra_conan_flags:
     description: "Extra flags to add to the cmake command"
     required: true
@@ -17,4 +20,4 @@ runs:
         set -e
         conan profile show
 
-        conan build . --build=missing -s build_type=${{ inputs.build_type }} -o "&:build_tests=True" -o "&:use_ccache=True" ${{ inputs.extra_conan_flags }}
+        conan build . --build=missing -s build_type=${{ inputs.build_type }} -o "&:build_tests=${{ inputs.build_tests }}" -o "&:use_ccache=True" ${{ inputs.extra_conan_flags }}

--- a/.github/workflows/actions/conan/install_dependencies/action.yaml
+++ b/.github/workflows/actions/conan/install_dependencies/action.yaml
@@ -4,21 +4,26 @@ inputs:
   build_type:
     description: "Which cmake build type to install the dependencies for (e.g. Release, Debug, RelWithDebInfo). Overrides the one in the conan profile."
     required: true
+  build_tests:
+    description: "Whether the dependencies of the tests are needed too, as conan's True or False. Must be what the build step is given."
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Install dependencies via conan
       shell: bash
-      # build_tests is set here because it decides whether gtest is part of the
-      # dependency graph, and the build step always sets it. Without it here,
-      # gtest is missing from the local conan cache after this step and the
-      # build step goes to the conan remote to look for it, which fails when
-      # the runner cannot reach the remote. The other options the build step
-      # passes do not change the graph, except update_checks, which only ever
-      # removes libcurl from it: installing that superset is harmless.
+      # build_tests has to match what the build step is given, because it
+      # decides whether gtest is part of the dependency graph. While this step
+      # left it at its default and the build step set it, gtest was missing
+      # from the local conan cache afterwards and the build step went to the
+      # conan remote to look for it, which fails on a runner that cannot reach
+      # the remote. Of the other options the build step passes, use_ccache and
+      # those in extra_conan_flags only reach cmake, except update_checks,
+      # which only ever removes libcurl from the graph: installing that
+      # superset is harmless.
       run: |
         set -v
         set -e
         conan profile show
 
-        conan install . --build=missing -s build_type=${{ inputs.build_type }} -o "&:build_tests=True"
+        conan install . --build=missing -s build_type=${{ inputs.build_type }} -o "&:build_tests=${{ inputs.build_tests }}"

--- a/.github/workflows/actions/conan/install_dependencies/action.yaml
+++ b/.github/workflows/actions/conan/install_dependencies/action.yaml
@@ -9,9 +9,16 @@ runs:
   steps:
     - name: Install dependencies via conan
       shell: bash
+      # build_tests is set here because it decides whether gtest is part of the
+      # dependency graph, and the build step always sets it. Without it here,
+      # gtest is missing from the local conan cache after this step and the
+      # build step goes to the conan remote to look for it, which fails when
+      # the runner cannot reach the remote. The other options the build step
+      # passes do not change the graph, except update_checks, which only ever
+      # removes libcurl from it: installing that superset is harmless.
       run: |
         set -v
         set -e
         conan profile show
 
-        conan install . --build=missing -s build_type=${{ inputs.build_type }}
+        conan install . --build=missing -s build_type=${{ inputs.build_type }} -o "&:build_tests=True"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -198,6 +198,11 @@ jobs:
         extra_cxxflags: ['[]']
         extra_env_vars_for_test: [""]
         install_dependencies_manually: [false]
+        # Whether to build the test binaries, as conan's True or False. The
+        # packaging job builds what it ships, which is without them. Every
+        # other job wants them, either to run them or to compile them under
+        # the check it exists for.
+        build_tests: ["True"]
         run_build: [true]
         run_tests: [true]
         run_cpack: [false]
@@ -298,6 +303,7 @@ jobs:
             extra_cxxflags: '[]'
             extra_env_vars_for_test: ""
             install_dependencies_manually: true
+            build_tests: "True"
             run_build: true
             run_tests: true
             run_cpack: false
@@ -315,6 +321,7 @@ jobs:
             extra_conan_flags: "-o '&:use_werror=True'"
             extra_cxxflags: '[]'
             install_dependencies_manually: false
+            build_tests: "True"
             run_build: true
             run_tests: false
             run_cpack: false
@@ -333,6 +340,7 @@ jobs:
             extra_conan_flags: "-o '&:use_werror=True'"
             extra_cxxflags: '["-D_LIBCPP_ENABLE_NODISCARD=1", "-D_LIBCPP_ENABLE_DEPRECATION_WARNINGS=1"]'
             install_dependencies_manually: false
+            build_tests: "True"
             run_build: true
             run_tests: false
             run_cpack: false
@@ -352,6 +360,7 @@ jobs:
             extra_cxxflags: '["-DCRYFS_NO_COMPATIBILITY"]'
             extra_env_vars_for_test: ""
             install_dependencies_manually: false
+            build_tests: "True"
             run_build: true
             run_tests: true
             run_cpack: false
@@ -371,6 +380,7 @@ jobs:
             extra_cxxflags: '[]'
             extra_env_vars_for_test: ""
             install_dependencies_manually: false
+            build_tests: "True"
             run_build: true
             run_tests: true
             run_cpack: false
@@ -390,6 +400,7 @@ jobs:
             extra_cxxflags: '[]'
             extra_env_vars_for_test: ""
             install_dependencies_manually: false
+            build_tests: "False"
             run_build: true
             run_tests: false
             run_cpack: true
@@ -412,6 +423,7 @@ jobs:
             extra_cxxflags: '["-O1", "-fsanitize=address", "-fno-omit-frame-pointer", "-fno-optimize-sibling-calls", "-fno-common", "-fsanitize-address-use-after-scope"]'
             extra_env_vars_for_test: ASAN_OPTIONS="detect_leaks=1 check_initialization_order=1 detect_stack_use_after_return=1 detect_invalid_pointer_pairs=1 atexit=1"
             install_dependencies_manually: false
+            build_tests: "True"
             run_build: true
             run_tests: true
             run_cpack: false
@@ -431,6 +443,7 @@ jobs:
             extra_cxxflags: '["-O1", "-fno-sanitize-recover=undefined,nullability,implicit-conversion,unsigned-integer-overflow,local-bounds,float-divide-by-zero", "-fno-omit-frame-pointer", "-fno-optimize-sibling-calls", "-fno-common"]'
             extra_env_vars_for_test: UBSAN_OPTIONS="print_stacktrace=1"
             install_dependencies_manually: false
+            build_tests: "True"
             run_build: true
             run_tests: true
             run_cpack: false
@@ -449,6 +462,7 @@ jobs:
             extra_conan_flags: ""
             extra_cxxflags: '["-O2", "-fsanitize=thread", "-fno-omit-frame-pointer", "-fno-omit-frame-pointer", "-fno-optimize-sibling-calls", "-fno-common"]'
             install_dependencies_manually: false
+            build_tests: "True"
             run_build: true
             run_tests: true
             run_cpack: false
@@ -469,6 +483,7 @@ jobs:
             extra_conan_flags: ""
             extra_cxxflags: '[]'
             install_dependencies_manually: false
+            build_tests: "True"
             run_build: false
             run_tests: false
             run_cpack: false
@@ -546,33 +561,39 @@ jobs:
         uses: ./.github/workflows/actions/conan/install_dependencies
         with:
           build_type: Debug
+          build_tests: ${{ matrix.build_tests }}
       - name: Build (Debug)
         if: ${{ matrix.run_build && !matrix.install_dependencies_manually && contains(matrix.build_types, 'Debug') }}
         uses: ./.github/workflows/actions/conan/build
         with:
           build_type: Debug
+          build_tests: ${{ matrix.build_tests }}
           extra_conan_flags: ${{ matrix.extra_conan_flags}}
       - name: Install dependencies (Release)
         if: ${{ !matrix.install_dependencies_manually && contains(matrix.build_types, 'Release') }}
         uses: ./.github/workflows/actions/conan/install_dependencies
         with:
           build_type: Release
+          build_tests: ${{ matrix.build_tests }}
       - name: Build (Release)
         if: ${{ matrix.run_build && !matrix.install_dependencies_manually && contains(matrix.build_types, 'Release') }}
         uses: ./.github/workflows/actions/conan/build
         with:
           build_type: Release
+          build_tests: ${{ matrix.build_tests }}
           extra_conan_flags: ${{ matrix.extra_conan_flags}}
       - name: Install dependencies (RelWithDebInfo)
         if: ${{ !matrix.install_dependencies_manually && contains(matrix.build_types, 'RelWithDebInfo') }}
         uses: ./.github/workflows/actions/conan/install_dependencies
         with:
           build_type: RelWithDebInfo
+          build_tests: ${{ matrix.build_tests }}
       - name: Build (RelWithDebInfo)
         if: ${{ matrix.run_build && !matrix.install_dependencies_manually && contains(matrix.build_types, 'RelWithDebInfo') }}
         uses: ./.github/workflows/actions/conan/build
         with:
           build_type: RelWithDebInfo
+          build_tests: ${{ matrix.build_tests }}
           extra_conan_flags: ${{ matrix.extra_conan_flags}}
       - name: Build (with local dependencies)
         # Only the "Local dependencies" configuration takes this path, and it
@@ -721,10 +742,12 @@ jobs:
         uses: ./.github/workflows/actions/conan/install_dependencies
         with:
           build_type: ${{ matrix.build_type }}
+          build_tests: "True"
       - name: Build
         uses: ./.github/workflows/actions/conan/build
         with:
           build_type: ${{ matrix.build_type }}
+          build_tests: "True"
           extra_conan_flags: "-o '&:windows_dokany_path=C:/Program Files/Dokan/DokanLibrary-2.2.0'"
       - name: Save ccache
         uses: ./.github/workflows/actions/ccache/cache


### PR DESCRIPTION
## The problem

`conan install .` ran without `build_tests`, and `conan build .` always set it. The option decides whether gtest is part of the dependency graph:

```python
if self.options.build_tests:
    self.requires("gtest/1.15.0")
```

So after the install step gtest was not in the local conan cache, and the build step went to the conan remote to look for it. When a runner cannot resolve the remote's host, the build fails. That killed the `macos-15-intel, clang 17` job on the run for #628, after its Debug build and all three Debug test binaries had passed:

```
ERROR: Failed checking for binary 'gtest/1.15.0:ae18f36...' in remote 'conancenter': remote not available
ERROR: HTTPSConnectionPool(host='center2.conan.io', port=443): Max retries exceeded with url:
/v1/ping (Caused by NameResolutionError("... Failed to resolve 'center2.conan.io'
([Errno 8] nodename nor servname provided, or not known)"))
```

## The change

Both conan steps now take `build_tests`, so the two always resolve the same graph. gtest is installed with everything else and the build step resolves it locally instead of from the remote. No work is added, it just happens in the step meant for it, before the conan cache is saved.

## Why the packaging job now passes False

Simply hardcoding the option to True in the install step would have removed the only place in CI where conan resolved a graph *without* the tests, and nothing else covered that configuration. The build step set the option for every job, so **no job had ever compiled CryFS with `BUILD_TESTING` off** — the packaging job included, which built the test binaries, never ran them, and packaged the result.

So the packaging job now builds what it ships. That configuration goes from being covered by a dependency-graph resolution to being covered by a full cmake configure, build and package, followed by the existing installation tests that unpack each artifact and run `cryfs --version` from it. The job also stops compiling test binaries nobody runs.

Every other job passes True. The ones that do not run their tests still want them compiled, because compiling the test code is the point of the check: the two werror jobs and clang-tidy.

## Notes

Of the remaining options the build step passes, `use_ccache` and everything in `extra_conan_flags` only reach cmake variables in `build()`. The exception is `update_checks`, which drops libcurl from the graph when false, used by the `No update checks` job. Installing libcurl there anyway leaves the build's graph a subset of what is installed, which is the harmless direction, so it stays out of this change.

actionlint reports no missing action inputs, which is what confirms all eight call sites pass the new one. The four findings it does report on `conan/setup` are pre-existing and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X