### PR TITLE
CI: build one macOS runner on pull requests instead of three

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,7 +48,41 @@ jobs:
       pull-requests: read
     outputs:
       run: ${{ steps.check.outputs.run }}
+      os_list: ${{ steps.matrix.outputs.os_list }}
     steps:
+      - name: Decide which runners this event builds on
+        id: matrix
+        # A pull request builds every Linux runner and one macOS runner; a push
+        # to a release branch or a tag builds all of them. The account gets five
+        # concurrent macOS runners, and with thirteen macOS jobs per run they
+        # were the bulk of the queue by job count.
+        #
+        # macos-15 is the one kept, because what macOS adds over Linux is the
+        # Darwin platform rather than a compiler version, and the Linux runners
+        # already build clang 13 to 19 and gcc 9 to 14 on every pull request.
+        # Of the two dropped, macos-15-intel is x86_64, the architecture the
+        # Linux runners cover thoroughly, and macos-26 is a second Darwin SDK
+        # behind the same architecture as macos-15. Neither is a combination
+        # only macOS can show, and a release branch keeps both.
+        #
+        # This is the os axis alone. The build types, the compiler list and the
+        # exclusions that say which compiler exists on which runner are the same
+        # for both events, so a dropped runner takes its exclusions with it and
+        # they simply match nothing.
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          full='["macos-15","macos-15-intel","macos-26","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"]'
+          pr='["macos-15","ubuntu-22.04","ubuntu-24.04","ubuntu-26.04"]'
+          if [[ "$EVENT" == "pull_request" ]]; then
+            os_list="$pr"
+          else
+            os_list="$full"
+          fi
+          # A malformed list fails every job with an unhelpful message, so check
+          # it here where the error is readable.
+          echo "$os_list" | python3 -m json.tool > /dev/null
+          echo "os_list=$os_list" >> "$GITHUB_OUTPUT"
       - name: Look for an open pull request from this branch
         id: check
         env:
@@ -83,13 +117,8 @@ jobs:
       fail-fast: false
       matrix:
         name: [""]
-        os:
-          - macos-15
-          - macos-15-intel
-          - macos-26
-          - ubuntu-22.04
-          - ubuntu-24.04
-          - ubuntu-26.04
+        # Which runners this is depends on the event; see should_run above.
+        os: ${{ fromJSON(needs.should_run.outputs.os_list) }}
         # Every build type of a configuration is built and tested in the same
         # job, one after another, so the job pays for the runner, the checkout
         # and the compiler installation once instead of once per build type.


### PR DESCRIPTION
## Why

The account gets five concurrent macOS runners, and this workflow puts thirteen macOS jobs into every run. By job count they are the bulk of the queue — a snapshot taken while writing this:

| | |
|---|---|
| macOS jobs waiting | 110 |
| ...of them from this workflow | 91 |
| macOS slots | 5 |

## What changes

A pull request builds **macos-15** and **every Linux runner**, unchanged. A push to a release branch or a tag still builds all three macOS runners.

| Event | Total jobs | macOS | Linux |
|---|---|---|---|
| push to `release/**`, tag | 53 | 13 | 40 |
| pull request | 46 | 6 | 40 |

Measured against the last green run of this workflow, the six that stay are 94 of the 236 macOS minutes:

| Per pull request run | Before | After |
|---|---|---|
| macOS runner time | 3.9 h | 1.6 h |

## Why macos-15

What macOS adds over Linux is the Darwin platform, not a compiler version, and the Linux runners still build clang 13 to 19 and gcc 9 to 14 on every pull request.

- **macos-15-intel** is x86_64, the architecture the Linux runners cover thoroughly.
- **macos-26** is a second Darwin SDK behind the same architecture as macos-15.

Neither is a combination only macOS can show. Nothing stops being tested before a change reaches a release branch, because those keep the full set.

Worth being explicit about the one real cost: on a pull request, a break specific to the Intel Darwin runner or to the macOS 26 SDK now surfaces after merge rather than before.

## Implementation note

Only the `os` axis changes. The build types, the compiler list, and the exclusions recording which compiler exists on which runner are shared by both events, so a dropped runner takes its exclusions with it and they simply match nothing — there is no second copy of that knowledge to keep in sync.

A matrix cannot ask which event it is running under, and a job-level `if` cannot either, since the `matrix` context is not available there. So `should_run` emits the list and the job reads it with `fromJSON`. The step validates the JSON before emitting it, because a malformed list otherwise fails every job with an unhelpful message.

## Verification

I reproduced GitHub's cross-product-minus-exclude expansion over the workflow as written:

- The **push** list yields the same thirteen macOS combinations the last green run actually ran, name for name (macos-15 clang 14–19, macos-15-intel clang 15/17/19, macos-26 clang 16–19).
- The **pull request** list yields six, and **Linux stays at 40 jobs for both events**.
- The gate script runs clean for both event types.
- `actionlint` reports the same four pre-existing findings in the `windows` job before and after — no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyVQXF6AvMQdyNVSdHNw9X)_