### PR TITLE
CI: run a subset of the macOS test jobs on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,42 @@ jobs:
       pull-requests: read
     outputs:
       run: ${{ steps.check.outputs.run }}
+      test_matrix: ${{ steps.matrix.outputs.test_matrix }}
     steps:
+      - name: Decide which test combinations this event runs
+        id: matrix
+        # A pull request runs every Linux combination and two macOS ones; a
+        # push to main or a tag runs all of them. The macOS jobs are what the
+        # five concurrent macOS runners the account gets have to be spent on,
+        # and they are long: a debug job is around 80 minutes and a release
+        # job on the Intel runner around 300, against 50 to 110 for Linux. At
+        # eighteen per run they were most of the queue.
+        #
+        # What the two kept ones are for: the Linux jobs already cover x86_64
+        # in both profiles on all three toolchains, so what macOS adds is the
+        # Darwin platform and, on macos-15, the only aarch64-apple-darwin
+        # build anything here does. Both profiles stay because the release
+        # profile is a different build, and because the cryfs-cli test for the
+        # release-build warning only runs there. The toolchain is stable only:
+        # a nightly regression or a use of something newer than the minimum
+        # supported version is almost never specific to a platform, and the
+        # Linux jobs still check all three on every pull request.
+        #
+        # Nothing is lost from main, which keeps every combination.
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          full='{"os":["macos-15","macos-15-intel","macos-26","ubuntu-22.04","ubuntu-24.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"]}'
+          pr='{"os":["macos-15","ubuntu-22.04","ubuntu-24.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"],"exclude":[{"os":"macos-15","toolchain":"nightly"},{"os":"macos-15","toolchain":"1.95"}]}'
+          if [[ "$EVENT" == "pull_request" ]]; then
+            matrix="$pr"
+          else
+            matrix="$full"
+          fi
+          # A malformed matrix fails every job with an unhelpful message, so
+          # check it here where the error is readable.
+          echo "$matrix" | python3 -m json.tool > /dev/null
+          echo "test_matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Look for an open pull request from this branch
         id: check
         env:
@@ -87,17 +122,10 @@ jobs:
     if: needs.should_run.outputs.run == 'true'
     strategy:
       fail-fast: false
-      matrix:
-        os:
-          - macos-15
-          - macos-15-intel
-          - macos-26
-          - ubuntu-22.04
-          - ubuntu-24.04
-        command: ["test"]
-        profile: ["", "--release"]
-        toolchain: ["stable", "nightly", "1.95"]
-        # The feature sets are not a matrix axis; see the cargo step below.
+      # Built by the should_run job above, because which combinations run
+      # depends on the event and a matrix cannot ask that itself. The feature
+      # sets are not a matrix axis either; see the cargo step below.
+      matrix: ${{ fromJSON(needs.should_run.outputs.test_matrix) }}
     runs-on: ${{matrix.os}}
     env:
       # `brew install` otherwise starts with a `brew update` of the whole tap.


### PR DESCRIPTION
## Why

The account gets five concurrent macOS runners. The macOS test jobs are both the longest and the most numerous thing competing for them: about 80 minutes for a debug job and about 300 for a release job on the Intel runner, against 50 to 110 for Linux, eighteen per run.

A snapshot taken while writing this, with sixteen runs active after a burst of branch pushes:

| | |
|---|---|
| macOS jobs running | 5, the cap |
| macOS jobs queued | 169 |
| Estimated work queued | ~244 macOS-hours |

The Rust macOS jobs were about half those jobs and roughly 85% of the time.

## What changes

A pull request runs **two** macOS jobs and **every Linux combination**, unchanged. A push to main or a tag still runs all eighteen.

| Event | Test jobs | macOS | Linux |
|---|---|---|---|
| push to main, tag | 30 | 18 | 12 |
| pull request | 14 | 2 | 12 |

Measured against yesterday's durations for these same configurations:

| Per pull request run | Before | After |
|---|---|---|
| macOS runner time | 45.5 h | 3.7 h |
| Longest single job | 253 min | 136 min |

So pull request feedback gets faster as well as cheaper.

## Why these two

`macos-15` in both profiles, on stable.

- The Linux jobs already build x86_64 in both profiles on all three toolchains, so what macOS adds is the Darwin platform, and on `macos-15` the only **aarch64-apple-darwin** build anything here does. Dropping the Intel macOS runner from pull requests loses least, because x86_64 is the architecture Linux covers thoroughly.
- **Both profiles stay.** The release profile is a different build, and the cryfs-cli test for the release-build warning only runs there, since #615.
- **Stable only.** A nightly regression, or a use of something newer than the minimum supported version, is almost never specific to a platform, and the Linux jobs still check all three toolchains on every pull request.

Nothing stops being tested before a change reaches main, because main keeps the full matrix.

## Implementation note

Which combinations run now depends on the event, and a matrix cannot ask that itself. A job-level `if` cannot either, since the `matrix` context is not available there, and conditioning the steps instead would still occupy a macOS runner for every skipped job. So the `should_run` job builds the matrix and the test job consumes it with `fromJSON`.

The step validates the JSON before emitting it, because a malformed matrix otherwise fails every job with an unhelpful message.

I verified the expansion locally by reproducing GitHub's cross-product-minus-exclude on both documents; the job counts and the exact combinations in the tables above are that simulation's output, and the gate script itself runs clean for both event types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_