### PR TITLE
CI: retry conan install so a failed download can be recovered

### DIFF
--- a/.github/workflows/actions/conan/install_dependencies/action.yaml
+++ b/.github/workflows/actions/conan/install_dependencies/action.yaml
@@ -21,9 +21,54 @@ runs:
       # those in extra_conan_flags only reach cmake, except update_checks,
       # which only ever removes libcurl from the graph: installing that
       # superset is harmless.
+      #
+      # A download that fails part way through leaves conan's partial
+      # conan_export.tgz behind, and conan's own retry then refuses to write over
+      # it:
+      #
+      #     <pkg>: ERROR: Error downloading from remote 'conancenter'
+      #     ERROR: Package '<pkg>' not resolved: Error, the file to download
+      #     already exists: '.../p/<pkg>/d/conan_export.tgz'
+      #
+      # so the retry conan does on its own can never succeed and the job gets one
+      # download attempt rather than several. A blip that conan is built to absorb
+      # fails the build instead. Only a cell whose cache is missing a package
+      # downloads anything at all, so this shows up on whichever few cells are
+      # cold for a package rather than across the matrix, which makes it look
+      # specific to them.
+      #
+      # Removing the download folders between attempts is what makes the retry a
+      # real one. The last attempt adds -vtrace so that if it still fails the log
+      # carries the underlying error rather than only conan's generic "Error
+      # downloading from remote".
       run: |
         set -v
         set -e
         conan profile show
 
-        conan install . --build=missing -s build_type=${{ inputs.build_type }} -o "&:build_tests=${{ inputs.build_tests }}"
+        set +e
+        attempt=1
+        max_attempts=3
+        while true; do
+          if [ "$attempt" -eq "$max_attempts" ]; then
+            verbosity=-vtrace
+          else
+            verbosity=
+          fi
+          conan install . --build=missing -s build_type=${{ inputs.build_type }} -o "&:build_tests=${{ inputs.build_tests }}" $verbosity
+          status=$?
+          if [ "$status" -eq 0 ]; then
+            break
+          fi
+          if [ "$attempt" -ge "$max_attempts" ]; then
+            echo "conan install failed after $max_attempts attempts"
+            exit "$status"
+          fi
+          echo "conan install failed (attempt $attempt of $max_attempts), discarding partially downloaded packages and retrying"
+          if [ -n "$CONAN_HOME" ]; then
+            rm -rf "$CONAN_HOME"/p/*/d
+          fi
+          sleep "$(( attempt * 5 ))"
+          attempt="$(( attempt + 1 ))"
+        done
+        set -e


### PR DESCRIPTION
## The problem

A download from the conan remote that fails part way through leaves conan's partial
`conan_export.tgz` behind, and conan's own retry then refuses to write over it:

```
spdlog/1.17.0: ERROR: Error downloading from remote 'conancenter'
ERROR: Package 'spdlog/1.17.0' not resolved: Error, the file to download already exists:
'.../conan-cache/p/spdlof9f2ab191c50e/d/conan_export.tgz'
```

So the retry conan performs on its own can never succeed, and a job ends up with a single
usable download attempt rather than several. A transient failure that conan is built to
absorb fails the build instead.

Only a cell whose cache is missing a package downloads anything at all — everything else
resolves `- Cache` from the restored cache and never touches the network. That is why this
surfaces on whichever few cells happen to be cold for a package, and looks specific to
them. It is not. The same signature hit `boost/1.84.0` on `ubuntu-22.04` with clang 16 and
gcc 11 across five runs over several days, and then `spdlog/1.17.0` on that same clang-16
cell four minutes after spdlog 1.17.0 landed on `release/1.0` — a package that had never
been in any cache, so the stale file could not have come from one.

## The change

`conan install` now gets up to three attempts. Between attempts the download folders are
removed:

```
rm -rf "$CONAN_HOME"/p/*/d
```

which is what makes the retry a real one rather than a guaranteed repeat of the same error.

The final attempt adds `-vtrace`, so that if all three fail the log carries the underlying
error instead of only conan's generic `Error downloading from remote`. That underlying cause
is currently invisible, and it is the thing that actually needs fixing — this change makes it
observable the next time it happens.

The common path is untouched: one attempt, no added verbosity, no delay.

## Validation

The loop was checked locally against a stub `conan`:

| scenario | result |
| --- | --- |
| install succeeds first try | 1 attempt, no trace, no delay |
| fails twice, then succeeds | partial cleared between attempts, exit 0 |
| fails all three times | job still fails, with `-vtrace` on the last attempt |

Then on CI, restricted to the two cells that currently have to download
(`ubuntu-22.04` × clang 16 / gcc 11), in run
[34624159366](https://github.com/cryfs/cryfs/actions/runs/34624159366): both cells green end
to end — install, build and tests for all three build types, and `Save conan cache`
succeeded on both, so those two cache keys now hold boost.

One caveat, stated plainly: that run does **not** prove the retry fired. The marker sits in
the middle of the install step under ~31 minutes of build output, and the log API available
to me is tail-only, so I could not read it back. The install may simply have succeeded on its
first attempt this time. What the run does show is that the change is harmless on the success
path and that the affected cells build and test cleanly. The retry's value is prospective:
the next time a cell is cold for a newly bumped dependency — exactly the spdlog 1.17.0 case
above — it gets more than one shot at the download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01KcjEjybKk82rBayppjutfu)_