### PR TITLE
ci: add the Rust beta toolchain to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
         run: |
-          full='{"os":["macos-15","macos-15-intel","macos-26","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"]}'
+          full='{"os":["macos-15","macos-15-intel","macos-26","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","beta","nightly","1.95"]}'
           pr='{"os":["macos-15","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"],"exclude":[{"os":"macos-15","toolchain":"nightly"},{"os":"macos-15","toolchain":"1.95"}]}'
           if [[ "$EVENT" == "pull_request" ]]; then
             matrix="$pr"


### PR DESCRIPTION
Adds `beta` to the `test` job's full matrix. Last of the three independent CI-version additions, after #597 and #636.

## Why

The matrix tests `stable`, `nightly` and the `1.95` minimum. Beta is the gap in between: it is what stable becomes in six weeks, so a regression that lands there is one we can report upstream while it can still be fixed *before* release, rather than discovering it the day stable moves.

Nightly does not cover this. It is far enough ahead that a nightly-only break is often churn that never reaches a release — which is exactly why a nightly failure is easy to wave through. A beta failure is a concrete warning about the next stable.

## Where it goes, and why not on pull requests

Full matrix only: 36 → 48 jobs on main, twelve new (six runner images × two profiles).

The pull-request matrix is untouched, for two reasons. What beta watches for is a property of the upstream release train, not of the diff under review, so an upstream regression should not redden every open pull request at once. And a fourth toolchain in the PR matrix would also pull a third macOS job in past the cut #635 made to conserve the five concurrent macOS runners.

## Testing

Validated on [run 34438272091](https://github.com/cryfs/cryfs/actions/runs/34438272091) against the pre-rebase head, with the rest of the workflow temporarily disabled so only the new beta jobs ran.

**Beta installs cleanly and the workspace compiles and passes on it.** Six of the ten jobs concluded before I stopped the run, all green — no failures anywhere:

| job | `cargo test` |
|---|---|
| `test (ubuntu-24.04, test, beta)` | ✅ 1h28m |
| `test (ubuntu-24.04, test, --release, beta)` | ✅ 1h29m |
| `test (ubuntu-22.04, test, beta)` | ✅ 1h41m |
| `test (ubuntu-22.04, test, --release, beta)` | ✅ 1h46m |
| `test (macos-15-intel, test, beta)` | ✅ 3h16m |
| `test (macos-15, test, --release, beta)` | ✅ 2h31m |

That covers both Linux images in both profiles, plus both macOS architectures — x86_64 via `macos-15-intel` and aarch64 via `macos-15`. The four that did not get a runner were the remaining macOS combinations, which are the same platforms already proven above on the other profile.

Note that beta is a moving target by design: unlike the other additions, this one can go red on a commit that did not change, because the toolchain underneath it moved. That is the signal, not a defect — but it does mean a red beta job should be read as "check what upstream changed" rather than "the diff broke something".

The current head is that verified change rebased onto main and re-derived for the JSON matrix #635 introduced. I re-validated locally: the YAML parses, both matrices parse as JSON (the same check the workflow runs on itself), and they expand to 48 and 20 jobs with beta in `full` only.

## AI disclosure

Per `AI_POLICY.md`: drafted with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kjjwx5NLxkKfB84jN6aYi7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kjjwx5NLxkKfB84jN6aYi7)_