### PR TITLE
CI: let a run on a release branch finish instead of cancelling it

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,13 +15,25 @@ on:
       - '**'
   pull_request:
 
-# Cancel in-progress runs on the same ref when a new commit is pushed, so a fix-up
-# push doesn't have to wait behind the superseded run. Without this, runs for commits
-# that no longer exist kept occupying the queue and reporting failures long after the
-# branch had moved on. Same setting the Rust workflow on main already uses.
+# One run per ref at a time. On a branch carrying a pull request, a new commit
+# cancels the run of the one it replaces, so a fix-up push doesn't have to wait behind
+# the superseded run. Without that, runs for commits that no longer exist kept
+# occupying the queue and reporting failures long after the branch had moved on.
+#
+# The release branches are exempt, because that is where this project's code lives and
+# a run there is worth finishing: it is the one that refreshes the ccache and conan
+# caches from the real branch state, and its packaging job is the only build of what
+# actually ships. While merges arrive more often than a run takes, cancelling means no
+# run ever reaches those steps.
+#
+# The group still keeps a release branch to one run at a time, and holds one pending
+# run behind it: further merges replace whatever is pending rather than queueing up, so
+# the run that starts next covers the newest commit at that moment. The cost is that
+# results lag by up to the length of a run, and a commit that was only ever the pending
+# one gets no run of its own. Same setting the Rust workflow uses for main.
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
 
 jobs:
   should_run:


### PR DESCRIPTION
The same change as #633, for this workflow's trunk.

## Why

The release branches are where this project's code lives, so a run there is the one worth finishing:

- it refreshes the ccache and conan caches from the real branch state, and
- its packaging job is the only build in CI of what actually ships, since #630.

Cancelling in-progress runs there means that while merges arrive more often than a run takes, no run ever reaches those steps. Runs here take a few hours once the macOS jobs are counted.

## The change

```yaml
cancel-in-progress: ${{ !startsWith(github.ref, 'refs/heads/release/') }}
```

Branches carrying a pull request keep cancelling, which is what the setting was added for: a fix-up push should not wait behind the run it supersedes, and runs for commits that no longer exist should not keep occupying the queue.

## What this does and does not do

The concurrency group is unchanged, so this does **not** start a run per commit. A group holds one run in progress plus at most one pending, and a new arrival evicts whatever was pending. A release branch still runs one at a time, and the run that starts next covers the newest commit at that moment.

The costs are that results lag by up to the length of a run, and that a commit which was only ever the pending one gets no run of its own. Today's setting has that same gap and additionally never finishes anything.

## Note on scope

This is slightly less critical here than on the Rust side, because #621 made pull request runs of this repository's own branches refresh the S3 caches too, so the caches do not depend on trunk runs alone. The packaging build and the value of not discarding a run that is already hours in still apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_