### PR TITLE
Stop the clock from pruning the cache in two LockingBlockStore tests

### DIFF
--- a/crates/blockstore/src/high_level/implementations/locking/tests.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/tests.rs
@@ -112,7 +112,6 @@ async fn test_whenCallingCreate_thenReturnsCorrectBlockId() {
 #[tokio::test]
 async fn test_whenRemovingABlockThatWasJustCreatedButNotFlushed_thenWasNeverCreatedAndDoesntRemove()
 {
-    // TODO This is potentially flaky. Let's make sure cache doesn't get pruned, maybe set flush time to infinity?
     let mut underlying_store = make_mock_block_store();
     underlying_store
         .expect_exists()
@@ -120,6 +119,10 @@ async fn test_whenRemovingABlockThatWasJustCreatedButNotFlushed_thenWasNeverCrea
     underlying_store.expect_store().never();
     underlying_store.expect_remove().never();
     let mut store = LockingBlockStore::new(underlying_store);
+    // The block below stays in the cache for the whole test. The periodic pruning would
+    // write it back to the base store and evict it, which is exactly what this test
+    // asserts doesn't happen, so it must not run on the clock's schedule.
+    store.stop_periodic_cache_pruning().await.unwrap();
 
     let block_id = store.create(&data(1024, 0)).await.unwrap();
     let block = store.load(block_id).await.unwrap().unwrap();
@@ -134,7 +137,6 @@ async fn test_whenRemovingABlockThatWasJustCreatedButThenFlushed_thenActuallyRem
     // but forgot to set the cache entry to "this block exists in the base store", so a later remove
     // didn't actually remove it from the base store.
 
-    // TODO This is potentially flaky. Let's make sure cache doesn't get pruned, maybe set flush time to infinity?
     let mut underlying_store = make_mock_block_store();
     underlying_store
         .expect_exists()
@@ -148,6 +150,10 @@ async fn test_whenRemovingABlockThatWasJustCreatedButThenFlushed_thenActuallyRem
         .once()
         .return_once(|_| Box::pin(async { Ok(crate::utils::RemoveResult::SuccessfullyRemoved) }));
     let mut store = LockingBlockStore::new(underlying_store);
+    // The periodic pruning would evict the block between creating and loading it, so the
+    // load would go to the base store and the write-back would be a second store call.
+    // This test counts both, so pruning must not run on the clock's schedule.
+    store.stop_periodic_cache_pruning().await.unwrap();
 
     let block_id = store.create(&data(1024, 0)).await.unwrap();
     let mut block = store.load(block_id).await.unwrap().unwrap();


### PR DESCRIPTION
Follow-up to #609, which noted these two TODOs.

## Problem

Two `LockingBlockStore` tests carried the same note:

```
// TODO This is potentially flaky. Let's make sure cache doesn't get pruned, maybe set flush time to infinity?
```

Both drive a block through the cache against a mock base store. A prune landing mid-test breaks each in a different way. Both were reproduced by sleeping past the prune interval before the block is loaded:

| Test | What the prune does | What the mock reports |
|---|---|---|
| `..ButNotFlushed_thenWasNeverCreatedAndDoesntRemove` | Writes the dirty block back, though the test asserts the base store is never written to | `MockBlockStore::store: Expectation(<anything>) should not have been called` |
| `..ButThenFlushed_thenActuallyRemoves` | Evicts the block between `create` and `load`, since the entry is unlocked there, so the load falls through to the base store | `MockBlockStore::load(...): No matching expectation found` |

## Fix

`LockingBlockStore::stop_periodic_cache_pruning` landed in #609, so the timer can be turned off rather than given an infinite flush time as the TODO suggested. One call per test, right after the store is built, plus a comment saying which expectation the prune would break.

With the timer stopped, both tests pass even with the reproduction sleep still in place. The sleeps were only for the reproduction and are not part of this change.

## The other tests in the file are unaffected

I checked all five. They either expect exactly one write, which happens on prune or on destruction but not both, or they never get a block into the cache at all. So the two TODOs marked exactly the exposed tests.

## Risk this was fixing

Low but real. These tests run in microseconds, and a prune needs the block to sit untouched for half a second, so they only failed on a machine stalled as badly as the macOS runner behind #609. Same class of failure, one layer down.

## Verification

- Reproduced both failures on unmodified code, then confirmed both pass with the fix and the sleep still present.
- `cargo test -p cryfs-blockstore`: 3085 passed, 0 failed.
- `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rvim5Wko3GoV2kTiEJnhsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rvim5Wko3GoV2kTiEJnhsJ)_