### PR TITLE
CI: let a run on main finish instead of cancelling it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,26 @@ on:
       - '**'
   pull_request:
 
-# Cancel in-progress runs on the same ref when a new commit is pushed,
-# so a fix-up push doesn't have to wait behind the superseded run.
+# One run per ref at a time. On a branch carrying a pull request, a new commit
+# cancels the run of the one it replaces, so a fix-up push doesn't wait behind a
+# superseded run.
+#
+# On main it does not. A run there is the only thing that refreshes the caches
+# every other run restores, because GitHub scopes a cache to the branch that
+# wrote it and only the default branch's caches can be read from everywhere, so
+# the test jobs save from main alone. Cancelling main meant that while merges
+# arrived more often than a run takes, no run ever reached its cache-saving
+# steps and the caches went stale.
+#
+# The group still keeps main to one run at a time, and holds one pending run
+# behind it: further merges replace whatever is pending rather than piling up,
+# so the run that starts next is the newest commit at that moment, not a queue
+# of stale ones. The cost is that main's results lag by up to the length of a
+# run, and commits that were only ever the pending one are not built on their
+# own.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## The problem

A run on main is the only thing that refreshes the caches every other run restores. GitHub scopes a cache to the branch that wrote it, and only the default branch's caches can be read from everywhere, which is why the test jobs carry `save-if: github.ref == 'refs/heads/main'`.

Cancelling in-progress runs on main therefore has a failure mode that only appeared once the caches were in use: while merges arrive more often than a run takes, every run is cancelled before reaching its cache-saving steps, so the caches never refresh and every job that restores one misses.

That is not hypothetical. The run for #631 was cancelled thirty minutes in by the next merge, with 18 jobs finished and 32 cancelled, having saved nothing. Our runs currently take many hours and merges have been arriving every half hour or so.

## The change

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Branches carrying a pull request keep cancelling, because there a fix-up push should not wait behind the run it supersedes.

## What this does and does not do

The concurrency group is unchanged, so this does **not** start a run per commit. A group holds one run in progress plus at most one pending, and a new arrival evicts whatever was pending. So on main:

| Event | Result |
|---|---|
| Merge 1 | run A starts |
| Merge 2 | run B pending |
| Merge 3 | run B cancelled, run C pending |
| A finishes, having saved its caches | C starts |

One run at a time, and the run that starts next covers the newest commit at that moment rather than working through a backlog of stale ones.

## Costs, so they are on the record

- Main's results lag by up to the length of a run.
- A commit that was only ever the pending one gets no run of its own. Note that today's setting has the same gap, and additionally never finishes anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_