### PR TITLE
ci: run the beta toolchain on Linux only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,18 @@ jobs:
         # supported version is almost never specific to a platform, and the
         # Linux jobs still check all three on every pull request.
         #
-        # Nothing is lost from main, which keeps every combination.
+        # Main keeps every combination but one: beta does not run on the
+        # macOS images. Beta is here to catch an upstream Rust regression a
+        # cycle before it reaches stable, and such a regression is almost
+        # never platform-specific -- the same reasoning that keeps the pull
+        # request macOS jobs to stable. On four macOS images it cost eight
+        # jobs for a signal the six Linux beta jobs already give. Adding a
+        # macOS image means adding it to that exclude list too, or beta
+        # starts running on it.
         env:
           EVENT: ${{ github.event_name }}
         run: |
-          full='{"os":["macos-15","macos-15-intel","macos-26","macos-26-intel","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","beta","nightly","1.95"]}'
+          full='{"os":["macos-15","macos-15-intel","macos-26","macos-26-intel","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","beta","nightly","1.95"],"exclude":[{"os":"macos-15","toolchain":"beta"},{"os":"macos-15-intel","toolchain":"beta"},{"os":"macos-26","toolchain":"beta"},{"os":"macos-26-intel","toolchain":"beta"}]}'
           pr='{"os":["macos-15","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"],"command":["test"],"profile":["","--release"],"toolchain":["stable","nightly","1.95"],"exclude":[{"os":"macos-15","toolchain":"nightly"},{"os":"macos-15","toolchain":"1.95"}]}'
           if [[ "$EVENT" == "pull_request" ]]; then
             matrix="$pr"


### PR DESCRIPTION
Follow-up to #637, which added `beta` across every runner image. Eight of its fourteen jobs landed on macOS; this excludes those.

## Why

Beta is here to catch an upstream Rust regression a cycle before it reaches stable. Such a regression is almost never platform-specific — the same argument #635 used when it cut the pull-request macOS jobs down to stable. The six Linux beta jobs give that signal; the macOS ones repeat it at several times the cost.

And they are the expensive half. Per #635's own measurements: a macOS debug job is around 80 minutes and a release job on the Intel runner around 300, against 50 to 110 for Linux — on five concurrent macOS runners.

## Effect

| | before | after |
|---|---|---|
| `full` matrix, total | 56 | **48** |
| `full` matrix, macOS | 32 | **24** |
| beta jobs | 14 (3 Linux images + 4 macOS images) | **6** (Linux only) |

The pull-request matrix is untouched — it never had beta. Every non-beta combination is untouched.

## Verification

Expanded both matrices from the branch and from `main`, applying the `exclude` rules the way Actions does, and diffed the resulting job sets:

```
BEFORE (main):   full = 56 jobs, 32 macOS, 14 beta
AFTER  (branch): full = 48 jobs, 24 macOS,  6 beta  (ubuntu-22.04, ubuntu-24.04, ubuntu-26.04)
pr matrix unchanged: 20 jobs
only removals are macOS beta:
  (macos-15, '', beta)          (macos-15, --release, beta)
  (macos-15-intel, '', beta)    (macos-15-intel, --release, beta)
  (macos-26, '', beta)          (macos-26, --release, beta)
  (macos-26-intel, '', beta)    (macos-26-intel, --release, beta)
```

So the change removes exactly the eight intended jobs and nothing else. The YAML parses and both matrices parse as JSON — the same `python3 -m json.tool` check the `should_run` job runs on itself.

## One maintenance note

The exclusions are per image, so **a macOS image added later needs an entry there too**, or beta starts running on it. That is the same shape the pull-request matrix already uses for its `nightly`/`1.95` exclusions, and I chose it over the `include` alternative deliberately: if someone forgets, the failure is two extra jobs — visible and cheap — rather than a new Linux image silently losing beta coverage. The comment above the matrix says so.

## AI disclosure

Per `AI_POLICY.md`: drafted with AI assistance (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kjjwx5NLxkKfB84jN6aYi7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kjjwx5NLxkKfB84jN6aYi7)_