### PR TITLE
CI: look for dead doc links without documenting the dependencies too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,14 +344,19 @@ jobs:
       with:
         toolchain: stable
     - name: Cache compiled dependencies
-      # Same as in the test job: the dependency artifacts and the generated
-      # documentation of the dependencies from the last main build of this
-      # job, keyed by job, rustc version and lockfile.
+      # Same as in the test job: the compiled dependency artifacts from the
+      # last main build of this job, keyed by job, rustc version and lockfile.
       uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
       with:
         save-if: ${{ github.ref == 'refs/heads/main' }}
         cache-on-failure: true
-    - run: RUSTDOCFLAGS="-Dwarnings" cargo doc
+    # --no-deps builds the documentation of this workspace only. Links into the
+    # dependencies still resolve, because rustdoc reads their metadata either
+    # way, so this job finds the same dead links as before; what it stops doing
+    # is generating the dependencies' own pages, which was nearly all of its
+    # runtime. A documentation warning inside a dependency can also no longer
+    # fail this job through -Dwarnings.
+    - run: RUSTDOCFLAGS="-Dwarnings" cargo doc --no-deps
   coverage:
     name: Code Coverage
     needs: should_run


### PR DESCRIPTION
## Why

The job exists to find dead links in this workspace's documentation, but it builds the documentation of every dependency as well. That is nearly all of its runtime: on the run for the #627 merge, with a warm cache, the step reported

```
Finished `dev` profile [unoptimized + debuginfo] target(s) in 6m 08s
```

in a job that took 6.6 minutes end to end.

Measured locally from the state CI is actually in, with the compiled dependencies restored from the cache and no generated documentation present:

| | wall time | units documented | `target/doc` |
|---|---|---|---|
| `cargo doc` | 12m 05s | 350 | 1.4 GB |
| `cargo doc --no-deps` | 11.5s | 26 | 45 MB |

(This machine is slower than the runner, hence 12 minutes against the runner's 6; the ratio is the point.)

## Why the cache does not already solve this

Worth stating, because it looks like it should. On a *fully warm* target directory the two commands are indistinguishable, 1m 13s against 1m 15s, since the dependency pages are already generated and cargo skips them. But rust-cache cleans the target directory before saving and does not keep `target/doc`, which is why the job's log re-documents every dependency on every run.

Caching them instead would mean carrying the 1.4 GB above in every save, against a 20 GB store that is already at 64%. Not documenting them at all is the cheaper answer.

## Does `--no-deps` still catch the same things?

Yes. Rustdoc reads the dependencies' metadata either way, so intra-doc links into them still resolve; what goes away is generating their pages. Checked both directions on `cryfs-utils`, whose documentation links into tokio.

A link to an item that does not exist still fails the build, under both the old command and the new one:

```
error: unresolved link to `DoesNotExistAnywhere`
error: could not document `cryfs-utils`
exit=101
```

and the links into tokio and std, in that same doc comment, are not reported. With only those links present it passes clean.

Doctests are unaffected: `cargo doc` does not run them, and the test jobs already do.

## Side benefit

A documentation warning inside a dependency can no longer fail this job through `-Dwarnings`. That was never something this workspace could fix.

The cache step's comment is updated because it claimed to cache the dependencies' generated documentation, which it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X