### PR TITLE
ci: add macos-26-intel to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
         run: |
-          full='{"os":["macos-15","macos-15-intel","macos-26","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","beta","nightly","1.95"]}'
+          full='{"os":["macos-15","macos-15-intel","macos-26","macos-26-intel","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","beta","nightly","1.95"]}'
           pr='{"os":["macos-15","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"],"exclude":[{"os":"macos-15","toolchain":"nightly"},{"os":"macos-15","toolchain":"1.95"}]}'
           if [[ "$EVENT" == "pull_request" ]]; then
             matrix="$pr"


### PR DESCRIPTION
Adds `macos-26-intel` to the `test` job's full matrix. Last of the three independent CI-version additions, after #597 and #637.

## Why

The matrix builds macOS 26 on aarch64 (`macos-26`) and macOS 15 on x86_64 (`macos-15-intel`), but nothing on **macOS 26 x86_64**. That is the combination our Intel macOS users land on once they upgrade, and the one where a Homebrew, macFUSE or SDK change on the newest macOS would show up first on x86_64.

## Where it goes, and what it costs

Full matrix only. The pull-request matrix is untouched: #635 cut it to two macOS jobs deliberately — the account gets five concurrent macOS runners and the long macOS jobs were most of the queue — so adding a third macOS image there would undo that. Every combination still runs on main, which is where this is meant to catch things.

**Cost, updated after #637 merged.** This was written when it would have added six jobs. #637 added `beta` in between, so the fourth toolchain multiplies through and it now adds **eight**:

| | before | after |
|---|---|---|
| full matrix, total | 48 | **56** |
| full matrix, macOS | 24 | **32** |

Eight new jobs = two profiles × four toolchains. Worth being explicit since macOS runners are the constrained resource.

## Testing

Validated on [run 34438269666](https://github.com/cryfs/cryfs/actions/runs/34438269666), with the rest of the workflow temporarily disabled so only the new jobs ran.

**The runner label resolves and the suite passes on it.** Four of the six jobs that existed at the time concluded; three passed outright:

| job | `cargo test` |
|---|---|
| `test (macos-26-intel, test, nightly)` | ✅ 3h47m |
| `test (macos-26-intel, test, --release, nightly)` | ✅ 3h55m |
| `test (macos-26-intel, test, 1.95)` | ✅ 3h01m |
| `test (macos-26-intel, test, stable)` | ❌ see below |

The fourth failed on **one** test, and not for a reason to do with this change:

```
test_macro_package_version::matches_git_version ... FAILED
  spurious network error: [6] Couldn't resolve host name (Could not resolve host: index.crates.io)
  error: failed to get `serde_json` as a dependency of package `cryfs-version-test`
  Caused by: unable to update registry `crates-io` ... download of config.json failed
```

`crates/cryfs-version/tests/cryfs-version.rs` builds a throwaway cargo project that declares `serde_json` and resolves it from crates.io *at test time*, so a resolver hiccup fails it. The proof that it is transient is inside that same job: the default-features pass failed the test at 15:08Z, and the `--no-default-features` pass ran the identical test on the same runner at 17:00Z and it **passed**. The other three jobs passed it too.

That test has a hard network dependency and can fail on any macOS runner, not just this one — the workflow already skips `version::http_client::tests::reqwest_http_client::test_get_valid_` on macOS citing the same resolver flakiness (actions/runner-images#12562, actions/runner-images#8649). Making it robust is worth doing but does not belong in a CI-matrix PR.

**Not covered by that run:** `stable --release`, `1.95 --release`, and both `beta` combinations (beta did not exist on main yet). Those are cross-products of things proven individually — the release profile works on this image via nightly, and stable/1.95 work on it in debug — but they are genuinely untested. The failure mode if one is wrong is a new job going red on main, visible and revertible by reverting one line; it cannot break an existing job or remove existing coverage.

**Cost note:** those ~3h50m figures are *cold* builds. `rust-cache` has `save-if: github.ref == 'refs/heads/main'`, so a branch never saves; every job with a new cache key rebuilds the whole dependency tree — vendored OpenSSL included — twice, once per feature set, on a 3-core runner. After merge, main's first run seeds the caches and later runs restore them, which should bring these in line with the 1h19m–2h24m the other macOS jobs take warm. Even cold they leave about two hours of headroom under GitHub's 6h job limit.

The head is that verified change rebased onto main `20db855` (which carries #637), with the one-line matrix edit re-derived. Re-validated locally: the YAML parses, both matrices parse as JSON — the same check the workflow runs on itself — and they expand to 56 and 20 jobs with the eight new ones in `full` only. Its CI run was cancelled deliberately, at the maintainer's request, since these combinations run on main after merge anyway and the pull-request matrix cannot exercise them.

## AI disclosure

Per `AI_POLICY.md`: drafted with AI assistance (Claude Code). The crates.io failure was diagnosed from the CI logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kjjwx5NLxkKfB84jN6aYi7