### PR TITLE
Make AsyncDrop take self by value and use native async fn in traits

### DIFF
--- a/.claude/skills/async-drop/SKILL.md
+++ b/.claude/skills/async-drop/SKILL.md
@@ -18,23 +18,40 @@ Rust's `Drop` trait is synchronous, but sometimes cleanup needs to be async. The
 ## Quick Reference
 
 ```rust
-// Creating
-let mut guard = AsyncDropGuard::new(my_value);
+// Creating (no `mut` needed unless you mutate the value)
+let guard = AsyncDropGuard::new(my_value);
 
 // Using (transparent via Deref)
 guard.do_something();
 
-// Cleanup (REQUIRED before dropping)
+// Cleanup (REQUIRED before dropping). Consumes the guard:
+// using `guard` after this line is a compile error.
 guard.async_drop().await?;
 ```
 
 ## The AsyncDrop Trait
 
 ```rust
-#[async_trait]
 pub trait AsyncDrop {
     type Error: Debug;
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error>;
+    fn async_drop_impl(self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+```
+
+Implement it as a plain `async fn async_drop_impl(self)` without `#[async_trait]`.
+`self` is taken by value, so destructure it to move `AsyncDropGuard` members out
+and drop them:
+
+```rust
+impl AsyncDrop for MyType {
+    type Error = anyhow::Error;
+
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { connection, cache, .. } = self;
+        cache.async_drop().await?;
+        connection.async_drop().await?;
+        Ok(())
+    }
 }
 ```
 
@@ -43,8 +60,10 @@ pub trait AsyncDrop {
 | Rule | Description |
 |------|-------------|
 | **Always call async_drop()** | Every `AsyncDropGuard` must have `async_drop()` called |
+| **async_drop() consumes the guard** | Use-after-drop and double-drop are compile errors |
 | **Factory methods return guards** | `fn new() -> AsyncDropGuard<Self>`, never plain `Self` |
-| **Types with guard members impl AsyncDrop** | Delegate to member async_drops |
+| **Types with guard members impl AsyncDrop** | `async fn async_drop_impl(self)`: destructure `self`, drop members |
+| **No `#[async_trait]` on AsyncDrop impls** | The trait uses native `async fn` in traits |
 | **Use the macro when possible** | `with_async_drop_2!` handles cleanup automatically |
 | **Panics are exceptions** | It's OK to skip async_drop on panic paths |
 

--- a/.claude/skills/async-drop/SKILL.md
+++ b/.claude/skills/async-drop/SKILL.md
@@ -40,14 +40,16 @@ pub trait AsyncDrop {
 
 Implement it as a plain `async fn async_drop_impl(self)` without `#[async_trait]`.
 `self` is taken by value, so destructure it to move `AsyncDropGuard` members out
-and drop them:
+and drop them. List every field (`name: _` for the ones that don't need dropping)
+instead of using `..`: that way adding a field later is a compile error here, which
+forces whoever adds an `AsyncDropGuard` field to decide how to drop it.
 
 ```rust
 impl AsyncDrop for MyType {
     type Error = anyhow::Error;
 
     async fn async_drop_impl(self) -> Result<(), Self::Error> {
-        let Self { connection, cache, .. } = self;
+        let Self { connection, cache, config: _ } = self;
         cache.async_drop().await?;
         connection.async_drop().await?;
         Ok(())

--- a/.claude/skills/async-drop/gotchas.md
+++ b/.claude/skills/async-drop/gotchas.md
@@ -163,7 +163,7 @@ impl MyType {
 // RIGHT - internal unwrapping, still clean up members
 impl MyType {
     pub async fn good(this: AsyncDropGuard<Self>) -> Result<()> {
-        let Self { mut member, .. } = this.unsafe_into_inner_dont_drop();
+        let Self { mut member, config: _ } = this.unsafe_into_inner_dont_drop();
         let result = member.do_work().await?;
         member.async_drop().await?;  // Still our responsibility!
         Ok(result)

--- a/.claude/skills/async-drop/gotchas.md
+++ b/.claude/skills/async-drop/gotchas.md
@@ -233,29 +233,7 @@ async fn may_panic(mut resource: AsyncDropGuard<R>) -> Result<()> {
 
 Don't try to call `async_drop()` in panic handlers.
 
-## Gotcha 9: Double async_drop or Use After async_drop
-
-`async_drop()` consumes the guard. Calling it twice, or using the value afterwards,
-is a compile error (use of moved value), not a runtime check.
-
-```rust
-let resource = Resource::new();
-resource.async_drop().await?;  // Does cleanup
-resource.async_drop().await?;  // Compile error: use of moved value
-resource.do_work().await?;     // Compile error: use of moved value
-```
-
-There is no `is_dropped()`. If a struct genuinely needs a "maybe already dropped" slot
-(for example a `Drop` impl that drops a guard synchronously, or a shared handle that is
-destroyed in place), store an `Option<AsyncDropGuard<T>>` and use `.take()`:
-
-```rust
-if let Some(resource) = self.resource.take() {
-    resource.async_drop().await?;
-}
-```
-
-## Gotcha 10: Holding Guards Across Await Points Without Cleanup
+## Gotcha 9: Holding Guards Across Await Points Without Cleanup
 
 Long-lived guards in loops need careful handling.
 
@@ -279,22 +257,7 @@ async fn good_loop() -> Result<()> {
 }
 ```
 
-## Gotcha 11: Clone vs AsyncDropArc
-
-Regular `Clone` on `AsyncDropGuard` is not available. Use `AsyncDropArc` for shared ownership.
-
-```rust
-// WRONG - AsyncDropGuard doesn't implement Clone
-let guard = AsyncDropGuard::new(resource);
-let clone = guard.clone();  // Compile error!
-
-// RIGHT - use AsyncDropArc for sharing
-let shared = AsyncDropArc::new(AsyncDropGuard::new(resource));
-let clone = AsyncDropArc::clone(&shared);
-// Both must be async_dropped, last one does actual cleanup
-```
-
-## Gotcha 12: Dropping a Guard Member Through `&mut self`
+## Gotcha 10: Dropping a Guard Member Through `&mut self`
 
 `async_drop()` takes `self` by value, so it cannot be called on a field behind `&mut self`.
 Inside `AsyncDrop::async_drop_impl(self)` destructure `self` instead. Elsewhere, prefer

--- a/.claude/skills/async-drop/gotchas.md
+++ b/.claude/skills/async-drop/gotchas.md
@@ -133,11 +133,10 @@ impl Container {
 // Container's async_drop doesn't call inner.async_drop()!
 
 // RIGHT
-#[async_trait]
 impl AsyncDrop for Container {
     type Error = <Resource as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
         self.inner.async_drop().await
     }
 }
@@ -164,9 +163,9 @@ impl MyType {
 // RIGHT - internal unwrapping, still clean up members
 impl MyType {
     pub async fn good(this: AsyncDropGuard<Self>) -> Result<()> {
-        let mut inner = this.unsafe_into_inner_dont_drop();
-        let result = inner.member.do_work().await?;
-        inner.member.async_drop().await?;  // Still our responsibility!
+        let Self { mut member, .. } = this.unsafe_into_inner_dont_drop();
+        let result = member.do_work().await?;
+        member.async_drop().await?;  // Still our responsibility!
         Ok(result)
     }
 }
@@ -195,18 +194,19 @@ pub struct System {
     database: AsyncDropGuard<Database>, // Independent
 }
 
-#[async_trait]
 impl AsyncDrop for System {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { cache, database } = self;
+
         // WRONG order - database closes while cache still uses it
-        // self.database.async_drop().await?;
-        // self.cache.async_drop().await?;
+        // database.async_drop().await?;
+        // cache.async_drop().await?;
 
         // RIGHT order - close cache first, then database
-        self.cache.async_drop().await?;
-        self.database.async_drop().await?;
+        cache.async_drop().await?;
+        database.async_drop().await?;
         Ok(())
     }
 }
@@ -233,20 +233,24 @@ async fn may_panic(mut resource: AsyncDropGuard<R>) -> Result<()> {
 
 Don't try to call `async_drop()` in panic handlers.
 
-## Gotcha 9: Double async_drop
+## Gotcha 9: Double async_drop or Use After async_drop
 
-Calling `async_drop()` twice is harmless but wasteful - it returns `Ok(())` on second call.
+`async_drop()` consumes the guard. Calling it twice, or using the value afterwards,
+is a compile error (use of moved value), not a runtime check.
 
 ```rust
-let mut resource = Resource::new();
+let resource = Resource::new();
 resource.async_drop().await?;  // Does cleanup
-resource.async_drop().await?;  // No-op, returns Ok(())
+resource.async_drop().await?;  // Compile error: use of moved value
+resource.do_work().await?;     // Compile error: use of moved value
 ```
 
-Use `is_dropped()` to check if already dropped if needed:
+There is no `is_dropped()`. If a struct genuinely needs a "maybe already dropped" slot
+(for example a `Drop` impl that drops a guard synchronously, or a shared handle that is
+destroyed in place), store an `Option<AsyncDropGuard<T>>` and use `.take()`:
 
 ```rust
-if !resource.is_dropped() {
+if let Some(resource) = self.resource.take() {
     resource.async_drop().await?;
 }
 ```
@@ -290,18 +294,28 @@ let clone = AsyncDropArc::clone(&shared);
 // Both must be async_dropped, last one does actual cleanup
 ```
 
-## Gotcha 12: Forgetting `mut` Binding
+## Gotcha 12: Dropping a Guard Member Through `&mut self`
 
-`async_drop()` takes `&mut self`, so the guard must be mutable.
+`async_drop()` takes `self` by value, so it cannot be called on a field behind `&mut self`.
+Inside `AsyncDrop::async_drop_impl(self)` destructure `self` instead. Elsewhere, prefer
+making the method consume `self` (or take `this: AsyncDropGuard<Self>`) over wrapping the
+field in an `Option`.
 
 ```rust
-// WRONG - can't call async_drop on immutable binding
-let resource = Resource::new();
-resource.async_drop().await?;  // Error: cannot borrow as mutable
+// WRONG - cannot move out of `self.inner` behind a mutable reference
+impl Container {
+    pub async fn close(&mut self) -> Result<()> {
+        self.inner.async_drop().await
+    }
+}
 
-// RIGHT
-let mut resource = Resource::new();
-resource.async_drop().await?;
+// RIGHT - consume the container
+impl Container {
+    pub async fn close(this: AsyncDropGuard<Self>) -> Result<()> {
+        let Self { inner } = this.unsafe_into_inner_dont_drop();
+        inner.async_drop().await
+    }
+}
 ```
 
 ## Summary Checklist
@@ -313,8 +327,7 @@ Before submitting code with AsyncDrop:
 - [ ] All early returns call `async_drop()` first
 - [ ] Factory methods return `AsyncDropGuard<Self>`
 - [ ] Direct instantiation prevented (private fields, newtype wrappers for enums)
-- [ ] Types with guard members implement `AsyncDrop`
-- [ ] Guard bindings are `mut`
+- [ ] Types with guard members implement `AsyncDrop` with `async fn async_drop_impl(self)` (no `#[async_trait]`), destructuring `self`
 - [ ] `unsafe_into_inner_dont_drop()` only used internally, with member cleanup handled
 - [ ] Drop order correct for dependent members (reverse of construction)
 - [ ] Independent members dropped concurrently (Pattern 10)

--- a/.claude/skills/async-drop/helpers.md
+++ b/.claude/skills/async-drop/helpers.md
@@ -15,8 +15,7 @@ pub struct AsyncDropGuard<T: Debug>(Option<T>);
 | Method | Description |
 |--------|-------------|
 | `new(v: T)` | Wrap a value |
-| `async_drop(&mut self)` | Perform async cleanup (required!) |
-| `is_dropped(&self)` | Check if already dropped |
+| `async_drop(self)` | Perform async cleanup (required!). Consumes the guard |
 | `unsafe_into_inner_dont_drop(self)` | Extract inner, bypassing cleanup |
 | `map_unsafe<U>(self, f)` | Transform inner type |
 
@@ -27,9 +26,9 @@ pub struct AsyncDropGuard<T: Debug>(Option<T>);
 - Panics in `Drop` if `async_drop()` was not called
 
 ```rust
-let mut guard = AsyncDropGuard::new(value);
+let guard = AsyncDropGuard::new(value);
 guard.method();  // Deref to inner
-guard.async_drop().await?;
+guard.async_drop().await?;  // consumes `guard`
 ```
 
 ---
@@ -40,7 +39,7 @@ Reference-counted sharing of async-droppable values.
 
 ```rust
 pub struct AsyncDropArc<T: AsyncDrop + Debug + Send> {
-    v: Option<Arc<AsyncDropGuard<T>>>,
+    v: Arc<AsyncDropGuard<T>>,
 }
 ```
 
@@ -69,7 +68,7 @@ shared.async_drop().await?;  // Actual cleanup (last Arc)
 |--------|-------------|
 | `new(guard)` | Wrap an AsyncDropGuard |
 | `clone(&self)` | Create another reference |
-| `async_drop(&mut self)` | Drop this reference (cleanup on last) |
+| `async_drop(self)` | Drop this reference (cleanup on last) |
 
 ---
 
@@ -79,7 +78,7 @@ Async mutex holding an async-droppable value.
 
 ```rust
 pub struct AsyncDropTokioMutex<T: AsyncDrop + Debug + Send> {
-    v: Option<Mutex<AsyncDropGuard<T>>>,
+    v: Mutex<AsyncDropGuard<T>>,
 }
 ```
 

--- a/.claude/skills/async-drop/patterns.md
+++ b/.claude/skills/async-drop/patterns.md
@@ -7,7 +7,6 @@ Common patterns for implementing and using AsyncDrop in this codebase.
 For types that need async cleanup:
 
 ```rust
-use async_trait::async_trait;
 use cryfs_utils::{AsyncDrop, AsyncDropGuard};
 
 pub struct MyResource {
@@ -21,11 +20,11 @@ impl MyResource {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for MyResource {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    // Takes `self` by value, no `#[async_trait]`
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
         self.connection.close().await?;
         Ok(())
     }
@@ -34,26 +33,30 @@ impl AsyncDrop for MyResource {
 
 ## Pattern 2: Delegating to Member AsyncDrops
 
-When a type contains `AsyncDropGuard` members:
+When a type contains `AsyncDropGuard` members, destructure `self` to move them out:
 
 ```rust
 pub struct CompositeResource {
     database: AsyncDropGuard<Database>,
     cache: AsyncDropGuard<Cache>,
+    name: String,
 }
 
-#[async_trait]
 impl AsyncDrop for CompositeResource {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { database, cache, name: _ } = self;
         // Drop members in appropriate order
-        self.cache.async_drop().await?;
-        self.database.async_drop().await?;
+        cache.async_drop().await?;
+        database.async_drop().await?;
         Ok(())
     }
 }
 ```
+
+A type that also implements `Drop` cannot be destructured. Store its guard members
+in an `Option` and `.take()` them in `async_drop_impl` instead.
 
 ## Pattern 3: Using `with_async_drop_2!` Macro
 
@@ -101,9 +104,7 @@ with_async_drop_2_infallible!(value, {
 When the macro doesn't fit, manually ensure cleanup on every path:
 
 ```rust
-async fn complex_operation(resource: AsyncDropGuard<Resource>) -> Result<Output> {
-    let mut resource = resource;
-
+async fn complex_operation(mut resource: AsyncDropGuard<Resource>) -> Result<Output> {
     // Early return path 1
     if !resource.is_valid() {
         resource.async_drop().await?;
@@ -139,23 +140,22 @@ impl Wrapper {
     /// The Wrapper's AsyncDrop handles cleanup of the inner resource.
     pub async fn consume(this: AsyncDropGuard<Self>) -> Result<Output> {
         // Unwrap Self from its guard - we're inside our own impl
-        let mut this = this.unsafe_into_inner_dont_drop();
+        let Self { mut inner } = this.unsafe_into_inner_dont_drop();
 
-        // Now we can work with this.inner directly
-        let result = this.inner.do_something().await?;
+        // Now we can work with inner directly
+        let result = inner.do_something().await?;
 
         // We MUST still clean up inner - our responsibility hasn't changed
-        this.inner.async_drop().await?;
+        inner.async_drop().await?;
 
         Ok(result)
     }
 }
 
-#[async_trait]
 impl AsyncDrop for Wrapper {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
         self.inner.async_drop().await?;
         Ok(())
     }
@@ -171,7 +171,7 @@ For types with multiple states (like enums), wrap in a newtype to prevent direct
 ```rust
 // Private enum - cannot be constructed outside this module
 enum MaybeInitializedInner<T> {
-    Uninitialized(Option<Box<dyn FnOnce() -> AsyncDropGuard<T>>>),
+    Uninitialized(Box<dyn FnOnce() -> AsyncDropGuard<T> + Send>),
     Initialized(AsyncDropGuard<T>),
 }
 
@@ -180,8 +180,8 @@ pub struct MaybeInitialized<T>(MaybeInitializedInner<T>);
 
 impl<T> MaybeInitialized<T> {
     // Factory methods return AsyncDropGuard<Self>, never Self
-    pub fn uninitialized(factory: impl FnOnce() -> AsyncDropGuard<T> + 'static) -> AsyncDropGuard<Self> {
-        AsyncDropGuard::new(Self(MaybeInitializedInner::Uninitialized(Some(Box::new(factory)))))
+    pub fn uninitialized(factory: impl FnOnce() -> AsyncDropGuard<T> + Send + 'static) -> AsyncDropGuard<Self> {
+        AsyncDropGuard::new(Self(MaybeInitializedInner::Uninitialized(Box::new(factory))))
     }
 
     pub fn initialized(value: AsyncDropGuard<T>) -> AsyncDropGuard<Self> {
@@ -189,22 +189,14 @@ impl<T> MaybeInitialized<T> {
     }
 }
 
-#[async_trait]
 impl<T: AsyncDrop + Debug + Send> AsyncDrop for MaybeInitialized<T> {
     type Error = T::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        match &mut self.0 {
-            MaybeInitializedInner::Uninitialized(factory) => {
-                if let Some(factory) = factory.take() {
-                    factory().async_drop().await?;
-                }
-            }
-            MaybeInitializedInner::Initialized(value) => {
-                value.async_drop().await?;
-            }
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        match self.0 {
+            MaybeInitializedInner::Uninitialized(factory) => factory().async_drop().await,
+            MaybeInitializedInner::Initialized(value) => value.async_drop().await,
         }
-        Ok(())
     }
 }
 ```
@@ -218,7 +210,7 @@ When passing `AsyncDropGuard<T>` by value, ownership and cleanup responsibility 
 ```rust
 // Caller is responsible for cleanup
 async fn caller() -> Result<()> {
-    let mut resource = create_resource();
+    let resource = create_resource();
     process_resource(resource).await?;  // Transfers ownership
     // No need to call async_drop - process_resource owns it now
     Ok(())
@@ -244,7 +236,7 @@ async fn create_and_configure() -> Result<AsyncDropGuard<Resource>> {
 }
 
 async fn use_it() -> Result<()> {
-    let mut resource = create_and_configure().await?;
+    let resource = create_and_configure().await?;
     resource.work().await?;
     resource.async_drop().await?;  // Our responsibility now
     Ok(())
@@ -277,16 +269,16 @@ pub struct ConnectionPool {
     conn_c: AsyncDropGuard<Connection>,
 }
 
-#[async_trait]
 impl AsyncDrop for ConnectionPool {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { conn_a, conn_b, conn_c } = self;
         // GOOD - concurrent drop for independent resources
         let (a, b, c) = tokio::join!(
-            self.conn_a.async_drop(),
-            self.conn_b.async_drop(),
-            self.conn_c.async_drop()
+            conn_a.async_drop(),
+            conn_b.async_drop(),
+            conn_c.async_drop()
         );
         a?;
         b?;
@@ -321,26 +313,23 @@ Choose error types based on context:
 
 ```rust
 // Specific error for library types
-#[async_trait]
 impl AsyncDrop for DatabaseConnection {
     type Error = DatabaseError;  // Specific, detailed
     // ...
 }
 
 // Anyhow for application-level types
-#[async_trait]
 impl AsyncDrop for AppResource {
     type Error = anyhow::Error;  // Flexible
     // ...
 }
 
 // Never for infallible cleanup
-#[async_trait]
 impl AsyncDrop for SimpleBuffer {
     type Error = std::convert::Infallible;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.data.clear();  // Can't fail
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        drop(self.data);  // Can't fail
         Ok(())
     }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ Types needing async cleanup use `AsyncDropGuard<T>`. See the async-drop skill fo
 - Every `AsyncDropGuard<T>` must have `async_drop()` called before drop (panics otherwise)
 - `async_drop()` consumes the guard: use-after-drop and double-drop are compile errors
 - Factory methods return `AsyncDropGuard<Self>`, never plain `Self`
-- Types with guard members must implement `AsyncDrop` to delegate: `async fn async_drop_impl(self)`, destructure `self`, drop the members. No `#[async_trait]` on `AsyncDrop` impls
+- Types with guard members must implement `AsyncDrop` to delegate: `async fn async_drop_impl(self)`, destructure `self` listing every field (no `..`), drop the guard members. No `#[async_trait]` on `AsyncDrop` impls
 - Use `with_async_drop_2!` macro when possible; otherwise call `async_drop()` on all exit paths
 - Panics are exceptions - ok to skip `async_drop()` on panic paths
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,9 @@ Types needing async cleanup use `AsyncDropGuard<T>`. See the async-drop skill fo
 
 **Essential rules**:
 - Every `AsyncDropGuard<T>` must have `async_drop()` called before drop (panics otherwise)
+- `async_drop()` consumes the guard: use-after-drop and double-drop are compile errors
 - Factory methods return `AsyncDropGuard<Self>`, never plain `Self`
-- Types with guard members must implement `AsyncDrop` to delegate
+- Types with guard members must implement `AsyncDrop` to delegate: `async fn async_drop_impl(self)`, destructure `self`, drop the members. No `#[async_trait]` on `AsyncDrop` impls
 - Use `with_async_drop_2!` macro when possible; otherwise call `async_drop()` on all exit paths
 - Panics are exceptions - ok to skip `async_drop()` on panic paths
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,7 +1057,6 @@ name = "cryfs-check"
 version = "2.0.0-alpha3"
 dependencies = [
  "anyhow",
- "async-trait",
  "byte-unit",
  "clap",
  "clap-logflag",
@@ -1160,7 +1159,6 @@ name = "cryfs-concurrent-store"
 version = "2.0.0-alpha3"
 dependencies = [
  "anyhow",
- "async-trait",
  "cryfs-utils",
  "cryfs-version",
  "futures",
@@ -1228,7 +1226,6 @@ name = "cryfs-e2e-perf-tests"
 version = "2.0.0-alpha3"
 dependencies = [
  "anyhow",
- "async-trait",
  "byte-unit",
  "crabtime",
  "criterion",
@@ -1278,7 +1275,6 @@ name = "cryfs-fsblobstore"
 version = "2.0.0-alpha3"
 dependencies = [
  "anyhow",
- "async-trait",
  "binary-layout",
  "binrw",
  "byte-unit",
@@ -1330,7 +1326,6 @@ name = "cryfs-utils"
 version = "2.0.0-alpha3"
 dependencies = [
  "anyhow",
- "async-trait",
  "binrw",
  "common_macros",
  "criterion",

--- a/crates/blobstore/src/implementations/on_blocks/blob_on_blocks.rs
+++ b/crates/blobstore/src/implementations/on_blocks/blob_on_blocks.rs
@@ -13,7 +13,6 @@ use cryfs_utils::{
 
 #[derive(Debug)]
 pub struct BlobOnBlocks<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> {
-    // Always Some unless during destruction
     tree: AsyncDropGuard<DataTree<B>>,
 }
 

--- a/crates/blobstore/src/implementations/on_blocks/blob_on_blocks.rs
+++ b/crates/blobstore/src/implementations/on_blocks/blob_on_blocks.rs
@@ -87,14 +87,14 @@ impl<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> Blob f
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for BlobOnBlocks<B>
 where
     B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync,
 {
     type Error = <B as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.tree.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { tree } = self;
+        tree.async_drop().await
     }
 }

--- a/crates/blobstore/src/implementations/on_blocks/blobstore_on_blocks.rs
+++ b/crates/blobstore/src/implementations/on_blocks/blobstore_on_blocks.rs
@@ -108,13 +108,13 @@ impl<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> fmt::D
     }
 }
 
-#[async_trait]
 impl<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> AsyncDrop
     for BlobStoreOnBlocks<B>
 {
     type Error = <B as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.tree_store.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { tree_store } = self;
+        tree_store.async_drop().await
     }
 }

--- a/crates/blobstore/src/implementations/on_blocks/data_node_store/data_node/data_node.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_node_store/data_node/data_node.rs
@@ -1202,13 +1202,13 @@ mod tests {
         async fn overwrite_with_wrong_source_layout() {
             const BLOCKSIZE_1: Byte = Byte::from_u64(100);
             const BLOCKSIZE_2: Byte = Byte::from_u64(200);
-            let mut nodestore1 = DataNodeStore::new(
+            let nodestore1 = DataNodeStore::new(
                 LockingBlockStore::new(InMemoryBlockStore::new()),
                 BLOCKSIZE_1,
             )
             .await
             .unwrap();
-            let mut nodestore2 = DataNodeStore::new(
+            let nodestore2 = DataNodeStore::new(
                 LockingBlockStore::new(InMemoryBlockStore::new()),
                 BLOCKSIZE_2,
             )
@@ -1230,13 +1230,13 @@ mod tests {
         async fn overwrite_with_wrong_target_layout() {
             const BLOCKSIZE_1: Byte = Byte::from_u64(100);
             const BLOCKSIZE_2: Byte = Byte::from_u64(200);
-            let mut nodestore1 = DataNodeStore::new(
+            let nodestore1 = DataNodeStore::new(
                 LockingBlockStore::new(InMemoryBlockStore::new()),
                 BLOCKSIZE_1,
             )
             .await
             .unwrap();
-            let mut nodestore2 = DataNodeStore::new(
+            let nodestore2 = DataNodeStore::new(
                 LockingBlockStore::new(InMemoryBlockStore::new()),
                 BLOCKSIZE_2,
             )

--- a/crates/blobstore/src/implementations/on_blocks/data_node_store/mod.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_node_store/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, anyhow, bail};
-use async_trait::async_trait;
 use binary_layout::Field;
 use byte_unit::Byte;
 #[cfg(test)]
@@ -36,7 +35,7 @@ pub struct DataNodeStore<B: BlockStore + AsyncDrop + Debug + Send> {
 
 impl<B: BlockStore + AsyncDrop + Debug + Send> DataNodeStore<B> {
     pub async fn new(
-        mut block_store: AsyncDropGuard<B>,
+        block_store: AsyncDropGuard<B>,
         physical_block_size: Byte,
     ) -> Result<AsyncDropGuard<Self>, InvalidBlockSizeError> {
         let block_size = match Self::_block_size(&block_store, physical_block_size) {
@@ -236,12 +235,12 @@ impl<B: BlockStore + AsyncDrop + Debug + Send> DataNodeStore<B> {
     }
 }
 
-#[async_trait]
 impl<B: BlockStore + AsyncDrop + Debug + Send> AsyncDrop for DataNodeStore<B> {
     type Error = <B as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.block_store.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { block_store, .. } = self;
+        block_store.async_drop().await
     }
 }
 
@@ -284,7 +283,7 @@ mod tests {
 
         #[tokio::test]
         async fn valid_block_size() {
-            let mut store = DataNodeStore::new(
+            let store = DataNodeStore::new(
                 LockingBlockStore::new(InMemoryBlockStore::new()),
                 Byte::from_u64(40),
             )
@@ -320,7 +319,7 @@ mod tests {
 
         #[tokio::test]
         async fn test() {
-            let mut nodestore = DataNodeStore::new(
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(InMemoryBlockStore::new()),
                 Byte::from_u64(100),
             )
@@ -349,7 +348,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(0)));
-            let mut nodestore =
+            let nodestore =
                 DataNodeStore::new(LockingBlockStore::new(blockstore), Byte::from_u64(100))
                     .await
                     .unwrap();
@@ -1278,8 +1277,8 @@ mod tests {
 
         #[tokio::test]
         async fn flushing_created_leaf_node() {
-            let mut blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
-            let mut nodestore = DataNodeStore::new(
+            let blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(LLSharedBlockStore::clone(&blockstore)),
                 PHYSICAL_BLOCK_SIZE,
             )
@@ -1317,8 +1316,8 @@ mod tests {
 
         #[tokio::test]
         async fn flushing_loaded_leaf_node() {
-            let mut blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
-            let mut nodestore = DataNodeStore::new(
+            let blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(LLSharedBlockStore::clone(&blockstore)),
                 PHYSICAL_BLOCK_SIZE,
             )
@@ -1375,8 +1374,8 @@ mod tests {
 
         #[tokio::test]
         async fn flushing_created_inner_node() {
-            let mut blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
-            let mut nodestore = DataNodeStore::new(
+            let blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(LLSharedBlockStore::clone(&blockstore)),
                 PHYSICAL_BLOCK_SIZE,
             )
@@ -1419,8 +1418,8 @@ mod tests {
 
         #[tokio::test]
         async fn flushing_loaded_inner_node() {
-            let mut blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
-            let mut nodestore = DataNodeStore::new(
+            let blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(LLSharedBlockStore::clone(&blockstore)),
                 PHYSICAL_BLOCK_SIZE,
             )
@@ -1510,7 +1509,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(0)));
-            let mut nodestore =
+            let nodestore =
                 DataNodeStore::new(LockingBlockStore::new(blockstore), Byte::from_u64(100))
                     .await
                     .unwrap();
@@ -1530,7 +1529,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(99)));
-            let mut nodestore =
+            let nodestore =
                 DataNodeStore::new(LockingBlockStore::new(blockstore), Byte::from_u64(100))
                     .await
                     .unwrap();
@@ -1550,7 +1549,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(100)));
-            let mut nodestore =
+            let nodestore =
                 DataNodeStore::new(LockingBlockStore::new(blockstore), Byte::from_u64(100))
                     .await
                     .unwrap();
@@ -1570,7 +1569,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(32 * 1024 * 10240 + 123)));
-            let mut nodestore = DataNodeStore::new(
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64_with_unit(32, byte_unit::Unit::KiB).unwrap(),
             )
@@ -1595,7 +1594,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(32 * 1024 * 10240 + 123)));
-            let mut nodestore = DataNodeStore::new(
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64_with_unit(32, byte_unit::Unit::KiB).unwrap(),
             )
@@ -1620,7 +1619,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Err(anyhow!("some error")));
-            let mut nodestore = DataNodeStore::new(
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64_with_unit(32, byte_unit::Unit::KiB).unwrap(),
             )
@@ -1651,7 +1650,7 @@ mod tests {
                 .expect_overhead()
                 .times(1)
                 .returning(|| Overhead::new(Byte::from_u64(100)));
-            let mut nodestore = DataNodeStore::new(
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64(32 * 1024 * 10),
             )
@@ -1698,7 +1697,7 @@ mod tests {
                     Ok(stream)
                 })
             });
-            let mut nodestore = DataNodeStore::new(
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64_with_unit(32, byte_unit::Unit::KiB).unwrap(),
             )
@@ -1733,7 +1732,7 @@ mod tests {
                 })
             });
 
-            let mut nodestore = DataNodeStore::new(
+            let nodestore = DataNodeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64_with_unit(32, byte_unit::Unit::KiB).unwrap(),
             )

--- a/crates/blobstore/src/implementations/on_blocks/data_node_store/mod.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_node_store/mod.rs
@@ -239,7 +239,11 @@ impl<B: BlockStore + AsyncDrop + Debug + Send> AsyncDrop for DataNodeStore<B> {
     type Error = <B as AsyncDrop>::Error;
 
     async fn async_drop_impl(self) -> Result<(), Self::Error> {
-        let Self { block_store, .. } = self;
+        let Self {
+            block_store,
+            layout: _,
+            physical_block_size: _,
+        } = self;
         block_store.async_drop().await
     }
 }

--- a/crates/blobstore/src/implementations/on_blocks/data_node_store/test_as_blockstore/block_store_adapter.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_node_store/test_as_blockstore/block_store_adapter.rs
@@ -117,11 +117,11 @@ impl Debug for BlockStoreAdapter {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for BlockStoreAdapter {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.0.async_drop().await
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self(node_store) = self;
+        node_store.async_drop().await
     }
 }
 

--- a/crates/blobstore/src/implementations/on_blocks/data_node_store/testutils.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_node_store/testutils.rs
@@ -97,7 +97,7 @@ pub async fn with_nodestore_with_blocksize(
     blocksize: Byte,
     f: impl FnOnce(&DataNodeStore<LockingBlockStore<InMemoryBlockStore>>) -> BoxFuture<'_, ()>,
 ) {
-    let mut nodestore =
+    let nodestore =
         DataNodeStore::new(LockingBlockStore::new(InMemoryBlockStore::new()), blocksize)
             .await
             .unwrap();

--- a/crates/blobstore/src/implementations/on_blocks/data_tree_store/store.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_tree_store/store.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use byte_unit::Byte;
 use futures::stream::BoxStream;
 #[cfg(test)]
@@ -160,14 +159,14 @@ impl<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> DataTr
     }
 }
 
-#[async_trait]
 impl<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> AsyncDrop
     for DataTreeStore<B>
 {
     type Error = <B as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.node_store.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { node_store } = self;
+        node_store.async_drop().await
     }
 }
 
@@ -208,7 +207,7 @@ mod tests {
 
         #[tokio::test]
         async fn valid_block_size() {
-            let mut store = DataTreeStore::new(
+            let store = DataTreeStore::new(
                 LockingBlockStore::new(InMemoryBlockStore::new()),
                 Byte::from_u64(40),
             )
@@ -259,12 +258,12 @@ mod tests {
             with_treestore(|store| {
                 Box::pin(async move {
                     let root_id = {
-                        let mut created = store.create_tree().await.unwrap();
+                        let created = store.create_tree().await.unwrap();
                         let root_id = *created.root_node_id();
                         created.async_drop().await.unwrap();
                         root_id
                     };
-                    let mut tree = store.load_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.load_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
                 })
@@ -285,7 +284,7 @@ mod tests {
                         tree.async_drop().await.unwrap();
                         root_id
                     };
-                    let mut tree = store.load_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.load_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
                 })
@@ -302,12 +301,12 @@ mod tests {
             with_treestore(|store| {
                 Box::pin(async move {
                     let root_id = {
-                        let mut created = store.create_tree().await.unwrap();
+                        let created = store.create_tree().await.unwrap();
                         let root_id = *created.root_node_id();
                         created.async_drop().await.unwrap();
                         root_id
                     };
-                    let mut tree = store.load_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.load_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
                 })
@@ -345,11 +344,11 @@ mod tests {
             with_treestore(|store| {
                 Box::pin(async move {
                     let root_id = BlockId::from_hex("d86afd0489d7c3046c446e8ec1a049fe").unwrap();
-                    let mut tree = store.try_create_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.try_create_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
 
-                    let mut tree = store.load_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.load_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
                 })
@@ -385,7 +384,7 @@ mod tests {
             with_treestore(|store| {
                 Box::pin(async move {
                     let root_id = BlockId::from_hex("d86afd0489d7c3046c446e8ec1a049fe").unwrap();
-                    let mut tree = store.try_create_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.try_create_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
 
@@ -692,7 +691,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(0)));
-            let mut treestore =
+            let treestore =
                 DataTreeStore::new(LockingBlockStore::new(blockstore), Byte::from_u64(100))
                     .await
                     .unwrap();
@@ -712,7 +711,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(99)));
-            let mut treestore =
+            let treestore =
                 DataTreeStore::new(LockingBlockStore::new(blockstore), Byte::from_u64(100))
                     .await
                     .unwrap();
@@ -732,7 +731,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(100)));
-            let mut treestore =
+            let treestore =
                 DataTreeStore::new(LockingBlockStore::new(blockstore), Byte::from_u64(100))
                     .await
                     .unwrap();
@@ -752,7 +751,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(32 * 1024 * 10240 + 123)));
-            let mut treestore = DataTreeStore::new(
+            let treestore = DataTreeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64(32 * 1024),
             )
@@ -777,7 +776,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Ok(Byte::from_u64(32 * 1024 * 10240 + 123)));
-            let mut treestore = DataTreeStore::new(
+            let treestore = DataTreeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64(32 * 1024),
             )
@@ -802,7 +801,7 @@ mod tests {
             blockstore
                 .expect_estimate_num_free_bytes()
                 .returning(|| Err(anyhow!("some error")));
-            let mut treestore = DataTreeStore::new(
+            let treestore = DataTreeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64(32 * 1024),
             )
@@ -831,7 +830,7 @@ mod tests {
                 .expect_overhead()
                 .times(1)
                 .returning(|| Overhead::new(Byte::from_u64(100)));
-            let mut treestore = DataTreeStore::new(
+            let treestore = DataTreeStore::new(
                 LockingBlockStore::new(blockstore),
                 Byte::from_u64(32 * 1024 * 10),
             )

--- a/crates/blobstore/src/implementations/on_blocks/data_tree_store/testutils.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_tree_store/testutils.rs
@@ -100,7 +100,7 @@ pub async fn create_one_leaf_tree_return_id<
 >(
     store: &DataTreeStore<B>,
 ) -> BlockId {
-    let mut tree = create_one_leaf_tree(store).await;
+    let tree = create_one_leaf_tree(store).await;
     let id = *tree.root_node_id();
     tree.async_drop().await.unwrap();
     id
@@ -125,7 +125,7 @@ pub async fn create_multi_leaf_tree_return_id<
     store: &DataTreeStore<B>,
     num_leaves: u64,
 ) -> BlockId {
-    let mut tree = create_multi_leaf_tree(store, num_leaves).await;
+    let tree = create_multi_leaf_tree(store, num_leaves).await;
     let id = *tree.root_node_id();
     tree.async_drop().await.unwrap();
     id
@@ -208,7 +208,7 @@ pub async fn with_treestore_with_blocksize(
     blocksize_bytes: Byte,
     f: impl FnOnce(&DataTreeStore<LockingBlockStore<InMemoryBlockStore>>) -> BoxFuture<'_, ()>,
 ) {
-    let mut treestore = DataTreeStore::new(
+    let treestore = DataTreeStore::new(
         LockingBlockStore::new(InMemoryBlockStore::new()),
         blocksize_bytes,
     )
@@ -235,13 +235,13 @@ pub async fn with_treestore_and_nodestore_with_blocksize(
     ) -> BoxFuture<'a, ()>,
 ) {
     let blockstore = LLSharedBlockStore::new(InMemoryBlockStore::new());
-    let mut nodestore = DataNodeStore::new(
+    let nodestore = DataNodeStore::new(
         LockingBlockStore::new(LLSharedBlockStore::clone(&blockstore)),
         blocksize,
     )
     .await
     .unwrap();
-    let mut treestore = DataTreeStore::new(LockingBlockStore::new(blockstore), blocksize)
+    let treestore = DataTreeStore::new(LockingBlockStore::new(blockstore), blocksize)
         .await
         .unwrap();
     f(&treestore, &nodestore).await;

--- a/crates/blobstore/src/implementations/on_blocks/data_tree_store/tree/mod.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_tree_store/tree/mod.rs
@@ -732,7 +732,7 @@ impl<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> DataTr
         let Self {
             node_store,
             root_node,
-            ..
+            num_bytes_cache: _,
         } = this.unsafe_into_inner_dont_drop();
         node_store.async_drop().await.unwrap(); // TODO No unwrap
         root_node.expect("DataTree.RootNode is none")
@@ -765,7 +765,11 @@ where
 {
     type Error = <B as AsyncDrop>::Error;
     async fn async_drop_impl(self) -> Result<(), Self::Error> {
-        let Self { node_store, .. } = self;
+        let Self {
+            node_store,
+            root_node: _,
+            num_bytes_cache: _,
+        } = self;
         node_store.async_drop().await
     }
 }

--- a/crates/blobstore/src/implementations/on_blocks/data_tree_store/tree/mod.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_tree_store/tree/mod.rs
@@ -729,9 +729,13 @@ impl<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> DataTr
 
     #[cfg(any(test, feature = "testutils"))]
     pub async fn into_root_node(this: AsyncDropGuard<Self>) -> DataNode<B> {
-        let mut this = this.unsafe_into_inner_dont_drop();
-        this.node_store.async_drop().await.unwrap(); // TODO No unwrap
-        this.root_node.expect("DataTree.RootNode is none")
+        let Self {
+            node_store,
+            root_node,
+            ..
+        } = this.unsafe_into_inner_dont_drop();
+        node_store.async_drop().await.unwrap(); // TODO No unwrap
+        root_node.expect("DataTree.RootNode is none")
     }
 }
 
@@ -755,14 +759,14 @@ impl<B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync> Debug 
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for DataTree<B>
 where
     B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync,
 {
     type Error = <B as AsyncDrop>::Error;
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.node_store.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { node_store, .. } = self;
+        node_store.async_drop().await
     }
 }
 

--- a/crates/blobstore/src/implementations/on_blocks/data_tree_store/tree/tests.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_tree_store/tree/tests.rs
@@ -331,14 +331,13 @@ mod testutils {
     pub async fn flush_caches<
         B: BlockStore<Block: Send + Sync> + AsyncDrop + Debug + Send + Sync,
     >(
-        mut tree: AsyncDropGuard<DataTree<B>>,
+        tree: AsyncDropGuard<DataTree<B>>,
         nodestore: &DataNodeStore<B>,
         treestore: &DataTreeStore<B>,
     ) -> BlockId {
         let root_id = *tree.root_node_id();
         // Flush tree
         tree.async_drop().await.unwrap();
-        std::mem::drop(tree);
 
         // Flush tree store cache
         treestore.clear_cache_slow().await.unwrap();
@@ -583,7 +582,7 @@ mod root_node_id {
             with_treestore(|store| {
                 Box::pin(async move {
                     let root_id = BlockId::from_hex("18834bc490faaab6bfdc6a53864cd0a8").unwrap();
-                    let mut tree = store.try_create_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.try_create_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
                 })
@@ -606,7 +605,7 @@ mod root_node_id {
                         .async_drop()
                         .await
                         .unwrap();
-                    let mut tree = store.load_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.load_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
                 })
@@ -644,9 +643,8 @@ mod root_node_id {
                         .await
                         .unwrap();
                     tree.async_drop().await.unwrap();
-                    std::mem::drop(tree);
 
-                    let mut tree = store.load_tree(root_id).await.unwrap().unwrap();
+                    let tree = store.load_tree(root_id).await.unwrap().unwrap();
                     assert_eq!(root_id, *tree.root_node_id());
                     tree.async_drop().await.unwrap();
                 })
@@ -1095,7 +1093,6 @@ mod write_bytes {
 
                 // Check new tree size (as read after clearing size cache)
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 let mut tree = treestore.load_tree(tree_id).await.unwrap().unwrap();
                 assert_eq!(
                     expected_new_data.len() as u64,
@@ -1209,7 +1206,6 @@ mod resize_num_bytes {
 
                     // Check tree has correct size (looked up after clearing the size cache of the `tree` instance)
                     tree.async_drop().await.unwrap();
-                    std::mem::drop(tree);
                     let mut tree = treestore.load_tree(tree_id).await.unwrap().unwrap();
                     assert_eq!(new_num_bytes, tree.num_bytes().await.unwrap());
                     assert_eq!(
@@ -1408,8 +1404,8 @@ mod all_blocks {
                         expected_tree2_blocks.len() as u64,
                     );
 
-                    let mut tree1 = treestore.load_tree(tree1_id).await.unwrap().unwrap();
-                    let mut tree2 = treestore.load_tree(tree2_id).await.unwrap().unwrap();
+                    let tree1 = treestore.load_tree(tree1_id).await.unwrap().unwrap();
+                    let tree2 = treestore.load_tree(tree2_id).await.unwrap().unwrap();
 
                     let tree1_blocks: Result<HashSet<BlockId>, _> =
                         tree1.all_blocks().unwrap().try_collect().await;

--- a/crates/blobstore/src/implementations/on_blocks/data_tree_store/tree/tests_performance.rs
+++ b/crates/blobstore/src/implementations/on_blocks/data_tree_store/tree/tests_performance.rs
@@ -36,9 +36,9 @@ mod testutils {
             &'a LLSharedBlockStore<LLTrackingBlockStore<InMemoryBlockStore>>,
         ) -> BoxFuture<'a, ()>,
     ) {
-        let mut blockstore =
+        let blockstore =
             LLSharedBlockStore::new(LLTrackingBlockStore::new(InMemoryBlockStore::new()));
-        let mut treestore = DataTreeStore::new(
+        let treestore = DataTreeStore::new(
             LockingBlockStore::new(LLSharedBlockStore::clone(&blockstore)),
             LAYOUT.block_size,
         )
@@ -55,10 +55,9 @@ mod testutils {
         >,
         blockstore: &LLSharedBlockStore<LLTrackingBlockStore<InMemoryBlockStore>>,
     ) -> BlockId {
-        let mut tree = treestore.create_tree().await.unwrap();
+        let tree = treestore.create_tree().await.unwrap();
         let id = *tree.root_node_id();
         tree.async_drop().await.unwrap();
-        std::mem::drop(tree);
         treestore.clear_cache_slow().await.unwrap();
         blockstore.get_and_reset_counts();
         id
@@ -76,7 +75,6 @@ mod testutils {
             .unwrap();
         let id = *tree.root_node_id();
         tree.async_drop().await.unwrap();
-        std::mem::drop(tree);
         treestore.clear_cache_slow().await.unwrap();
         blockstore.get_and_reset_counts();
         id
@@ -400,7 +398,7 @@ mod create_tree {
     async fn only_creates_one_leaf() {
         with_treestore_and_tracking_blockstore(|treestore, blockstore| {
             Box::pin(async move {
-                let mut tree = treestore.create_tree().await.unwrap();
+                let tree = treestore.create_tree().await.unwrap();
                 tree.async_drop().await.unwrap();
                 treestore.clear_cache_slow().await.unwrap();
                 assert_eq!(
@@ -777,7 +775,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 assert_eq!(
                     LLActionCounts {
@@ -818,7 +815,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 assert_eq!(
                     LLActionCounts {
@@ -867,7 +863,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 assert_eq!(
                     LLActionCounts {
@@ -914,7 +909,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 assert_eq!(
                     LLActionCounts {
@@ -972,7 +966,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 assert_eq!(
                     LLActionCounts {
@@ -1028,7 +1021,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 assert_eq!(
                     LLActionCounts {
@@ -1075,7 +1067,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 let expected_stored =
                     num_nodes_written_when_growing_tree(NUM_LEAVES, WRITTEN_LEAF_INDEX as u64 + 1)
@@ -1122,7 +1113,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 let expected_stored =
                     num_nodes_written_when_growing_tree(NUM_LEAVES, WRITTEN_LEAF_INDEX as u64 + 1)
@@ -1176,7 +1166,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 let expected_stored =
                     num_nodes_written_when_growing_tree(NUM_LEAVES, WRITTEN_LEAF_INDEX as u64 + 1)
@@ -1228,7 +1217,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 let expected_stored =
                     num_nodes_written_when_growing_tree(NUM_LEAVES, WRITTEN_LEAF_INDEX as u64 + 1)
@@ -1285,7 +1273,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 let expected_stored = num_nodes_written_when_growing_tree(
                     NUM_LEAVES,
@@ -1340,7 +1327,6 @@ mod write_bytes {
 
                 // After flushing, the new content should have been written
                 tree.async_drop().await.unwrap();
-                std::mem::drop(tree);
                 treestore.clear_cache_slow().await.unwrap();
                 let expected_stored = num_nodes_written_when_growing_tree(
                     NUM_LEAVES,

--- a/crates/blobstore/src/implementations/tracking/tests.rs
+++ b/crates/blobstore/src/implementations/tracking/tests.rs
@@ -48,7 +48,7 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn counters_start_at_zero() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         assert_eq!(
             BlobStoreActionCounts {
@@ -80,7 +80,7 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn store_create_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         store.create().await.unwrap().async_drop().await.unwrap();
         store.create().await.unwrap().async_drop().await.unwrap();
@@ -100,7 +100,7 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn store_try_create_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id = BlobId::from_hex("1bdad9f4879fd1417870e42b8a4e547b").unwrap();
 
@@ -128,12 +128,11 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn store_load_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
-        let mut blob = store.create().await.unwrap();
+        let blob = store.create().await.unwrap();
         let id = blob.id();
         blob.async_drop().await.unwrap();
-        drop(blob);
 
         store
             .load(&id)
@@ -172,12 +171,11 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn store_remove_by_id_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
-        let mut blob = store.create().await.unwrap();
+        let blob = store.create().await.unwrap();
         let id = blob.id();
         blob.async_drop().await.unwrap();
-        drop(blob);
 
         assert_eq!(
             RemoveResult::SuccessfullyRemoved,
@@ -213,7 +211,7 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn store_num_nodes_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         store.num_nodes().await.unwrap();
         store.num_nodes().await.unwrap();
@@ -233,7 +231,7 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn store_estimate_space_for_num_blocks_left_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         store.estimate_space_for_num_blocks_left().unwrap();
         store.estimate_space_for_num_blocks_left().unwrap();
@@ -253,7 +251,7 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn store_logical_block_size_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         store.logical_block_size_bytes();
         store.logical_block_size_bytes();
@@ -273,7 +271,7 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_num_bytes_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let mut blob = store.create().await.unwrap();
         blob.num_bytes().await.unwrap();
@@ -290,14 +288,13 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_resize_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let mut blob = store.create().await.unwrap();
         blob.resize(100).await.unwrap();
@@ -314,14 +311,13 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_read_all_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let mut blob = store.create().await.unwrap();
         blob.read_all().await.unwrap();
@@ -338,14 +334,13 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_read_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let mut blob = store.create().await.unwrap();
         blob.write(&[1, 2, 3], 0).await.unwrap();
@@ -366,14 +361,13 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_try_read_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let mut blob = store.create().await.unwrap();
         blob.write(&[1, 2, 3], 0).await.unwrap();
@@ -394,14 +388,13 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_write_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         // Create a blob and write data
         let mut blob = store.create().await.unwrap();
@@ -419,14 +412,13 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_flush_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         // Create a blob and flush
         let mut blob = store.create().await.unwrap();
@@ -444,14 +436,13 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_num_nodes_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let mut blob = store.create().await.unwrap();
         blob.num_nodes().await.unwrap();
@@ -468,14 +459,13 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_remove_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let blob = store.create().await.unwrap();
         TrackingBlob::remove(blob).await.unwrap();
@@ -496,9 +486,9 @@ mod counter_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn blob_all_blocks_increases_counter() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
-        let mut blob = store.create().await.unwrap();
+        let blob = store.create().await.unwrap();
         let stream = blob.all_blocks().unwrap();
         // Use the stream to make sure it's properly executed
         let _ = stream.collect::<Vec<_>>().await;
@@ -517,20 +507,18 @@ mod counter_tests {
         );
 
         blob.async_drop().await.unwrap();
-        drop(blob);
         store.async_drop().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_and_reset_counts_resets_counters() {
         let mut fixture = super::TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         // Perform operations to increase counters
-        let mut blob = store.create().await.unwrap();
+        let blob = store.create().await.unwrap();
         let _ = blob.all_blocks().unwrap();
         blob.async_drop().await.unwrap();
-        drop(blob);
 
         // Check counts were increased
         let counts = store.counts();

--- a/crates/blobstore/src/implementations/tracking/tracking_blob.rs
+++ b/crates/blobstore/src/implementations/tracking/tracking_blob.rs
@@ -101,7 +101,7 @@ where
 {
     type Error = <B::ConcreteBlob as AsyncDrop>::Error;
     async fn async_drop_impl(self) -> Result<(), Self::Error> {
-        let Self { blob, .. } = self;
+        let Self { blob, counts: _ } = self;
         blob.async_drop().await
     }
 }

--- a/crates/blobstore/src/implementations/tracking/tracking_blob.rs
+++ b/crates/blobstore/src/implementations/tracking/tracking_blob.rs
@@ -95,13 +95,13 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for TrackingBlob<B>
 where
     B: BlobStore + AsyncDrop + Debug + 'static,
 {
     type Error = <B::ConcreteBlob as AsyncDrop>::Error;
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.blob.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { blob, .. } = self;
+        blob.async_drop().await
     }
 }

--- a/crates/blobstore/src/implementations/tracking/tracking_blobstore.rs
+++ b/crates/blobstore/src/implementations/tracking/tracking_blobstore.rs
@@ -112,14 +112,16 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for TrackingBlobStore<B>
 where
     B: BlobStore + AsyncDrop + Debug + Send + Sync + 'static,
 {
     type Error = B::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), B::Error> {
-        self.underlying_store.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), B::Error> {
+        let Self {
+            underlying_store, ..
+        } = self;
+        underlying_store.async_drop().await
     }
 }

--- a/crates/blobstore/src/tests/test_as_blockstore/block_store_adapter.rs
+++ b/crates/blobstore/src/tests/test_as_blockstore/block_store_adapter.rs
@@ -48,7 +48,7 @@ where
     async fn exists(&self, id: &BlockId) -> Result<bool> {
         let loaded = self.underlying_store.load(&BlobId { root: *id }).await?;
         match loaded {
-            Some(mut blob) => {
+            Some(blob) => {
                 blob.async_drop().await.unwrap();
                 Ok(true)
             }
@@ -157,14 +157,14 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for BlockStoreAdapter<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
 {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.underlying_store.async_drop().await
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { underlying_store } = self;
+        underlying_store.async_drop().await
     }
 }
 

--- a/crates/blobstore/src/tests/tests.rs
+++ b/crates/blobstore/src/tests/tests.rs
@@ -45,7 +45,7 @@ pub mod load {
     pub async fn test_givenEmptyBlobstore_whenLoadingNonexistingBlob_thenReturnsNone(
         mut f: impl Fixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         let loaded = store
             .load(&BlobId::from_hex("1491BB4932A389EE14BC7090AC772972").unwrap())
@@ -59,7 +59,7 @@ pub mod load {
     pub async fn test_givenNonEmptyBlobstore_whenLoadingNonexistingBlob_thenReturnsNone(
         mut f: impl Fixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .try_create(&BlobId::from_hex("AB0DC45269804AC6B1CF95391895DDF1").unwrap())

--- a/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
@@ -143,17 +143,15 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
     /// TODO Test
     #[cfg(any(test, feature = "testutils"))]
     pub async fn prune_unloaded_blocks(&self) -> Result<()> {
-        let cache = &self.cache;
-        Self::_prune_blocks_not_accessed_for_at_least(Arc::clone(cache), Duration::ZERO).await
+        Self::_prune_blocks_not_accessed_for_at_least(Arc::clone(&self.cache), Duration::ZERO).await
     }
 
     /// TODO Docs
     /// TODO Test
     #[cfg(any(test, feature = "testutils"))]
     pub async fn prune_all_blocks(&self) -> Result<()> {
-        let cache = &self.cache;
-        let to_prune = cache.lock_all_entries().await;
-        Self::_prune_blocks_stream(Arc::clone(cache), to_prune).await
+        let to_prune = self.cache.lock_all_entries().await;
+        Self::_prune_blocks_stream(Arc::clone(&self.cache), to_prune).await
     }
 
     #[cfg(any(test, feature = "testutils"))]

--- a/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
@@ -29,11 +29,9 @@ pub(super) const PRUNE_BLOCKS_INTERVAL: Duration = Duration::from_millis(500);
 pub(super) const PRUNE_BLOCKS_OLDER_THAN: Duration = Duration::from_millis(500);
 
 pub struct BlockCache<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> {
-    // Always Some except during destruction
-    cache: Option<Arc<BlockCacheImpl<B>>>,
+    cache: Arc<BlockCacheImpl<B>>,
     // The background task evicting blocks nobody has touched for a while. `None` after
-    // destruction, and also after [Self::stop_periodic_pruning] (tests only) turned the
-    // wall-clock driven eviction off.
+    // [Self::stop_periodic_pruning] (tests only) turned the wall-clock driven eviction off.
     prune_task: Option<AsyncDropGuard<PeriodicTask>>,
 }
 
@@ -42,7 +40,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
         let cache = BlockCacheImpl::new();
         let cache_clone = Arc::clone(&cache);
         AsyncDropGuard::new(Self {
-            cache: Some(cache),
+            cache,
             prune_task: Some(PeriodicTask::spawn(
                 "BlockCache::prune",
                 PRUNE_BLOCKS_INTERVAL,
@@ -55,10 +53,8 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
     }
 
     pub async fn async_lock(&self, block_id: BlockId) -> Result<BlockCacheEntryGuard<B>> {
-        let cache = Arc::clone(self.cache.as_ref().expect("Object is already destructed"));
+        let cache = Arc::clone(&self.cache);
         self.cache
-            .as_ref()
-            .expect("Object is already destructed")
             .async_lock(block_id, async move |evicted| {
                 Self::_prune_blocks(Arc::clone(&cache), evicted.into_iter()).await
             })
@@ -66,16 +62,11 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
     }
 
     pub fn keys_with_entries_or_locked(&self) -> Vec<BlockId> {
-        self.cache
-            .as_ref()
-            .expect("Object is already destructed")
-            .keys_with_entries_or_locked()
+        self.cache.keys_with_entries_or_locked()
     }
 
     pub fn delete_entry_from_cache_even_if_dirty(&self, entry: &mut BlockCacheEntryGuard<B>) {
         self.cache
-            .as_ref()
-            .expect("Object is already destructed")
             .delete_entry_from_cache_even_if_dirty(&mut entry.guard);
     }
 
@@ -88,8 +79,6 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
         base_store_state: BlockBaseStoreState,
     ) {
         self.cache
-            .as_ref()
-            .expect("Object is already destructed")
             .set_entry(base_store, entry, new_value, dirty, base_store_state);
     }
 
@@ -102,8 +91,6 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
         base_store_state: impl AsyncFnOnce() -> Result<BlockBaseStoreState>,
     ) -> Result<()> {
         self.cache
-            .as_ref()
-            .expect("Object is already destructed")
             .set_or_overwrite_entry_even_if_dirty(
                 base_store,
                 entry,
@@ -115,10 +102,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
     }
 
     pub fn num_blocks_in_cache_but_not_in_base_store(&self) -> u64 {
-        self.cache
-            .as_ref()
-            .expect("Object is already destructed")
-            .num_blocks_in_cache_but_not_in_base_store()
+        self.cache.num_blocks_in_cache_but_not_in_base_store()
     }
 
     async fn _prune_old_blocks(cache: Arc<BlockCacheImpl<B>>) -> Result<()> {
@@ -159,7 +143,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
     /// TODO Test
     #[cfg(any(test, feature = "testutils"))]
     pub async fn prune_unloaded_blocks(&self) -> Result<()> {
-        let cache = self.cache.as_ref().expect("Object is already destructed");
+        let cache = &self.cache;
         Self::_prune_blocks_not_accessed_for_at_least(Arc::clone(cache), Duration::ZERO).await
     }
 
@@ -167,7 +151,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
     /// TODO Test
     #[cfg(any(test, feature = "testutils"))]
     pub async fn prune_all_blocks(&self) -> Result<()> {
-        let cache = self.cache.as_ref().expect("Object is already destructed");
+        let cache = &self.cache;
         let to_prune = cache.lock_all_entries().await;
         Self::_prune_blocks_stream(Arc::clone(cache), to_prune).await
     }
@@ -239,11 +223,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
         block: &mut BlockCacheEntry<B>,
         block_id: &BlockId,
     ) -> Result<()> {
-        self.cache
-            .as_ref()
-            .expect("Object is already destructed")
-            .flush_entry(block, block_id)
-            .await
+        self.cache.flush_entry(block, block_id).await
     }
 }
 
@@ -267,7 +247,6 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> AsyncDro
             // Since self is passed in by value, prune task is the only one
             // that also has an instance. We're dropping prune_task concurrently
             // with this task. So let's wait until it has dropped it
-            let cache = cache.expect("Object is already destructed");
             while Arc::strong_count(&cache) > 1 {
                 // TODO Is there a better alternative that doesn't involve busy waiting?
                 tokio::task::yield_now().await;

--- a/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/cache/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use futures::join;
 #[cfg(any(test, feature = "testutils"))]
 use futures::{Stream, StreamExt};
@@ -150,7 +149,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
     /// Only meant for tests; production keeps the periodic task.
     #[cfg(any(test, feature = "testutils"))]
     pub async fn stop_periodic_pruning(&mut self) -> Result<()> {
-        if let Some(mut prune_task) = self.prune_task.take() {
+        if let Some(prune_task) = self.prune_task.take() {
             prune_task.async_drop().await?;
         }
         Ok(())
@@ -248,18 +247,16 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockCac
     }
 }
 
-#[async_trait]
 impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> AsyncDrop
     for BlockCache<B>
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { cache, prune_task } = self;
         // `None` means `stop_periodic_pruning` (tests only) already stopped the task.
-        // Destructing twice is caught by the `self.cache.take()` below.
-        let prune_task = self.prune_task.take();
         let stop_prune_task = async move {
-            if let Some(mut prune_task) = prune_task {
+            if let Some(prune_task) = prune_task {
                 prune_task.async_drop().await
             } else {
                 Ok(())
@@ -270,7 +267,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> AsyncDro
             // Since self is passed in by value, prune task is the only one
             // that also has an instance. We're dropping prune_task concurrently
             // with this task. So let's wait until it has dropped it
-            let cache = self.cache.take().expect("Object is already destructed");
+            let cache = cache.expect("Object is already destructed");
             while Arc::strong_count(&cache) > 1 {
                 // TODO Is there a better alternative that doesn't involve busy waiting?
                 tokio::task::yield_now().await;

--- a/crates/blockstore/src/high_level/implementations/locking/locking_blockstore.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/locking_blockstore.rs
@@ -55,8 +55,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> LockingB
             };
 
         let removed_from_base_store = if should_remove_from_base_store {
-            let base_store = &self.base_store;
-            match base_store.remove(block_id).await? {
+            match self.base_store.remove(block_id).await? {
                 RemoveResult::SuccessfullyRemoved => true,
                 RemoveResult::NotRemovedBecauseItDoesntExist => false,
             }
@@ -112,11 +111,10 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
         // TODO Cache non-existence?
         let mut cache_entry = self.cache.async_lock(block_id).await?;
         if cache_entry.value().is_none() {
-            let base_store = &self.base_store;
-            let loaded = base_store.load(&block_id).await?;
+            let loaded = self.base_store.load(&block_id).await?;
             if let Some(loaded) = loaded {
                 self.cache.set_entry(
-                    base_store,
+                    &self.base_store,
                     &mut cache_entry,
                     loaded,
                     CacheEntryState::Clean,
@@ -137,12 +135,11 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
             // Block already exists in the cache
             return Ok(TryCreateResult::NotCreatedBecauseBlockIdAlreadyExists);
         }
-        let base_store = &self.base_store;
-        if base_store.exists(block_id).await? {
+        if self.base_store.exists(block_id).await? {
             return Ok(TryCreateResult::NotCreatedBecauseBlockIdAlreadyExists);
         }
         self.cache.set_entry(
-            base_store,
+            &self.base_store,
             &mut cache_entry,
             data.clone(),
             CacheEntryState::Dirty,
@@ -154,10 +151,8 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
     async fn overwrite(&self, block_id: &BlockId, data: &Data) -> Result<()> {
         let mut cache_entry = self.cache.async_lock(*block_id).await?;
 
-        let base_store = &self.base_store;
-
         let exists_in_base_store = async || {
-            if base_store.exists(block_id).await? {
+            if self.base_store.exists(block_id).await? {
                 Ok(BlockBaseStoreState::ExistsInBaseStore)
             } else {
                 Ok(BlockBaseStoreState::DoesntExistInBaseStore)
@@ -167,7 +162,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
         // Add the new value to the cache.
         self.cache
             .set_or_overwrite_entry_even_if_dirty(
-                base_store,
+                &self.base_store,
                 &mut cache_entry,
                 data.clone(),
                 CacheEntryState::Dirty,
@@ -198,27 +193,23 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
     }
 
     async fn num_blocks(&self) -> Result<u64> {
-        let base_store = &self.base_store;
-        Ok(base_store.num_blocks().await? + self.cache.num_blocks_in_cache_but_not_in_base_store())
+        Ok(self.base_store.num_blocks().await?
+            + self.cache.num_blocks_in_cache_but_not_in_base_store())
     }
 
     fn estimate_num_free_bytes(&self) -> Result<Byte> {
-        let base_store = &self.base_store;
-        base_store.estimate_num_free_bytes()
+        self.base_store.estimate_num_free_bytes()
     }
 
     fn overhead(&self) -> Overhead {
-        let base_store = &self.base_store;
-        base_store.overhead()
+        self.base_store.overhead()
     }
 
     // TODO Make sure we have tests that have some blocks in the cache and some in the base store
     async fn all_blocks(&self) -> Result<BoxStream<'static, Result<BlockId>>> {
-        let base_store = &self.base_store;
-
         // TODO Is keys_with_entries_or_locked the right thing here? Do we want to count locked entries?
         let blocks_in_cache = self.cache.keys_with_entries_or_locked();
-        let blocks_in_base_store = base_store.all_blocks().await?;
+        let blocks_in_base_store = self.base_store.all_blocks().await?;
 
         let blocks_in_cache_set: HashSet<_> = blocks_in_cache.iter().copied().collect();
         let blocks_in_base_store_and_not_in_cache = blocks_in_base_store

--- a/crates/blockstore/src/high_level/implementations/locking/locking_blockstore.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/locking_blockstore.rs
@@ -73,13 +73,13 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> LockingB
     }
 
     pub async fn into_inner_block_store(this: AsyncDropGuard<Self>) -> Result<AsyncDropGuard<B>> {
-        let mut this = this.unsafe_into_inner_dont_drop();
-        if let Err(e) = this.cache.async_drop().await {
-            let base_store = this.base_store.take().expect("Already destructed");
+        let Self { base_store, cache } = this.unsafe_into_inner_dont_drop();
+        if let Err(e) = cache.async_drop().await {
+            let base_store = base_store.expect("Already destructed");
             // After th cache was dropped, there should be only our own reference left and Arc::try_unwrap should succeed.
             // However, since dropping the cache failed, we don't know what the exact state is.
             // Let's clean up as a best effort.
-            if let Ok(mut base_store) = Arc::try_unwrap(base_store) {
+            if let Ok(base_store) = Arc::try_unwrap(base_store) {
                 if let Err(drop_err) = base_store.async_drop().await {
                     log::error!("Error dropping base_store: {:?}", drop_err);
                 }
@@ -87,7 +87,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> LockingB
             return Err(e);
         }
 
-        let base_store = this.base_store.take().expect("Already destructed");
+        let base_store = base_store.expect("Already destructed");
         let base_store = Arc::into_inner(base_store).expect("We should be the only ones with access to self.base_store, but seems there is still something else accessing it");
         Ok(base_store)
     }
@@ -267,21 +267,21 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
     }
 }
 
-#[async_trait]
 impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> AsyncDrop
     for LockingBlockStore<B>
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { base_store, cache } = self;
         // TODO Exception safety. Should we drop base_store even if dropping the cache fails?
-        self.cache.async_drop().await?;
+        cache.async_drop().await?;
 
         // Since we just dropped the cache, we know there are no cache entries left with access to the self.base_store Arc.
         // This also means there can't be any other tasks/threads currently locking cache entries and doing things with it,
         // we're truly the only one with access to self.base_store.
-        let base_store = self.base_store.take().expect("Already destructed");
-        let mut base_store = Arc::into_inner(base_store).expect("We should be the only ones with access to self.base_store, but seems there is still something else accessing it");
+        let base_store = base_store.expect("Already destructed");
+        let base_store = Arc::into_inner(base_store).expect("We should be the only ones with access to self.base_store, but seems there is still something else accessing it");
         base_store.async_drop().await?;
 
         Ok(())

--- a/crates/blockstore/src/high_level/implementations/locking/locking_blockstore.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/locking_blockstore.rs
@@ -18,8 +18,7 @@ use super::cache::{BlockBaseStoreState, BlockCache, BlockCacheEntryGuard, CacheE
 
 // TODO Should we require B: OptimizedBlockStoreWriter and use its methods?
 pub struct LockingBlockStore<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> {
-    // Always Some unless during destruction
-    base_store: Option<Arc<AsyncDropGuard<B>>>,
+    base_store: Arc<AsyncDropGuard<B>>,
 
     // cache doubles as a cache for blocks that are being returned and might be
     // re-requested, and as a set of mutexes making sure we don't concurrently
@@ -30,7 +29,7 @@ pub struct LockingBlockStore<B: crate::low_level::LLBlockStore + Send + Sync + D
 impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> LockingBlockStore<B> {
     pub fn new(base_store: AsyncDropGuard<B>) -> AsyncDropGuard<Self> {
         AsyncDropGuard::new(Self {
-            base_store: Some(Arc::new(base_store)),
+            base_store: Arc::new(base_store),
             cache: BlockCache::new(),
         })
     }
@@ -56,7 +55,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> LockingB
             };
 
         let removed_from_base_store = if should_remove_from_base_store {
-            let base_store = self.base_store.as_ref().expect("Already destructed");
+            let base_store = &self.base_store;
             match base_store.remove(block_id).await? {
                 RemoveResult::SuccessfullyRemoved => true,
                 RemoveResult::NotRemovedBecauseItDoesntExist => false,
@@ -75,7 +74,6 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> LockingB
     pub async fn into_inner_block_store(this: AsyncDropGuard<Self>) -> Result<AsyncDropGuard<B>> {
         let Self { base_store, cache } = this.unsafe_into_inner_dont_drop();
         if let Err(e) = cache.async_drop().await {
-            let base_store = base_store.expect("Already destructed");
             // After th cache was dropped, there should be only our own reference left and Arc::try_unwrap should succeed.
             // However, since dropping the cache failed, we don't know what the exact state is.
             // Let's clean up as a best effort.
@@ -87,14 +85,13 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> LockingB
             return Err(e);
         }
 
-        let base_store = base_store.expect("Already destructed");
         let base_store = Arc::into_inner(base_store).expect("We should be the only ones with access to self.base_store, but seems there is still something else accessing it");
         Ok(base_store)
     }
 
     #[cfg(any(test, feature = "testutils"))]
     pub fn inner_block_store(&self) -> &AsyncDropGuard<B> {
-        self.base_store.as_ref().expect("Already destructed")
+        &self.base_store
     }
 
     /// See `BlockCache::stop_periodic_pruning`. Only meant for tests that assert exact
@@ -115,7 +112,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
         // TODO Cache non-existence?
         let mut cache_entry = self.cache.async_lock(block_id).await?;
         if cache_entry.value().is_none() {
-            let base_store = self.base_store.as_ref().expect("Already destructed");
+            let base_store = &self.base_store;
             let loaded = base_store.load(&block_id).await?;
             if let Some(loaded) = loaded {
                 self.cache.set_entry(
@@ -140,7 +137,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
             // Block already exists in the cache
             return Ok(TryCreateResult::NotCreatedBecauseBlockIdAlreadyExists);
         }
-        let base_store = self.base_store.as_ref().expect("Already destructed");
+        let base_store = &self.base_store;
         if base_store.exists(block_id).await? {
             return Ok(TryCreateResult::NotCreatedBecauseBlockIdAlreadyExists);
         }
@@ -157,7 +154,7 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
     async fn overwrite(&self, block_id: &BlockId, data: &Data) -> Result<()> {
         let mut cache_entry = self.cache.async_lock(*block_id).await?;
 
-        let base_store = self.base_store.as_ref().expect("Already destructed");
+        let base_store = &self.base_store;
 
         let exists_in_base_store = async || {
             if base_store.exists(block_id).await? {
@@ -201,23 +198,23 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> BlockSto
     }
 
     async fn num_blocks(&self) -> Result<u64> {
-        let base_store = self.base_store.as_ref().expect("Already destructed");
+        let base_store = &self.base_store;
         Ok(base_store.num_blocks().await? + self.cache.num_blocks_in_cache_but_not_in_base_store())
     }
 
     fn estimate_num_free_bytes(&self) -> Result<Byte> {
-        let base_store = self.base_store.as_ref().expect("Already destructed");
+        let base_store = &self.base_store;
         base_store.estimate_num_free_bytes()
     }
 
     fn overhead(&self) -> Overhead {
-        let base_store = self.base_store.as_ref().expect("Already destructed");
+        let base_store = &self.base_store;
         base_store.overhead()
     }
 
     // TODO Make sure we have tests that have some blocks in the cache and some in the base store
     async fn all_blocks(&self) -> Result<BoxStream<'static, Result<BlockId>>> {
-        let base_store = self.base_store.as_ref().expect("Already destructed");
+        let base_store = &self.base_store;
 
         // TODO Is keys_with_entries_or_locked the right thing here? Do we want to count locked entries?
         let blocks_in_cache = self.cache.keys_with_entries_or_locked();
@@ -280,7 +277,6 @@ impl<B: crate::low_level::LLBlockStore + Send + Sync + Debug + 'static> AsyncDro
         // Since we just dropped the cache, we know there are no cache entries left with access to the self.base_store Arc.
         // This also means there can't be any other tasks/threads currently locking cache entries and doing things with it,
         // we're truly the only one with access to self.base_store.
-        let base_store = base_store.expect("Already destructed");
         let base_store = Arc::into_inner(base_store).expect("We should be the only ones with access to self.base_store, but seems there is still something else accessing it");
         base_store.async_drop().await?;
 

--- a/crates/blockstore/src/high_level/implementations/locking/tests.rs
+++ b/crates/blockstore/src/high_level/implementations/locking/tests.rs
@@ -70,7 +70,7 @@ async fn test_whenCallingCreate_thenPassesThroughDataToBaseStore() {
         .expect_store()
         .with(always(), function(|v| v == data(1024, 0).as_ref()))
         .returning(|_, _| Box::pin(async { Ok(()) }));
-    let mut store = LockingBlockStore::new(underlying_store);
+    let store = LockingBlockStore::new(underlying_store);
 
     store.create(&data(1024, 0)).await.unwrap();
 
@@ -101,7 +101,7 @@ async fn test_whenCallingCreate_thenReturnsCorrectBlockId() {
             assert_eq!(*id, id_watcher.expect("id_watcher not set yet"));
             Box::pin(async { Ok(()) })
         });
-    let mut store = LockingBlockStore::new(underlying_store);
+    let store = LockingBlockStore::new(underlying_store);
 
     let block_id = store.create(&data(1024, 0)).await.unwrap();
     assert_eq!(*id_watcher.lock().unwrap(), Some(block_id));
@@ -200,7 +200,7 @@ async fn test_whenCallingCreate_butIdAlreadyExists_thenTriesAgain() {
             );
             Box::pin(async { Ok(()) })
         });
-    let mut store = LockingBlockStore::new(underlying_store);
+    let store = LockingBlockStore::new(underlying_store);
 
     let block_id = store.create(&data(1024, 0)).await.unwrap();
     assert_eq!(attempted_ids.lock().unwrap().last(), Some(&block_id));
@@ -216,7 +216,7 @@ async fn test_whenCallingCreate_butExistsReturnsError_thenReturnsError() {
         .once()
         .returning(move |_| Box::pin(async { Err(anyhow!("Some error")) }));
     underlying_store.expect_store().never();
-    let mut store = LockingBlockStore::new(underlying_store);
+    let store = LockingBlockStore::new(underlying_store);
 
     let err = store.create(&data(1024, 0)).await.unwrap_err();
     assert_eq!("Some error", err.to_string());
@@ -232,7 +232,7 @@ async fn test_overhead() {
     underlying_store
         .expect_overhead()
         .returning(move || expected_overhead);
-    let mut store = LockingBlockStore::new(underlying_store);
+    let store = LockingBlockStore::new(underlying_store);
 
     assert_eq!(expected_overhead, store.overhead());
 

--- a/crates/blockstore/src/high_level/implementations/shared.rs
+++ b/crates/blockstore/src/high_level/implementations/shared.rs
@@ -114,7 +114,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for SharedBlockStore<B>
 where
     B: BlockStore + AsyncDrop + Debug + Send + Sync,
@@ -122,8 +121,9 @@ where
 {
     type Error = <B as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.underlying_store.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { underlying_store } = self;
+        underlying_store.async_drop().await
     }
 }
 

--- a/crates/blockstore/src/high_level/implementations/tracking/tests.rs
+++ b/crates/blockstore/src/high_level/implementations/tracking/tests.rs
@@ -48,7 +48,7 @@ mod without_flushing {
 #[tokio::test]
 async fn counters_start_at_zero() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     assert_eq!(
         ActionCounts {
@@ -76,7 +76,7 @@ async fn counters_start_at_zero() {
 #[tokio::test]
 async fn load_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     let id2 = store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -101,7 +101,7 @@ async fn load_increases_counter() {
 #[tokio::test]
 async fn overwrite_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     let id2 = store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -134,7 +134,7 @@ async fn overwrite_increases_counter() {
 #[tokio::test]
 async fn remove_by_id_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     let id2 = store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -162,7 +162,7 @@ async fn remove_by_id_increases_counter() {
 #[tokio::test]
 async fn remove_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     let id2 = store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -189,7 +189,7 @@ async fn remove_increases_counter() {
 #[tokio::test]
 async fn try_create_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
     let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();
@@ -244,7 +244,7 @@ async fn try_create_increases_counter() {
 #[tokio::test]
 async fn create_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -263,7 +263,7 @@ async fn create_increases_counter() {
 #[tokio::test]
 async fn resize_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     let id2 = store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -294,7 +294,7 @@ async fn resize_increases_counter() {
 #[tokio::test]
 async fn flush_block_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     let id2 = store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -325,7 +325,7 @@ async fn flush_block_increases_counter() {
 #[tokio::test]
 async fn data_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     let id2 = store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -358,7 +358,7 @@ async fn data_increases_counter() {
 #[tokio::test]
 async fn data_mut_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
     let id2 = store.create(&Data::from(vec![4, 5, 6])).await.unwrap();
@@ -391,7 +391,7 @@ async fn data_mut_increases_counter() {
 #[tokio::test]
 async fn num_blocks_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     // Create some blocks to make the test more meaningful
     store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
@@ -417,7 +417,7 @@ async fn num_blocks_increases_counter() {
 #[tokio::test]
 async fn estimate_num_free_bytes_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     store.estimate_num_free_bytes().unwrap();
     store.estimate_num_free_bytes().unwrap();
@@ -438,7 +438,7 @@ async fn estimate_num_free_bytes_increases_counter() {
 #[tokio::test]
 async fn usable_block_size_from_physical_block_size_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     store
         .overhead()
@@ -467,7 +467,7 @@ async fn usable_block_size_from_physical_block_size_increases_counter() {
 #[tokio::test]
 async fn all_blocks_increases_counter() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     // Create some blocks to make the test more meaningful
     store.create(&Data::from(vec![1, 2, 3])).await.unwrap();
@@ -494,7 +494,7 @@ async fn all_blocks_increases_counter() {
 #[tokio::test]
 async fn get_and_reset_totals_works() {
     let mut fixture = TestFixture::<false>::new();
-    let mut store = fixture.store().await;
+    let store = fixture.store().await;
 
     let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
     let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();

--- a/crates/blockstore/src/high_level/implementations/tracking/tracking_blockstore.rs
+++ b/crates/blockstore/src/high_level/implementations/tracking/tracking_blockstore.rs
@@ -121,7 +121,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for TrackingBlockStore<B>
 where
     B: BlockStore + AsyncDrop + Debug + Send + Sync,
@@ -129,8 +128,11 @@ where
 {
     type Error = <B as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.underlying_store.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self {
+            underlying_store, ..
+        } = self;
+        underlying_store.async_drop().await?;
 
         Ok(())
     }

--- a/crates/blockstore/src/lib.rs
+++ b/crates/blockstore/src/lib.rs
@@ -17,7 +17,7 @@ pub use high_level::{Block, BlockStore, LockingBlockStore};
 mod low_level;
 pub use low_level::{
     AllowIntegrityViolations, BlockStoreDeleter, BlockStoreReader, BlockStoreWriter, ClientId,
-    CompressingBlockStore, DynBlockStore, EncryptedBlockStore, InMemoryBlockStore,
+    CompressingBlockStore, DynBlockStore, DynLLBlockStore, EncryptedBlockStore, InMemoryBlockStore,
     IntegrityBlockStore, IntegrityBlockStoreInitError, IntegrityConfig, IntegrityViolationError,
     LLBlockStore, MissingBlockIsIntegrityViolation, OnDiskBlockStore, OptimizedBlockStoreWriter,
     ReadOnlyBlockStore,

--- a/crates/blockstore/src/low_level/implementations/box_dyn.rs
+++ b/crates/blockstore/src/low_level/implementations/box_dyn.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use byte_unit::Byte;
+use futures::future::BoxFuture;
 use futures::stream::BoxStream;
+use std::any::Any;
+use std::fmt::Debug;
 
 use crate::{
     BlockId, Overhead, RemoveResult, TryCreateResult,
@@ -10,8 +13,28 @@ use crate::{
 use cryfs_utils::async_drop::AsyncDrop;
 use cryfs_utils::data::Data;
 
+/// Dyn-compatible version of [LLBlockStore], for use behind `dyn` (see [DynBlockStore]).
+///
+/// [LLBlockStore] has [AsyncDrop] as a supertrait, and [AsyncDrop::async_drop_impl]
+/// returns `impl Future`, which makes [AsyncDrop] and with it [LLBlockStore] not
+/// dyn-compatible. This trait has the same supertraits as [LLBlockStore] except for
+/// [AsyncDrop], which it replaces by [DynLLBlockStore::async_drop_boxed], a method taking
+/// `self: Box<Self>` and returning a boxed future. It is implemented for every [LLBlockStore].
+pub trait DynLLBlockStore:
+    BlockStoreReader + BlockStoreWriter + BlockStoreDeleter + Debug + Any
+{
+    /// Same as [AsyncDrop::async_drop_impl], but callable on a `Box<dyn DynLLBlockStore>`.
+    fn async_drop_boxed(self: Box<Self>) -> BoxFuture<'static, Result<()>>;
+}
+
+impl<B: LLBlockStore> DynLLBlockStore for B {
+    fn async_drop_boxed(self: Box<Self>) -> BoxFuture<'static, Result<()>> {
+        Box::pin((*self).async_drop_impl())
+    }
+}
+
 #[derive(Debug)]
-pub struct DynBlockStore(pub Box<dyn LLBlockStore + Sync + Send>);
+pub struct DynBlockStore(pub Box<dyn DynLLBlockStore + Sync + Send>);
 
 #[async_trait]
 impl BlockStoreReader for DynBlockStore {
@@ -65,12 +88,11 @@ impl BlockStoreDeleter for DynBlockStore {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for DynBlockStore {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        let r = (*self.0).async_drop_impl();
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let r = self.0.async_drop_boxed();
         let r = r.await?;
         Ok(r)
     }

--- a/crates/blockstore/src/low_level/implementations/compressing.rs
+++ b/crates/blockstore/src/low_level/implementations/compressing.rs
@@ -116,13 +116,15 @@ impl<B: OptimizedBlockStoreWriter + Sync + Send + Debug + AsyncDrop<Error = anyh
     }
 }
 
-#[async_trait]
 impl<B: Sync + Send + Debug + AsyncDrop<Error = anyhow::Error>> AsyncDrop
     for CompressingBlockStore<B>
 {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.underlying_block_store.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self {
+            underlying_block_store,
+        } = self;
+        underlying_block_store.async_drop().await?;
         Ok(())
     }
 }
@@ -181,7 +183,7 @@ mod generic_tests {
     #[tokio::test]
     async fn test_usable_block_size_from_physical_block_size() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
         let expected_overhead = Byte::from_u64(0);
 
         assert_eq!(

--- a/crates/blockstore/src/low_level/implementations/encrypted/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/encrypted/mod.rs
@@ -215,7 +215,9 @@ impl<
     async fn async_drop_impl(self) -> Result<()> {
         let Self {
             underlying_block_store,
-            ..
+            cipher: _,
+            threadpool: _,
+            _phantom: _,
         } = self;
         underlying_block_store.async_drop().await
     }

--- a/crates/blockstore/src/low_level/implementations/encrypted/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/encrypted/mod.rs
@@ -205,7 +205,6 @@ impl<
     }
 }
 
-#[async_trait]
 impl<
     C: 'static + CipherDef + Send + Sync,
     _B: Sync + Send + Debug,
@@ -213,8 +212,12 @@ impl<
 > AsyncDrop for EncryptedBlockStore<C, _B, B>
 {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.underlying_block_store.async_drop().await
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self {
+            underlying_block_store,
+            ..
+        } = self;
+        underlying_block_store.async_drop().await
     }
 }
 
@@ -351,7 +354,7 @@ mod tests {
             C: 'static + CipherDef + Send + Sync,
         >() {
             let mut fixture = TestFixture::<C>::new();
-            let mut store = fixture.store().await;
+            let store = fixture.store().await;
             let expected_overhead = Byte::from_u64(
                 FORMAT_VERSION_HEADER.len() as u64
                     + C::CIPHERTEXT_OVERHEAD_PREFIX as u64
@@ -410,7 +413,7 @@ mod tests {
         block_id: &BlockId,
         data: &Data,
     ) {
-        let mut store = EncryptedBlockStore::<
+        let store = EncryptedBlockStore::<
             Aes256Gcm,
             InMemoryBlockStore,
             AsyncDropArc<InMemoryBlockStore>,
@@ -425,7 +428,7 @@ mod tests {
         key: EncryptionKey,
         block_id: &BlockId,
     ) -> Result<Option<Data>> {
-        let mut store = EncryptedBlockStore::<
+        let store = EncryptedBlockStore::<
             Aes256Gcm,
             InMemoryBlockStore,
             AsyncDropArc<InMemoryBlockStore>,
@@ -447,7 +450,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_loading_with_same_key_works() {
-        let mut inner = AsyncDropArc::new(InMemoryBlockStore::new());
+        let inner = AsyncDropArc::new(InMemoryBlockStore::new());
 
         _store(
             &inner,
@@ -472,7 +475,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_loading_with_different_key_doesnt_work() {
-        let mut inner = AsyncDropArc::new(InMemoryBlockStore::new());
+        let inner = AsyncDropArc::new(InMemoryBlockStore::new());
 
         _store(
             &inner,
@@ -494,7 +497,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_loading_manipulated_block_doesnt_work() {
-        let mut inner = AsyncDropArc::new(InMemoryBlockStore::new());
+        let inner = AsyncDropArc::new(InMemoryBlockStore::new());
 
         _store(
             &inner,

--- a/crates/blockstore/src/low_level/implementations/inmemory.rs
+++ b/crates/blockstore/src/low_level/implementations/inmemory.rs
@@ -146,10 +146,9 @@ impl Debug for InMemoryBlockStore {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for InMemoryBlockStore {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
+    async fn async_drop_impl(self) -> Result<()> {
         Ok(())
     }
 }
@@ -180,7 +179,7 @@ mod tests {
     #[tokio::test]
     async fn test_usable_block_size_from_physical_block_size() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
         let expected_overhead = Byte::from_u64(0);
 
         assert_eq!(

--- a/crates/blockstore/src/low_level/implementations/integrity/integrity_data/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/integrity/integrity_data/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{Context, Result};
-use async_trait::async_trait;
 use lockable::{Lockable, LockableHashMap};
 use std::path::PathBuf;
 
@@ -94,14 +93,17 @@ impl IntegrityData {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for IntegrityData {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.known_block_versions
-            .take()
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self {
+            state_file_path,
+            known_block_versions,
+            ..
+        } = self;
+        known_block_versions
             .expect("Was already destructed")
-            .save(&self.state_file_path)
+            .save(&state_file_path)
             .await
     }
 }

--- a/crates/blockstore/src/low_level/implementations/integrity/integrity_data/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/integrity/integrity_data/mod.rs
@@ -49,7 +49,7 @@ impl IntegrityData {
         &self,
         block_id: BlockId,
     ) -> <LockableHashMap<BlockId, BlockInfo> as Lockable<BlockId, BlockInfo>>::OwnedGuard {
-        self._known_block_versions().lock_block_info(block_id).await
+        self.known_block_versions.lock_block_info(block_id).await
     }
 
     /// Checks if any previous runs recognized any integrity violations and marked it in the local state.
@@ -59,14 +59,14 @@ impl IntegrityData {
     /// so there's a way to reset and allow them to access the file system again, but they definitely
     /// won't miss that something weird happened.
     pub fn integrity_violation_in_previous_run(&self) -> bool {
-        self._known_block_versions()
+        self.known_block_versions
             .integrity_violation_in_previous_run()
     }
 
     /// This is intended to be called when an integrity violation was recognized and it marks the local
     /// state so that future attempts to open the file system will fail. See [IntegrityData::integrity_violation_in_previous_run].
     pub fn set_integrity_violation_in_previous_run(&self) {
-        self._known_block_versions()
+        self.known_block_versions
             .set_integrity_violation_in_previous_run();
     }
 
@@ -74,15 +74,7 @@ impl IntegrityData {
     /// seen them before and we haven't deleted it. Note that, this can return
     /// blocks that have been correctly deleted by other authorized clients.
     pub fn existing_blocks(&self) -> Vec<BlockId> {
-        self._known_block_versions().existing_blocks()
-    }
-
-    fn _known_block_versions(&self) -> &KnownBlockVersions {
-        &self.known_block_versions
-    }
-
-    fn _known_block_versions_mut(&mut self) -> &mut KnownBlockVersions {
-        &mut self.known_block_versions
+        self.known_block_versions.existing_blocks()
     }
 }
 
@@ -91,8 +83,8 @@ impl AsyncDrop for IntegrityData {
     async fn async_drop_impl(self) -> Result<()> {
         let Self {
             state_file_path,
+            my_client_id: _,
             known_block_versions,
-            ..
         } = self;
         known_block_versions.save(&state_file_path).await
     }

--- a/crates/blockstore/src/low_level/implementations/integrity/integrity_data/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/integrity/integrity_data/mod.rs
@@ -24,18 +24,15 @@ pub struct IntegrityData {
     state_file_path: PathBuf,
     my_client_id: ClientId,
 
-    // Always Some except for during destruction
-    known_block_versions: Option<KnownBlockVersions>,
+    known_block_versions: KnownBlockVersions,
 }
 
 // TODO We should probably lock the file while it's open so that another CryFS process doesn't open it too
 
 impl IntegrityData {
     pub fn new(state_file_path: PathBuf, my_client_id: ClientId) -> Result<AsyncDropGuard<Self>> {
-        let known_block_versions = Some(
-            KnownBlockVersions::load_or_default(&state_file_path)
-                .context("Tried to deserialize the state file")?,
-        );
+        let known_block_versions = KnownBlockVersions::load_or_default(&state_file_path)
+            .context("Tried to deserialize the state file")?;
         Ok(AsyncDropGuard::new(Self {
             state_file_path,
             my_client_id,
@@ -81,15 +78,11 @@ impl IntegrityData {
     }
 
     fn _known_block_versions(&self) -> &KnownBlockVersions {
-        self.known_block_versions
-            .as_ref()
-            .expect("Object is currently being destructed")
+        &self.known_block_versions
     }
 
     fn _known_block_versions_mut(&mut self) -> &mut KnownBlockVersions {
-        self.known_block_versions
-            .as_mut()
-            .expect("Object is currently being destructed")
+        &mut self.known_block_versions
     }
 }
 
@@ -101,10 +94,7 @@ impl AsyncDrop for IntegrityData {
             known_block_versions,
             ..
         } = self;
-        known_block_versions
-            .expect("Was already destructed")
-            .save(&state_file_path)
-            .await
+        known_block_versions.save(&state_file_path).await
     }
 }
 

--- a/crates/blockstore/src/low_level/implementations/integrity/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/integrity/mod.rs
@@ -85,14 +85,14 @@ pub enum IntegrityBlockStoreInitError {
 
 impl<B: Send + Sync + Debug + AsyncDrop<Error = anyhow::Error>> IntegrityBlockStore<B> {
     pub async fn new(
-        mut underlying_block_store: AsyncDropGuard<B>,
+        underlying_block_store: AsyncDropGuard<B>,
         integrity_file_path: PathBuf,
         my_client_id: ClientId,
         config: IntegrityConfig,
     ) -> Result<AsyncDropGuard<Self>, IntegrityBlockStoreInitError> {
         let integrity_data = IntegrityData::new(integrity_file_path.clone(), my_client_id)
             .context("Tried to create IntegrityData");
-        let mut integrity_data = match integrity_data {
+        let integrity_data = match integrity_data {
             Ok(integrity_data) => integrity_data,
             Err(err) => {
                 if let Err(async_drop_err) = underlying_block_store.async_drop().await {
@@ -486,15 +486,19 @@ impl<B: Send + Debug + AsyncDrop<Error = anyhow::Error>> IntegrityBlockStore<B> 
     }
 }
 
-#[async_trait]
 impl<B: Sync + Send + Debug + AsyncDrop<Error = anyhow::Error>> AsyncDrop
     for IntegrityBlockStore<B>
 {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self {
+            underlying_block_store,
+            integrity_data,
+            ..
+        } = self;
         let (drop1, drop2) = join!(
-            self.underlying_block_store.async_drop(),
-            self.integrity_data.async_drop(),
+            underlying_block_store.async_drop(),
+            integrity_data.async_drop(),
         );
         drop1?;
         drop2?;
@@ -590,7 +594,7 @@ mod generic_tests {
     #[tokio::test]
     async fn test_usable_block_size_from_physical_block_size() {
         let mut fixture = TestFixture::<false, false>::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
         let expected_overhead = Byte::from_u64(HEADER_SIZE_BYTES as u64);
 
         assert_eq!(

--- a/crates/blockstore/src/low_level/implementations/integrity/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/integrity/mod.rs
@@ -493,8 +493,8 @@ impl<B: Sync + Send + Debug + AsyncDrop<Error = anyhow::Error>> AsyncDrop
     async fn async_drop_impl(self) -> Result<()> {
         let Self {
             underlying_block_store,
+            config: _,
             integrity_data,
-            ..
         } = self;
         let (drop1, drop2) = join!(
             underlying_block_store.async_drop(),

--- a/crates/blockstore/src/low_level/implementations/mock.rs
+++ b/crates/blockstore/src/low_level/implementations/mock.rs
@@ -32,7 +32,7 @@ mock! {
     }
     impl AsyncDrop for BlockStore {
         type Error = anyhow::Error;
-        fn async_drop_impl<'a, 'r>(&'a mut self) -> BoxFuture<'r, Result<()>> where 'a: 'r;
+        fn async_drop_impl(self) -> impl std::future::Future<Output = Result<()>> + Send;
     }
     impl LLBlockStore for BlockStore {}
 }

--- a/crates/blockstore/src/low_level/implementations/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/mod.rs
@@ -20,7 +20,7 @@ mod readonly;
 pub use readonly::ReadOnlyBlockStore;
 
 mod box_dyn;
-pub use box_dyn::DynBlockStore;
+pub use box_dyn::{DynBlockStore, DynLLBlockStore};
 
 #[cfg(any(test, feature = "testutils"))]
 mod mock;

--- a/crates/blockstore/src/low_level/implementations/ondisk/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/ondisk/mod.rs
@@ -154,10 +154,9 @@ impl Debug for OnDiskBlockStore {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for OnDiskBlockStore {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
+    async fn async_drop_impl(self) -> Result<()> {
         Ok(())
     }
 }
@@ -382,7 +381,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_block_path() {
-        let mut block_store = OnDiskBlockStore::new(PathBuf::from("/base/path"));
+        let block_store = OnDiskBlockStore::new(PathBuf::from("/base/path"));
         assert_eq!(
             Path::new("/base/path/2AC/9C78D80937AD50852C50BD3F1F982"),
             block_store._block_path(
@@ -401,7 +400,7 @@ mod tests {
     #[tokio::test]
     async fn test_usable_block_size_from_physical_block_size() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
         let expected_overhead = Byte::from_u64(FORMAT_VERSION_HEADER.len() as u64);
 
         assert_eq!(
@@ -446,7 +445,7 @@ mod tests {
     #[tokio::test]
     async fn test_ondisk_block_size() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         store.store(&blockid(0), &[]).await.unwrap();
         assert_eq!(
@@ -478,7 +477,7 @@ mod tests {
     #[tokio::test]
     async fn test_whenStoringBlock_thenBlockFileExists() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         assert!(!_block_file_exists(fixture.basedir.path(), &blockid(0)));
         store.store(&blockid(0), &[]).await.unwrap();
@@ -494,7 +493,7 @@ mod tests {
     #[tokio::test]
     async fn test_whenRemovingBlock_thenBlockFileDoesntExist() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         store.store(&blockid(0), &[]).await.unwrap();
         assert!(_block_file_exists(fixture.basedir.path(), &blockid(0)));

--- a/crates/blockstore/src/low_level/implementations/readonly.rs
+++ b/crates/blockstore/src/low_level/implementations/readonly.rs
@@ -89,13 +89,13 @@ impl<B: OptimizedBlockStoreWriter + Debug + Sync + Send + AsyncDrop<Error = anyh
     }
 }
 
-#[async_trait]
 impl<B: Sync + Send + Debug + AsyncDrop<Error = anyhow::Error>> AsyncDrop
     for ReadOnlyBlockStore<B>
 {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.underlying_store.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { underlying_store } = self;
+        underlying_store.async_drop().await?;
         Ok(())
     }
 }

--- a/crates/blockstore/src/low_level/implementations/shared.rs
+++ b/crates/blockstore/src/low_level/implementations/shared.rs
@@ -100,11 +100,11 @@ impl<B: OptimizedBlockStoreWriter + Debug + Sync + Send + AsyncDrop<Error = anyh
     }
 }
 
-#[async_trait]
 impl<B: Sync + Send + Debug + AsyncDrop<Error = anyhow::Error>> AsyncDrop for SharedBlockStore<B> {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.underlying_store.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { underlying_store } = self;
+        underlying_store.async_drop().await?;
         Ok(())
     }
 }
@@ -147,7 +147,7 @@ mod tests {
     #[tokio::test]
     async fn test_usable_block_size_from_physical_block_size() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
         let expected_overhead = Byte::from_u64(0);
 
         assert_eq!(

--- a/crates/blockstore/src/low_level/implementations/tempdir.rs
+++ b/crates/blockstore/src/low_level/implementations/tempdir.rs
@@ -21,9 +21,8 @@ use super::OnDiskBlockStore;
 /// deletes the directory when the block store is dropped.
 #[derive(Debug)]
 pub struct TempDirBlockStore {
-    // Order is important, we want to drop the underlying store before the tempdir
     underlying_store: AsyncDropGuard<OnDiskBlockStore>,
-    _tempdir: TempDir,
+    tempdir: TempDir,
 }
 
 impl TempDirBlockStore {
@@ -34,7 +33,7 @@ impl TempDirBlockStore {
             .expect("Failed to create tempdir");
         let path = tempdir.path().to_owned();
         AsyncDropGuard::new(Self {
-            _tempdir: tempdir,
+            tempdir,
             underlying_store: OnDiskBlockStore::new(path),
         })
     }
@@ -98,13 +97,13 @@ impl OptimizedBlockStoreWriter for TempDirBlockStore {
 impl AsyncDrop for TempDirBlockStore {
     type Error = anyhow::Error;
     async fn async_drop_impl(self) -> Result<()> {
-        // `_tempdir` stays alive until the end of this function, so the underlying store
-        // is dropped before the tempdir gets deleted.
         let Self {
             underlying_store,
-            _tempdir,
+            tempdir,
         } = self;
         underlying_store.async_drop().await?;
+        // Order is important, the underlying store must be dropped before the tempdir gets deleted.
+        std::mem::drop(tempdir);
         Ok(())
     }
 }

--- a/crates/blockstore/src/low_level/implementations/tempdir.rs
+++ b/crates/blockstore/src/low_level/implementations/tempdir.rs
@@ -95,11 +95,16 @@ impl OptimizedBlockStoreWriter for TempDirBlockStore {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for TempDirBlockStore {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.underlying_store.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<()> {
+        // `_tempdir` stays alive until the end of this function, so the underlying store
+        // is dropped before the tempdir gets deleted.
+        let Self {
+            underlying_store,
+            _tempdir,
+        } = self;
+        underlying_store.async_drop().await?;
         Ok(())
     }
 }

--- a/crates/blockstore/src/low_level/implementations/tracking.rs
+++ b/crates/blockstore/src/low_level/implementations/tracking.rs
@@ -159,13 +159,15 @@ impl<B: OptimizedBlockStoreWriter + Debug + Sync + Send + AsyncDrop<Error = anyh
     }
 }
 
-#[async_trait]
 impl<B: Sync + Send + Debug + AsyncDrop<Error = anyhow::Error>> AsyncDrop
     for TrackingBlockStore<B>
 {
     type Error = anyhow::Error;
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.underlying_store.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self {
+            underlying_store, ..
+        } = self;
+        underlying_store.async_drop().await?;
         Ok(())
     }
 }
@@ -200,7 +202,7 @@ mod tests {
     #[tokio::test]
     async fn counters_start_at_zero() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         assert_eq!(
             ActionCounts {
@@ -223,7 +225,7 @@ mod tests {
     #[tokio::test]
     async fn exists_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
         let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();
@@ -251,7 +253,7 @@ mod tests {
     #[tokio::test]
     async fn load_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
         let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();
@@ -285,7 +287,7 @@ mod tests {
     #[tokio::test]
     async fn store_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
         let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();
@@ -314,7 +316,7 @@ mod tests {
     #[tokio::test]
     async fn store_optimized_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
         let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();
@@ -355,7 +357,7 @@ mod tests {
     #[tokio::test]
     async fn remove_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
         let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();
@@ -410,7 +412,7 @@ mod tests {
     #[tokio::test]
     async fn try_create_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
         let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();
@@ -453,7 +455,7 @@ mod tests {
     #[tokio::test]
     async fn try_create_optimized_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
         let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();
@@ -508,7 +510,7 @@ mod tests {
     #[tokio::test]
     async fn test_usable_block_size_from_physical_block_size() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
         let expected_overhead = Byte::from_u64(0);
 
         assert_eq!(
@@ -534,7 +536,7 @@ mod tests {
     #[tokio::test]
     async fn num_blocks_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         // Create some blocks to make the test more meaningful
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
@@ -562,7 +564,7 @@ mod tests {
     #[tokio::test]
     async fn estimate_num_free_bytes_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         // Call estimate_num_free_bytes multiple times
         store.estimate_num_free_bytes().unwrap();
@@ -584,7 +586,7 @@ mod tests {
     #[tokio::test]
     async fn usable_block_size_from_physical_block_size_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         // Call usable_block_size_from_physical_block_size multiple times
         store
@@ -614,7 +616,7 @@ mod tests {
     #[tokio::test]
     async fn all_blocks_increases_counter() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         // Create some blocks to make the test more meaningful
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
@@ -643,7 +645,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_and_reset_totals() {
         let mut fixture = TestFixture::new();
-        let mut store = fixture.store().await;
+        let store = fixture.store().await;
 
         let id1 = BlockId::from_hex("715db62b0b4e333f8b16c76ee886c95b").unwrap();
         let id2 = BlockId::from_hex("62b0b4e333f8b16c76ee886c95b715db").unwrap();

--- a/crates/blockstore/src/low_level/mod.rs
+++ b/crates/blockstore/src/low_level/mod.rs
@@ -10,8 +10,8 @@ pub use implementations::{
     ActionCounts, MockBlockStore, SharedBlockStore, TempDirBlockStore, TrackingBlockStore,
 };
 pub use implementations::{
-    AllowIntegrityViolations, ClientId, CompressingBlockStore, DynBlockStore, EncryptedBlockStore,
-    InMemoryBlockStore, IntegrityBlockStore, IntegrityBlockStoreInitError, IntegrityConfig,
-    IntegrityViolationError, MissingBlockIsIntegrityViolation, OnDiskBlockStore,
+    AllowIntegrityViolations, ClientId, CompressingBlockStore, DynBlockStore, DynLLBlockStore,
+    EncryptedBlockStore, InMemoryBlockStore, IntegrityBlockStore, IntegrityBlockStoreInitError,
+    IntegrityConfig, IntegrityViolationError, MissingBlockIsIntegrityViolation, OnDiskBlockStore,
     ReadOnlyBlockStore,
 };

--- a/crates/blockstore/src/tests/high_level/adapter_for_low_level_tests.rs
+++ b/crates/blockstore/src/tests/high_level/adapter_for_low_level_tests.rs
@@ -96,13 +96,13 @@ impl<B: BlockStore + AsyncDrop<Error = anyhow::Error> + Send + Sync + Debug + 's
     }
 }
 
-#[async_trait]
 impl<B: BlockStore + AsyncDrop<Error = anyhow::Error> + Send + Sync + Debug + 'static> AsyncDrop
     for BlockStoreToLLBlockStoreAdapter<B>
 {
     type Error = <B as AsyncDrop>::Error;
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.0.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self(inner) = self;
+        inner.async_drop().await
     }
 }
 

--- a/crates/blockstore/src/tests/high_level/tests.rs
+++ b/crates/blockstore/src/tests/high_level/tests.rs
@@ -111,7 +111,7 @@ pub mod create {
     use super::*;
 
     pub async fn test_twoCreatedBlocksHaveDifferentIds(mut f: impl HLFixture) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let first = store.create(&data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -131,7 +131,7 @@ pub mod remove {
     use super::*;
 
     pub async fn test_canRemoveAModifiedBlock(mut f: impl HLFixture) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
         let mut block = store.load(blockid).await.unwrap().unwrap();
@@ -157,7 +157,7 @@ pub mod resize {
     pub async fn test_givenZeroSizeBlock_whenResizingToBeLarger_thenSucceeds(
         mut f: impl HLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(0, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -175,7 +175,7 @@ pub mod resize {
     pub async fn test_givenZeroSizeBlock_whenResizingToBeLarger_thenBlockIsStillUsable(
         mut f: impl HLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(0, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -192,7 +192,7 @@ pub mod resize {
     pub async fn test_givenNonzeroSizeBlock_whenResizingToBeLarger_thenSucceeds(
         mut f: impl HLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(100, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -210,7 +210,7 @@ pub mod resize {
     pub async fn test_givenNonzeroSizeBlock_whenResizingToBeLarger_thenBlockIsStillUsable(
         mut f: impl HLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(100, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -227,7 +227,7 @@ pub mod resize {
     pub async fn test_givenNonzeroSizeBlock_whenResizingToBeSmaller_thenSucceeds(
         mut f: impl HLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -245,7 +245,7 @@ pub mod resize {
     pub async fn test_givenNonzeroSizeBlock_whenResizingToBeSmaller_thenBlockIsStillUsable(
         mut f: impl HLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -262,7 +262,7 @@ pub mod resize {
     pub async fn test_givenNonzeroSizeBlock_whenResizingToBeZero_thenSucceeds(
         mut f: impl HLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -280,7 +280,7 @@ pub mod resize {
     pub async fn test_givenNonzeroSizeBlock_whenResizingToBeZero_thenBlockIsStillUsable(
         mut f: impl HLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         let blockid = store.create(&data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
 
@@ -328,7 +328,7 @@ pub mod data {
 
     pub async fn test_writeAndReadImmediately(mut f: impl HLFixture) {
         for data_range in DATA_RANGES {
-            let mut store = f.store().await;
+            let store = f.store().await;
 
             let blockid = store.create(&data(data_range.blocksize, 0)).await.unwrap();
             f.yield_fixture(&store).await;
@@ -365,7 +365,7 @@ pub mod data {
 
     pub async fn test_writeAndReadAfterLoading(mut f: impl HLFixture) {
         for data_range in DATA_RANGES {
-            let mut store = f.store().await;
+            let store = f.store().await;
 
             let blockid = store.create(&data(data_range.blocksize, 0)).await.unwrap();
             f.yield_fixture(&store).await;
@@ -457,7 +457,7 @@ pub mod usable_block_size_from_physical_block_size {
     use super::*;
 
     pub async fn test_physicalToUsableToPhysical(mut f: impl HLFixture) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         let physical = Byte::from_u64(100);
         let usable = store
@@ -476,7 +476,7 @@ pub mod usable_block_size_from_physical_block_size {
     }
 
     pub async fn test_usableToPhysicalToUsable(mut f: impl HLFixture) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         let usable = Byte::from_u64(100);
         let physical = store

--- a/crates/blockstore/src/tests/low_level/tests.rs
+++ b/crates/blockstore/src/tests/low_level/tests.rs
@@ -111,7 +111,7 @@ pub mod try_create {
     pub async fn test_givenNonEmptyBlockStore_whenCallingTryCreateOnExistingBlock_thenFails(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store.store(&blockid(1), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
@@ -135,7 +135,7 @@ pub mod try_create {
     pub async fn test_givenNonEmptyBlockStore_whenCallingTryCreateOnExistingEmptyBlock_thenFails(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store.store(&blockid(1), &data(0, 0)).await.unwrap();
         f.yield_fixture(&store).await;
@@ -159,7 +159,7 @@ pub mod try_create {
     pub async fn test_givenNonEmptyBlockStore_whenCallingTryCreateOnNonExistingBlock_withNonEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store.store(&blockid(1), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
@@ -180,7 +180,7 @@ pub mod try_create {
     pub async fn test_givenNonEmptyBlockStore_whenCallingTryCreateOnNonExistingBlock_withEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store.store(&blockid(1), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
@@ -201,7 +201,7 @@ pub mod try_create {
     pub async fn test_givenEmptyBlockStore_whenCallingTryCreateOnNonExistingBlock_withNonEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         let status = store
             .try_create(&blockid(1), data(1024, 1).as_ref())
@@ -219,7 +219,7 @@ pub mod try_create {
     pub async fn test_givenEmptyBlockStore_whenCallingTryCreateOnNonExistingBlock_withEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         let status = store
             .try_create(&blockid(1), data(0, 1).as_ref())
@@ -241,7 +241,7 @@ pub mod load {
     pub async fn test_givenNonEmptyBlockStore_whenLoadExistingBlock_withNonEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(0), data(1024, 0).as_ref())
@@ -265,7 +265,7 @@ pub mod load {
     pub async fn test_givenNonEmptyBlockStore_whenLoadExistingBlock_withEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(0), data(1024, 0).as_ref())
@@ -286,7 +286,7 @@ pub mod load {
     pub async fn test_givenNonEmptyBlockStore_whenLoadNonexistingBlock_thenFails(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(0), data(1024, 0).as_ref())
@@ -310,7 +310,7 @@ pub mod load {
     pub async fn test_givenEmptyBlockStore_whenLoadNonexistingBlock_thenFails(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         let loaded = store.load(&blockid(1)).await.unwrap();
         assert_eq!(None, loaded);
@@ -326,7 +326,7 @@ pub mod store {
     pub async fn test_givenEmptyBlockStore_whenStoringNonExistingBlock_withNonEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 1).as_ref())
@@ -343,7 +343,7 @@ pub mod store {
     pub async fn test_givenEmptyBlockStore_whenStoringNonExistingBlock_withEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store.store(&blockid(1), data(0, 1).as_ref()).await.unwrap();
         f.yield_fixture(&store).await;
@@ -357,7 +357,7 @@ pub mod store {
     pub async fn test_givenNonEmptyBlockStore_whenStoringNonExistingBlock_withNonEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 0).as_ref())
@@ -379,7 +379,7 @@ pub mod store {
     pub async fn test_givenNonEmptyBlockStore_whenStoringNonExistingBlock_withEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 0).as_ref())
@@ -399,7 +399,7 @@ pub mod store {
     pub async fn test_givenNonEmptyBlockStore_whenStoringExistingBlock_withNonEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 0).as_ref())
@@ -433,7 +433,7 @@ pub mod store {
     pub async fn test_givenNonEmptyBlockStore_whenStoringExistingBlock_withEmptyData_thenSucceeds(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 0).as_ref())
@@ -470,7 +470,7 @@ pub mod remove {
     pub async fn test_givenOtherwiseEmptyBlockStore_whenRemovingNonEmptyBlock_thenBlockIsNotLoadableAnymore(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 1).as_ref())
@@ -496,7 +496,7 @@ pub mod remove {
     pub async fn test_givenOtherwiseEmptyBlockStore_whenRemovingEmptyBlock_thenBlockIsNotLoadableAnymore(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store.store(&blockid(1), data(0, 1).as_ref()).await.unwrap();
         f.yield_fixture(&store).await;
@@ -519,7 +519,7 @@ pub mod remove {
     pub async fn test_givenNonEmptyBlockStore_whenRemovingNonEmptyBlock_thenBlockIsNotLoadableAnymore(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 2).as_ref())
@@ -551,7 +551,7 @@ pub mod remove {
     pub async fn test_givenNonEmptyBlockStore_whenRemovingEmptyBlock_thenBlockIsNotLoadableAnymore(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 2).as_ref())
@@ -580,7 +580,7 @@ pub mod remove {
     pub async fn test_givenEmptyBlockStore_whenRemovingNonexistingBlock_thenFails(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         assert_eq!(
             RemoveResult::NotRemovedBecauseItDoesntExist,
@@ -597,7 +597,7 @@ pub mod remove {
     pub async fn test_givenNonEmptyBlockStore_whenRemovingNonexistingBlock_thenFails(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store
             .store(&blockid(1), data(1024, 2).as_ref())
@@ -624,7 +624,7 @@ pub mod num_blocks {
     pub async fn test_givenEmptyBlockStore_whenCallingNumBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         assert_eq!(0, store.num_blocks().await.unwrap());
         f.yield_fixture(&store).await;
 
@@ -634,7 +634,7 @@ pub mod num_blocks {
     pub async fn test_afterStoringBlocks_whenCallingNumBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         assert_eq!(0, store.num_blocks().await.unwrap());
         f.yield_fixture(&store).await;
 
@@ -664,7 +664,7 @@ pub mod num_blocks {
     pub async fn test_afterStoringBlocks_withSameId_whenCallingNumBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         assert_eq!(0, store.num_blocks().await.unwrap());
         f.yield_fixture(&store).await;
 
@@ -684,7 +684,7 @@ pub mod num_blocks {
     pub async fn test_afterTryCreatingBlocks_whenCallingNumBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         assert_eq!(0, store.num_blocks().await.unwrap());
         f.yield_fixture(&store).await;
@@ -727,7 +727,7 @@ pub mod num_blocks {
     pub async fn test_afterRemovingBlocks_whenCallingNumBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         store.store(&blockid(0), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
@@ -791,7 +791,7 @@ pub mod all_blocks {
     pub async fn test_givenEmptyBlockStore_whenCallingAllBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         assert_unordered_vec_eq(vec![], call_all_blocks(store.deref()).await);
         f.yield_fixture(&store).await;
 
@@ -801,7 +801,7 @@ pub mod all_blocks {
     pub async fn test_givenBlockStoreWithOneNonEmptyBlock_whenCallingAllBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         store.store(&blockid(0), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
         assert_unordered_vec_eq(vec![blockid(0)], call_all_blocks(store.deref()).await);
@@ -813,7 +813,7 @@ pub mod all_blocks {
     pub async fn test_givenBlockStoreWithOneEmptyBlock_whenCallingAllBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         store.store(&blockid(0), &data(0, 0)).await.unwrap();
         f.yield_fixture(&store).await;
         assert_unordered_vec_eq(vec![blockid(0)], call_all_blocks(store.deref()).await);
@@ -825,7 +825,7 @@ pub mod all_blocks {
     pub async fn test_givenBlockStoreWithTwoBlocks_whenCallingAllBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         store.store(&blockid(0), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
         store.store(&blockid(1), &data(1024, 0)).await.unwrap();
@@ -842,7 +842,7 @@ pub mod all_blocks {
     pub async fn test_givenBlockStoreWithThreeBlocks_whenCallingAllBlocks_thenReturnsCorrectResult(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         store.store(&blockid(0), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
         store.store(&blockid(1), &data(1024, 0)).await.unwrap();
@@ -861,7 +861,7 @@ pub mod all_blocks {
     pub async fn test_afterRemovingBlock_whenCallingAllBlocks_doesntListRemovedBlocks(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         store.store(&blockid(0), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
         store.store(&blockid(1), &data(1024, 0)).await.unwrap();
@@ -906,7 +906,7 @@ pub mod exists {
     pub async fn test_givenEmptyBlockStore_whenCallingExistsOnNonExistingBlock_thenReturnsFalse(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         assert!(!store.exists(&blockid(0)).await.unwrap());
         f.yield_fixture(&store).await;
 
@@ -916,7 +916,7 @@ pub mod exists {
     pub async fn test_givenNonEmptyBlockStore_whenCallingExistsOnNonExistingBlock_thenReturnsFalse(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         store.store(&blockid(0), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
         assert!(!store.exists(&blockid(1)).await.unwrap());
@@ -928,7 +928,7 @@ pub mod exists {
     pub async fn test_givenNonEmptyBlockStore_whenCallingExistsOnExistingBlock_thenReturnsTrue(
         mut f: impl LLFixture,
     ) {
-        let mut store = f.store().await;
+        let store = f.store().await;
         store.store(&blockid(0), &data(1024, 0)).await.unwrap();
         f.yield_fixture(&store).await;
         assert!(store.exists(&blockid(0)).await.unwrap());
@@ -942,7 +942,7 @@ pub mod overhead {
     use super::*;
 
     pub async fn test_physicalToUsableToPhysical(mut f: impl LLFixture) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         let physical = Byte::from_u64(100_000);
         let usable = store
@@ -961,7 +961,7 @@ pub mod overhead {
     }
 
     pub async fn test_usableToPhysicalToUsable(mut f: impl LLFixture) {
-        let mut store = f.store().await;
+        let store = f.store().await;
 
         let usable = Byte::from_u64(100_000);
         let physical = store

--- a/crates/check/Cargo.toml
+++ b/crates/check/Cargo.toml
@@ -14,7 +14,6 @@ name = "cryfs-check"
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 byte-unit.workspace = true
 clap = { workspace = true, features = ["derive"] }
 clap-logflag.workspace = true

--- a/crates/check/src/runner.rs
+++ b/crates/check/src/runner.rs
@@ -47,7 +47,7 @@ impl<'l, PBM: ProgressBarManager> BlockstoreCallback for RecoverRunner<'l, PBM> 
 
     async fn callback<B: LLBlockStore + AsyncDrop + Send + Sync + 'static>(
         self,
-        mut blockstore: AsyncDropGuard<LockingBlockStore<B>>,
+        blockstore: AsyncDropGuard<LockingBlockStore<B>>,
     ) -> Self::Result {
         // TODO Function too large. Split into subfunctions
 
@@ -78,7 +78,7 @@ impl<'l, PBM: ProgressBarManager> BlockstoreCallback for RecoverRunner<'l, PBM> 
         let checks = AllChecks::new(root_blob_id);
 
         let blocksize = self.config.config.config().blocksize;
-        let mut blobstore = FsBlobStore::new(BlobStoreOnBlocks::new(blockstore, blocksize).await?);
+        let blobstore = FsBlobStore::new(BlobStoreOnBlocks::new(blockstore, blocksize).await?);
 
         let pb = self
             .progress_bar_manager
@@ -112,7 +112,7 @@ impl<'l, PBM: ProgressBarManager> BlockstoreCallback for RecoverRunner<'l, PBM> 
             "Checking all nodes",
             u64::try_from(all_nodes.len()).unwrap(),
         );
-        let mut nodestore = DataTreeStore::into_inner_node_store(
+        let nodestore = DataTreeStore::into_inner_node_store(
             BlobStoreOnBlocks::into_inner_tree_store(FsBlobStore::into_inner_blobstore(blobstore)),
         );
         let processed_nodes = Arc::new(ProcessedItems::new());
@@ -295,7 +295,7 @@ where
                 // TODO Can we deduplicate this with the AlreadySeen::NotSeenYet branch below?
                 //      Also, do we want to add the same assertions here that we have below?
                 match loaded {
-                    Ok(Some(mut blob)) => {
+                    Ok(Some(blob)) => {
                         let result = checks.process_reachable_blob_again(
                             BlobToProcess::Readable(&blob),
                             &blob_referenced_as.referenced_as,
@@ -335,7 +335,7 @@ where
             }
             AlreadySeen::NotSeenYet => {
                 match loaded {
-                    Ok(Some(mut blob)) => {
+                    Ok(Some(blob)) => {
                         if !all_nodes.contains(blob_referenced_as.blob_id.to_root_block_id()) {
                             Err(CheckError::FilesystemModified {
                                 msg: format!(

--- a/crates/check/tests/blob_unreferenced.rs
+++ b/crates/check/tests/blob_unreferenced.rs
@@ -47,7 +47,7 @@ fn make_single_node_file_blob(
         fs_fixture
             .update_fsblobstore(|fsblobstore| {
                 Box::pin(async move {
-                    let mut blob = fsblobstore
+                    let blob = fsblobstore
                         .create_file_blob(&parent_id(), FlushBehavior::DontFlush)
                         .await
                         .unwrap();
@@ -104,7 +104,7 @@ fn make_single_node_dir_blob(
         fs_fixture
             .update_fsblobstore(|fsblobstore| {
                 Box::pin(async move {
-                    let mut dir_blob = fsblobstore
+                    let dir_blob = fsblobstore
                         .create_dir_blob(&parent_id(), FlushBehavior::DontFlush)
                         .await
                         .unwrap();
@@ -214,7 +214,7 @@ fn make_single_node_symlink_blob(
         fs_fixture
             .update_fsblobstore(|fsblobstore| {
                 Box::pin(async move {
-                    let mut blob = fsblobstore
+                    let blob = fsblobstore
                         .create_symlink_blob(&parent_id(), "target", FlushBehavior::DontFlush)
                         .await
                         .unwrap();

--- a/crates/check/tests/blob_with_wrong_parent_pointer.rs
+++ b/crates/check/tests/blob_with_wrong_parent_pointer.rs
@@ -77,7 +77,7 @@ fn make_large_dir<'a>(
                         .unwrap()
                         .unwrap();
                     let mut parent = CreatedDirBlob::new(parent, parent_info.referenced_as.path);
-                    let mut dir =
+                    let dir =
                         entry_helpers::create_large_dir(fsblobstore, &mut *parent, "dirname").await;
                     let result = (&*dir).into();
                     dir.async_drop().await.unwrap();

--- a/crates/check/tests/common/entry_helpers.rs
+++ b/crates/check/tests/common/entry_helpers.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use futures::{
     future::FutureExt,
     stream::{self, BoxStream, StreamExt},
@@ -72,7 +71,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for CreatedDirBlob<B>
 where
     B: BlobStore + Debug + 'static,
@@ -80,8 +78,9 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.blob.async_drop().await
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { blob, path: _ } = self;
+        blob.async_drop().await
     }
 }
 
@@ -151,7 +150,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for CreatedFileBlob<B>
 where
     B: BlobStore + Debug + 'static,
@@ -159,8 +157,9 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.blob.async_drop().await
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { blob, path: _ } = self;
+        blob.async_drop().await
     }
 }
 
@@ -196,7 +195,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for CreatedSymlinkBlob<B>
 where
     B: BlobStore + Debug + 'static,
@@ -204,8 +202,9 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.blob.async_drop().await
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { blob, path: _ } = self;
+        blob.async_drop().await
     }
 }
 
@@ -526,26 +525,23 @@ where
     let mut dir2_dir7 = create_empty_dir(fsblobstore, &mut dir2, "somedir7").await;
 
     // Let's create a directory, symlink and file with lots of entries (so it'll use multiple nodes)
-    let mut large_dir_1 =
+    let large_dir_1 =
         create_large_dir_with_large_entries(fsblobstore, &mut dir2_dir6, "some_large_dir_1", 2)
             .await;
-    let mut large_dir_2 =
+    let large_dir_2 =
         create_large_dir_with_large_entries(fsblobstore, &mut dir1_dir4, "some_large_dir_2", 2)
             .await;
-    let mut dir2_dir7_large_symlink_1 =
+    let dir2_dir7_large_symlink_1 =
         create_large_symlink(fsblobstore, &mut dir2_dir7, "some_large_symlink_1").await;
-    let mut dir2_large_symlink_1 =
+    let dir2_large_symlink_1 =
         create_large_symlink(fsblobstore, &mut dir2, "some_large_symlink_2").await;
-    let mut dir2_dir7_large_file_1 =
+    let dir2_dir7_large_file_1 =
         create_large_file(fsblobstore, &mut dir2_dir7, "some_large_file_1").await;
-    let mut dir2_large_file_1 =
-        create_large_file(fsblobstore, &mut dir2, "some_large_file_2").await;
+    let dir2_large_file_1 = create_large_file(fsblobstore, &mut dir2, "some_large_file_2").await;
 
-    let mut empty_file =
-        create_empty_file(fsblobstore, &mut dir1_dir3_dir5, "some_empty_file").await;
-    let mut empty_dir = create_empty_dir(fsblobstore, &mut dir2_dir7, "some_empty_dir").await;
-    let mut empty_symlink =
-        create_symlink(fsblobstore, &mut dir1_dir3, "some_empty_symlink", "").await;
+    let empty_file = create_empty_file(fsblobstore, &mut dir1_dir3_dir5, "some_empty_file").await;
+    let empty_dir = create_empty_dir(fsblobstore, &mut dir2_dir7, "some_empty_dir").await;
+    let empty_symlink = create_symlink(fsblobstore, &mut dir1_dir3, "some_empty_symlink", "").await;
 
     let result = SomeBlobs {
         root: (&*root).into(),

--- a/crates/check/tests/common/fixture.rs
+++ b/crates/check/tests/common/fixture.rs
@@ -70,8 +70,8 @@ impl FilesystemFixture {
     }
 
     async fn create_root_dir_blob(&self) {
-        let mut fsblobstore = self.make_fsblobstore().await;
-        let mut blob = fsblobstore
+        let fsblobstore = self.make_fsblobstore().await;
+        let blob = fsblobstore
             .create_root_dir_blob(&self.root_blob_id)
             .await
             .expect("Failed to create rootdir blob");
@@ -144,7 +144,7 @@ impl FilesystemFixture {
             &'b DataNodeStore<LockingBlockStore<DynBlockStore>>,
         ) -> BoxFuture<'b, R>,
     ) -> R {
-        let mut nodestore = self.make_nodestore().await;
+        let nodestore = self.make_nodestore().await;
         let result = update_fn(&nodestore).await;
         nodestore.async_drop().await.unwrap();
         result
@@ -156,7 +156,7 @@ impl FilesystemFixture {
             &'b BlobStoreOnBlocks<LockingBlockStore<DynBlockStore>>,
         ) -> BoxFuture<'b, R>,
     ) -> R {
-        let mut blobstore = self.make_blobstore().await;
+        let blobstore = self.make_blobstore().await;
         let result = update_fn(&blobstore).await;
         blobstore.async_drop().await.unwrap();
         result
@@ -168,7 +168,7 @@ impl FilesystemFixture {
             &'b FsBlobStore<BlobStoreOnBlocks<LockingBlockStore<DynBlockStore>>>,
         ) -> BoxFuture<'b, R>,
     ) -> R {
-        let mut fsblobstore = self.make_fsblobstore().await;
+        let fsblobstore = self.make_fsblobstore().await;
         let result = update_fn(&fsblobstore).await;
         fsblobstore.async_drop().await.unwrap();
         result
@@ -230,7 +230,7 @@ impl FilesystemFixture {
                 let parent_blob = blobstore.load(&parent.blob_id).await.unwrap().unwrap();
                 let mut parent = CreatedDirBlob::new(parent_blob, parent.referenced_as.path);
                 with_async_drop_2!(parent, {
-                    let mut file =
+                    let file =
                         super::entry_helpers::create_empty_file(blobstore, &mut parent, &name)
                             .await;
                     let result = (&*file).into();
@@ -289,7 +289,7 @@ impl FilesystemFixture {
                 let parent_blob = blobstore.load(&parent.blob_id).await.unwrap().unwrap();
                 let mut parent_blob = CreatedDirBlob::new(parent_blob, parent.referenced_as.path);
                 with_async_drop_2!(parent_blob, {
-                    let mut symlink = super::entry_helpers::create_symlink(
+                    let symlink = super::entry_helpers::create_symlink(
                         blobstore,
                         &mut parent_blob,
                         &name,
@@ -405,7 +405,7 @@ impl FilesystemFixture {
     pub async fn is_dir_blob(&self, blob_id: BlobId) -> bool {
         self.update_fsblobstore(move |fsblobstore| {
             Box::pin(async move {
-                let mut blob = fsblobstore.load(&blob_id).await.unwrap().unwrap();
+                let blob = fsblobstore.load(&blob_id).await.unwrap().unwrap();
                 let result = matches!(&*blob, FsBlob::Directory(_));
                 blob.async_drop().await.unwrap();
                 result

--- a/crates/cli-utils/src/blockstore_setup.rs
+++ b/crates/cli-utils/src/blockstore_setup.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 use cryfs_blockstore::{
-    ClientId, DynBlockStore, EncryptedBlockStore, IntegrityBlockStore,
+    ClientId, DynBlockStore, DynLLBlockStore, EncryptedBlockStore, IntegrityBlockStore,
     IntegrityBlockStoreInitError, IntegrityConfig, LLBlockStore, LockingBlockStore,
     OptimizedBlockStoreWriter,
 };
@@ -75,7 +75,7 @@ impl<B: LLBlockStore + OptimizedBlockStoreWriter + Send + Sync, CB: BlockstoreCa
 {
     type Result = Result<CB::Result, CliError>;
 
-    async fn callback<C: CipherDef + Send + Sync + 'static>(mut self) -> Self::Result {
+    async fn callback<C: CipherDef + Send + Sync + 'static>(self) -> Self::Result {
         let key = match EncryptionKey::from_hex(&self.config.enc_key) {
             Ok(key) => key,
             Err(err) => {
@@ -97,7 +97,7 @@ impl<B: LLBlockStore + OptimizedBlockStoreWriter + Send + Sync, CB: BlockstoreCa
                 return Err(err).map_cli_error(|_| CliErrorKind::InvalidFilesystem);
             }
         };
-        let mut encrypted_blockstore = EncryptedBlockStore::new(self.base_blockstore, cipher);
+        let encrypted_blockstore = EncryptedBlockStore::new(self.base_blockstore, cipher);
 
         let integrity_file_path = self
             .local_state_dir
@@ -161,7 +161,7 @@ impl BlockstoreCallback for DynCallback {
         blockstore: AsyncDropGuard<LockingBlockStore<B>>,
     ) -> Self::Result {
         let inner = LockingBlockStore::into_inner_block_store(blockstore).await?;
-        let inner: Box<dyn LLBlockStore + Send + Sync> =
+        let inner: Box<dyn DynLLBlockStore + Send + Sync> =
             Box::new(inner.unsafe_into_inner_dont_drop());
         let inner = AsyncDropGuard::new(DynBlockStore(inner));
         Ok(LockingBlockStore::new(inner))

--- a/crates/concurrent-store/Cargo.toml
+++ b/crates/concurrent-store/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 futures.workspace = true
 lockable.workspace = true
 cryfs-utils = { path = "../utils" }

--- a/crates/concurrent-store/src/guard.rs
+++ b/crates/concurrent-store/src/guard.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use lockable::Never;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -56,7 +55,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K, V, E> AsyncDrop for LoadedEntryGuard<K, V, E>
 where
     K: Hash + Eq + Clone + Debug + Send + Sync + 'static,
@@ -65,10 +63,10 @@ where
 {
     type Error = Never;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        let value = std::mem::replace(&mut self.value, AsyncDropGuard::new_invalid());
-        ConcurrentStoreInner::unload(&self.store, self.key.clone(), value).await;
-        self.store.async_drop().await.unwrap(); // TODO No unwrap
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { store, key, value } = self;
+        ConcurrentStoreInner::unload(&store, key, value).await;
+        store.async_drop().await.unwrap(); // TODO No unwrap
         Ok(())
     }
 }

--- a/crates/concurrent-store/src/store.rs
+++ b/crates/concurrent-store/src/store.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use futures::FutureExt as _;
 use futures::future::{BoxFuture, Shared};
 use lockable::{InfallibleUnwrap as _, Never};
@@ -149,7 +148,7 @@ where
     pub async fn try_insert_loaded(
         &self,
         mut key: K,
-        mut value: AsyncDropGuard<V>,
+        value: AsyncDropGuard<V>,
     ) -> Result<AsyncDropGuard<LoadedEntryGuard<K, V, E>>> {
         // TODO Deduplicate between this and try_insert_loading
         loop {
@@ -539,11 +538,10 @@ where
     pub(super) async fn unload(
         this: &AsyncDropGuard<AsyncDropArc<ConcurrentStoreInner<K, V, E>>>,
         key: K,
-        mut entry: AsyncDropGuard<AsyncDropArc<V>>,
+        entry: AsyncDropGuard<AsyncDropArc<V>>,
     ) {
         // First drop the entry to decrement the reference count
         entry.async_drop().await.unwrap(); // TODO No unwrap? But what to do if it fails? We need to guarantee that we still remove the entry since the guard is gone now.
-        std::mem::drop(entry);
 
         // Now check if we're the last reference. If yes, remove the entry from our map.
         Self::_drop_if_no_references(this, key).await;
@@ -619,7 +617,7 @@ where
         key: K,
         loaded: EntryStateLoaded<V>,
     ) -> Shared<BoxFuture<'static, ()>> {
-        let (immediate_drop_request, mut entry) = loaded.into_inner();
+        let (immediate_drop_request, entry) = loaded.into_inner();
         let this = AsyncDropArc::clone(this);
         async move {
             with_async_drop_2!(this, {
@@ -728,7 +726,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K, V, E> AsyncDrop for ConcurrentStoreInner<K, V, E>
 where
     K: Hash + Eq + Clone + Debug + Send + Sync + 'static,
@@ -737,11 +734,13 @@ where
 {
     type Error = Never;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
         // Wait for any currently dropping entries to complete
-        let mut entries = std::mem::take(&mut *self.entries.get_mut().unwrap());
+        let Self { entries } = self;
         let dropping_futures = entries
-                .drain()
+                .into_inner()
+                .unwrap()
+                .into_iter()
                 .filter_map(|(_, entry_state)| match entry_state {
                     EntryState::Dropping(dropping) => Some(dropping.into_future()),
                     EntryState::Loading(loading) => {
@@ -772,7 +771,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K, V, E> AsyncDrop for ConcurrentStore<K, V, E>
 where
     K: Hash + Eq + Clone + Debug + Send + Sync + 'static,
@@ -781,8 +779,9 @@ where
 {
     type Error = Never;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.inner.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { inner } = self;
+        inner.async_drop().await
     }
 }
 

--- a/crates/cryfs-cli/src/runner/mount.rs
+++ b/crates/cryfs-cli/src/runner/mount.rs
@@ -232,7 +232,7 @@ impl<'v, 'm, 'c, OnSuccessfullyMounted: FnOnce()> BlockstoreCallback
 }
 
 async fn make_device<B>(
-    mut blobstore: AsyncDropGuard<B>,
+    blobstore: AsyncDropGuard<B>,
     config: &CryConfig,
     create_or_load: CreateOrLoad,
     atime_behavior: AtimeUpdateBehavior,
@@ -254,7 +254,7 @@ where
         }
     };
 
-    let mut device = match create_or_load {
+    let device = match create_or_load {
         CreateOrLoad::CreateNewFilesystem => {
             CryDevice::create_new_filesystem(blobstore, root_blob_id, atime_behavior)
                 .await

--- a/crates/cryfs-filesystem/src/filesystem/device.rs
+++ b/crates/cryfs-filesystem/src/filesystem/device.rs
@@ -64,7 +64,7 @@ where
         root_blob_id: BlobId,
         atime_update_behavior: AtimeUpdateBehavior,
     ) -> Result<AsyncDropGuard<Self>, Arc<anyhow::Error>> {
-        let mut fsblobstore = ConcurrentFsBlobStore::new(FsBlobStore::new(blobstore));
+        let fsblobstore = ConcurrentFsBlobStore::new(FsBlobStore::new(blobstore));
         match fsblobstore.create_root_dir_blob(&root_blob_id).await {
             Ok(()) => Ok(AsyncDropGuard::new(Self {
                 blobstore: AsyncDropArc::new(fsblobstore),
@@ -95,7 +95,7 @@ where
         &self,
         path: impl IntoIterator<Item = &PathComponent>,
     ) -> FsResult<AsyncDropGuard<ConcurrentFsBlob<B>>> {
-        let mut root_blob = self
+        let root_blob = self
             .blobstore
             .load(&self.root_blob_id)
             .await
@@ -162,13 +162,16 @@ where
                 })
                 .await;
 
-            if let Some(current_blob) = current_blob.as_mut() {
-                current_blob
-                    .async_drop()
-                    .await
-                    .map_err(FsError::internal_error)?;
-            } else {
-                // current_blob is borrowed. No need to drop it
+            match current_blob {
+                MaybeOwned::Owned(current_blob) => {
+                    current_blob
+                        .async_drop()
+                        .await
+                        .map_err(FsError::internal_error)?;
+                }
+                MaybeOwned::Borrowed(_) => {
+                    // current_blob is borrowed. No need to drop it
+                }
             }
 
             let blob_id = blob_id?;
@@ -206,7 +209,7 @@ where
         let shared_path = path1.iter().take(num_shared_path_components);
         let relative_path1 = path1.iter().skip(num_shared_path_components);
         let relative_path2 = path2.iter().skip(num_shared_path_components);
-        let mut shared_blob = self.load_blob(shared_path).await?;
+        let shared_blob = self.load_blob(shared_path).await?;
 
         let relative_path1_len = relative_path1.len();
         let relative_path2_len = relative_path2.len();
@@ -224,12 +227,15 @@ where
                     .map_err(FsError::internal_error)?;
                 Err(err1)
             }
-            (Err(err1), Ok(mut blob2)) => {
+            (Err(err1), Ok(blob2)) => {
                 // TODO async_drop blob2 and shared_blob concurrently
-                if let Some(blob2) = blob2.as_mut() {
-                    blob2.async_drop().await.map_err(FsError::internal_error)?;
-                } else {
-                    // blob2 is borrowed. No need to drop it
+                match blob2 {
+                    MaybeOwned::Owned(blob2) => {
+                        blob2.async_drop().await.map_err(FsError::internal_error)?;
+                    }
+                    MaybeOwned::Borrowed(_) => {
+                        // blob2 is borrowed. No need to drop it
+                    }
                 }
                 shared_blob
                     .async_drop()
@@ -237,12 +243,15 @@ where
                     .map_err(FsError::internal_error)?;
                 Err(err1)
             }
-            (Ok(mut blob1), Err(err2)) => {
+            (Ok(blob1), Err(err2)) => {
                 // TODO async_drop blob1 and shared_blob concurrently
-                if let Some(blob1) = blob1.as_mut() {
-                    blob1.async_drop().await.map_err(FsError::internal_error)?;
-                } else {
-                    // blob1 is borrowed. No need to drop it
+                match blob1 {
+                    MaybeOwned::Owned(blob1) => {
+                        blob1.async_drop().await.map_err(FsError::internal_error)?;
+                    }
+                    MaybeOwned::Borrowed(_) => {
+                        // blob1 is borrowed. No need to drop it
+                    }
                 }
                 shared_blob
                     .async_drop()
@@ -624,7 +633,6 @@ where
     Ok(())
 }
 
-#[async_trait]
 impl<B> AsyncDrop for CryDevice<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
@@ -632,8 +640,14 @@ where
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.blobstore
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self {
+            blobstore,
+            root_blob_id: _,
+            atime_update_behavior: _,
+            last_access_time: _,
+        } = self;
+        blobstore
             .async_drop()
             .await
             .map_err(FsError::internal_error)

--- a/crates/cryfs-filesystem/src/filesystem/dir.rs
+++ b/crates/cryfs-filesystem/src/filesystem/dir.rs
@@ -75,7 +75,7 @@ where
     }
 
     async fn create_dir_blob(&self, parent: &BlobId) -> Result<BlobId, FsError> {
-        let mut blob = self
+        let blob = self
             .blobstore
             .create_dir_blob(
                 parent,
@@ -96,7 +96,7 @@ where
     }
 
     async fn create_file_blob(&self, parent: &BlobId) -> Result<BlobId, FsError> {
-        let mut blob = self
+        let blob = self
             .blobstore
             .create_file_blob(
                 parent,
@@ -117,7 +117,7 @@ where
     }
 
     async fn create_symlink_blob(&self, target: &str, parent: &BlobId) -> Result<BlobId, FsError> {
-        let mut blob = self
+        let blob = self
             .blobstore
             .create_symlink_blob(
                 parent,
@@ -206,7 +206,7 @@ where
 
     async fn lookup_child(&self, name: &PathComponent) -> FsResult<AsyncDropGuard<CryNode<B>>> {
         // TODO We shouldn't have to reload the self blob here, that's weird
-        let mut self_blob = self.load_blob().await?;
+        let self_blob = self.load_blob().await?;
 
         let blob_details = self_blob
             .with_lock(async |self_blob| {
@@ -485,7 +485,7 @@ where
                 let self_blob_id = self.node_info.blob_id();
                 let (blob, new_dir_blob_id) =
                     join!(self.load_blob(), self.create_dir_blob(&self_blob_id));
-                let mut blob = match blob {
+                let blob = match blob {
                     Ok(blob) => blob,
                     Err(err) => {
                         log::error!("Error loading blob: {err:?}");
@@ -589,7 +589,7 @@ where
                         })
                         .await?;
 
-                    let mut child_blob = self.blobstore.load(&child_id).await.map_err(|_| FsError::NodeDoesNotExist)?.ok_or_else(|| FsError::NodeDoesNotExist)?;
+                    let child_blob = self.blobstore.load(&child_id).await.map_err(|_| FsError::NodeDoesNotExist)?.ok_or_else(|| FsError::NodeDoesNotExist)?;
 
                     let entries_check = child_blob.with_lock(async |child_blob| {
                         let child_blob_dir = Self::blob_as_dir(&child_blob).map_err(|err| {
@@ -677,7 +677,7 @@ where
                     self.load_blob(),
                     self.create_symlink_blob(target, self_blob_id),
                 );
-                let mut blob = match blob {
+                let blob = match blob {
                     Ok(blob) => blob,
                     Err(err) => {
                         log::error!("Error loading blob: {err:?}");
@@ -824,7 +824,7 @@ where
                 let self_blob_id = self.node_info.blob_id();
                 let (blob, new_file_blob_id) =
                     join!(self.load_blob(), self.create_file_blob(&self_blob_id),);
-                let mut blob = match blob {
+                let blob = match blob {
                     Ok(blob) => blob,
                     Err(err) => {
                         log::error!("Error loading blob: {err:?}");
@@ -925,14 +925,17 @@ where
     }
 }
 
-#[async_trait]
 impl<'a, B> AsyncDrop for CryDir<'a, B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
     <B as BlobStore>::ConcreteBlob: Send + Sync + AsyncDrop<Error = anyhow::Error>,
 {
     type Error = FsError;
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
-        self.node_info.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), FsError> {
+        let Self {
+            blobstore: _,
+            node_info,
+        } = self;
+        node_info.async_drop().await
     }
 }

--- a/crates/cryfs-filesystem/src/filesystem/file.rs
+++ b/crates/cryfs-filesystem/src/filesystem/file.rs
@@ -67,14 +67,17 @@ where
     }
 }
 
-#[async_trait]
 impl<'a, B> AsyncDrop for CryFile<'a, B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
     <B as BlobStore>::ConcreteBlob: Send + Sync + AsyncDrop<Error = anyhow::Error>,
 {
     type Error = FsError;
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
-        self.node_info.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), FsError> {
+        let Self {
+            blobstore: _,
+            node_info,
+        } = self;
+        node_info.async_drop().await
     }
 }

--- a/crates/cryfs-filesystem/src/filesystem/node.rs
+++ b/crates/cryfs-filesystem/src/filesystem/node.rs
@@ -173,7 +173,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for CryNode<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
@@ -181,9 +180,13 @@ where
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
-        self.node_info.async_drop().await?;
-        self.blobstore
+    async fn async_drop_impl(self) -> Result<(), FsError> {
+        let Self {
+            blobstore,
+            node_info,
+        } = self;
+        node_info.async_drop().await?;
+        blobstore
             .async_drop()
             .await
             .map_err(FsError::internal_error)

--- a/crates/cryfs-filesystem/src/filesystem/node_info.rs
+++ b/crates/cryfs-filesystem/src/filesystem/node_info.rs
@@ -460,8 +460,19 @@ where
     async fn async_drop_impl(self) -> Result<(), Self::Error> {
         let Self { inner } = self;
         match inner {
-            NodeInfoImpl::IsRootDir { .. } => (),
-            NodeInfoImpl::IsNotRootDir { parent_blob, .. } => {
+            NodeInfoImpl::IsRootDir {
+                root_blob_id: _,
+                atime_update_behavior: _,
+            } => (),
+            NodeInfoImpl::IsNotRootDir {
+                parent_blob,
+                #[cfg(feature = "ancestor_checks_on_move")]
+                    ancestors: _,
+                name: _,
+                blob_id: _,
+                blob_type: _,
+                atime_update_behavior: _,
+            } => {
                 parent_blob
                     .async_drop()
                     .await

--- a/crates/cryfs-filesystem/src/filesystem/node_info.rs
+++ b/crates/cryfs-filesystem/src/filesystem/node_info.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use cryfs_utils::with_async_drop_2;
 use std::fmt::Debug;
 use std::time::SystemTime;
@@ -189,7 +188,7 @@ where
     }
 
     async fn load_lstat_size(&self, blobstore: &ConcurrentFsBlobStore<B>) -> FsResult<NumBytes> {
-        let mut blob = self.load_blob(blobstore).await?;
+        let blob = self.load_blob(blobstore).await?;
         let lstat_size = blob.with_lock(async |blob| blob.lstat_size().await).await;
         let result = match lstat_size {
             // TODO Return NumBytes from blob.lstat_size() instead of converting it here
@@ -451,7 +450,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for NodeInfo<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
@@ -459,8 +457,9 @@ where
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        match &mut self.inner {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { inner } = self;
+        match inner {
             NodeInfoImpl::IsRootDir { .. } => (),
             NodeInfoImpl::IsNotRootDir { parent_blob, .. } => {
                 parent_blob

--- a/crates/cryfs-filesystem/src/filesystem/open_file.rs
+++ b/crates/cryfs-filesystem/src/filesystem/open_file.rs
@@ -230,7 +230,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for CryOpenFile<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
@@ -238,9 +237,13 @@ where
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
-        self.node_info.async_drop().await?;
-        self.blobstore
+    async fn async_drop_impl(self) -> Result<(), FsError> {
+        let Self {
+            blobstore,
+            node_info,
+        } = self;
+        node_info.async_drop().await?;
+        blobstore
             .async_drop()
             .await
             .map_err(FsError::internal_error)

--- a/crates/cryfs-filesystem/src/filesystem/symlink.rs
+++ b/crates/cryfs-filesystem/src/filesystem/symlink.rs
@@ -94,7 +94,6 @@ where
     }
 }
 
-#[async_trait]
 impl<'a, B> AsyncDrop for CrySymlink<'a, B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
@@ -102,7 +101,11 @@ where
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> FsResult<()> {
-        self.node_info.async_drop().await
+    async fn async_drop_impl(self) -> FsResult<()> {
+        let Self {
+            blobstore: _,
+            node_info,
+        } = self;
+        node_info.async_drop().await
     }
 }

--- a/crates/e2e-perf-tests/Cargo.toml
+++ b/crates/e2e-perf-tests/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 byte-unit.workspace = true
 crabtime.workspace = true
 criterion = {workspace = true, features = ["async_tokio"]}

--- a/crates/e2e-perf-tests/src/filesystem_driver/fuse_mt.rs
+++ b/crates/e2e-perf-tests/src/filesystem_driver/fuse_mt.rs
@@ -5,7 +5,6 @@ use std::{fmt::Debug, sync::Arc};
 
 use super::FilesystemDriver;
 use super::common::request_info;
-use async_trait::async_trait;
 use cryfs_blobstore::{BlobStoreOnBlocks, TrackingBlobStore};
 use cryfs_blockstore::{
     DynBlockStore, HLSharedBlockStore, HLTrackingBlockStore, LockingBlockStore,
@@ -380,12 +379,12 @@ impl FilesystemDriver for FusemtFilesystemDriver {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for FusemtFilesystemDriver {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.fs.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { fs } = self;
+        fs.async_drop().await?;
         Ok(())
     }
 }

--- a/crates/e2e-perf-tests/src/filesystem_driver/fuser.rs
+++ b/crates/e2e-perf-tests/src/filesystem_driver/fuser.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use futures::try_join;
 use std::{
     fmt::Debug,
@@ -206,7 +205,8 @@ pub struct InodeGuard {
 /// Holds an inode number and will tell the filesystem to forget it when dropped.
 #[derive(Debug)]
 pub struct InodeGuardInner {
-    fs: AsyncDropGuard<AsyncDropArc<ObjectBasedFsAdapterLL<Device>>>,
+    // `Option` because [Drop::drop] only gets `&mut self` but has to move the guard out to drop it.
+    fs: Option<AsyncDropGuard<AsyncDropArc<ObjectBasedFsAdapterLL<Device>>>>,
     ino: InodeNumber,
 }
 
@@ -216,7 +216,7 @@ impl InodeGuard {
         ino: InodeNumber,
     ) -> Self {
         Self {
-            inner: Arc::new(InodeGuardInner { fs, ino }),
+            inner: Arc::new(InodeGuardInner { fs: Some(fs), ino }),
         }
     }
 }
@@ -229,9 +229,10 @@ impl Drop for InodeGuardInner {
         // could starve the tokio runtime.
         tokio::task::block_in_place(|| {
             let handle = tokio::runtime::Handle::current();
+            let fs = self.fs.take().expect("InodeGuardInner::drop called twice");
             handle.block_on(async {
-                self.fs.forget(&request_info(), self.ino, 1).await.unwrap();
-                self.fs.async_drop().await.unwrap();
+                fs.forget(&request_info(), self.ino, 1).await.unwrap();
+                fs.async_drop().await.unwrap();
             });
         });
     }
@@ -844,12 +845,12 @@ impl<C: FuserCacheBehavior> FilesystemDriver for FuserFilesystemDriver<C> {
     }
 }
 
-#[async_trait]
 impl<C: FuserCacheBehavior> AsyncDrop for FuserFilesystemDriver<C> {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.fs.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { fs, _c: _ } = self;
+        fs.async_drop().await?;
         Ok(())
     }
 }

--- a/crates/e2e-perf-tests/src/filesystem_driver/fuser.rs
+++ b/crates/e2e-perf-tests/src/filesystem_driver/fuser.rs
@@ -205,7 +205,7 @@ pub struct InodeGuard {
 /// Holds an inode number and will tell the filesystem to forget it when dropped.
 #[derive(Debug)]
 pub struct InodeGuardInner {
-    // `Option` because [Drop::drop] only gets `&mut self` but has to move the guard out to drop it.
+    // Always Some except during destruction
     fs: Option<AsyncDropGuard<AsyncDropArc<ObjectBasedFsAdapterLL<Device>>>>,
     ino: InodeNumber,
 }

--- a/crates/e2e-perf-tests/src/filesystem_driver/mounting.rs
+++ b/crates/e2e-perf-tests/src/filesystem_driver/mounting.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use nix::{
     fcntl::AT_FDCWD,
     sys::{stat::UtimensatFlags, time::TimeSpec},
@@ -780,14 +779,13 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for MountingFilesystemDriver<B>
 where
     B: MountingBackend,
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
+    async fn async_drop_impl(self) -> Result<()> {
         // The filesystem will be unmounted when RunningFilesystem is dropped
         Ok(())
     }

--- a/crates/fsblobstore/Cargo.toml
+++ b/crates/fsblobstore/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 binary-layout.workspace = true
 binrw.workspace = true
 byte-unit.workspace = true

--- a/crates/fsblobstore/src/concurrentfsblobstore/blob.rs
+++ b/crates/fsblobstore/src/concurrentfsblobstore/blob.rs
@@ -44,7 +44,6 @@ where
     }
 }
 
-#[async_trait::async_trait]
 impl<B> AsyncDrop for ConcurrentFsBlob<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + 'static,
@@ -52,7 +51,8 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.blob.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { blob } = self;
+        blob.async_drop().await
     }
 }

--- a/crates/fsblobstore/src/concurrentfsblobstore/loaded_blobs/guard.rs
+++ b/crates/fsblobstore/src/concurrentfsblobstore/loaded_blobs/guard.rs
@@ -1,6 +1,5 @@
 use std::{fmt::Debug, sync::Arc};
 
-use async_trait::async_trait;
 use cryfs_blobstore::{BlobId, BlobStore, RemoveResult};
 use cryfs_concurrent_store::{LoadedEntryGuard, RequestImmediateDropResult};
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard, AsyncDropTokioMutex};
@@ -44,9 +43,7 @@ where
         f(&mut *guard).await
     }
 
-    pub async fn remove(
-        mut this: AsyncDropGuard<Self>,
-    ) -> Result<RemoveResult, Arc<anyhow::Error>> {
+    pub async fn remove(this: AsyncDropGuard<Self>) -> Result<RemoveResult, Arc<anyhow::Error>> {
         loop {
             match this.loaded_blob.request_immediate_drop(
                 |blob| async move {
@@ -61,7 +58,6 @@ where
                 RequestImmediateDropResult::ImmediateDropRequested { drop_result } => {
                     // Drop the blob so we don't hold a lock on it, which would prevent the removal. Removal waits until all readers relinquished their blob.
                     this.async_drop().await?;
-                    std::mem::drop(this);
                     // Wait until the blob is removed. If there are other readers, this will wait.
                     return drop_result.await;
                 }
@@ -75,7 +71,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for LoadedBlobGuard<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + 'static,
@@ -83,8 +78,9 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.loaded_blob.async_drop().await.infallible_unwrap();
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { loaded_blob } = self;
+        loaded_blob.async_drop().await.infallible_unwrap();
         Ok(())
     }
 }

--- a/crates/fsblobstore/src/concurrentfsblobstore/loaded_blobs/store.rs
+++ b/crates/fsblobstore/src/concurrentfsblobstore/loaded_blobs/store.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use cryfs_concurrent_store::{ConcurrentStore, RequestImmediateDropResult};
 use futures::future::{BoxFuture, Shared};
 use lockable::InfallibleUnwrap as _;
@@ -44,7 +43,7 @@ where
         F: Future<Output = Result<AsyncDropGuard<FsBlob<B>>, Arc<anyhow::Error>>> + Send,
     {
         let loading_fn = move || async move { loading_fn().await.map(AsyncDropTokioMutex::new) };
-        let mut inserted = self
+        let inserted = self
             .loaded_blobs
             .try_insert_loading(blob_id, loading_fn)
             .await?
@@ -105,7 +104,7 @@ where
         blob_id: BlobId,
         blobstore: &AsyncDropGuard<AsyncDropArc<FsBlobStore<B>>>,
     ) -> RequestRemovalResult {
-        let mut blobstore = AsyncDropArc::clone(blobstore);
+        let blobstore = AsyncDropArc::clone(blobstore);
         let request = self
             .loaded_blobs
             .request_immediate_drop(blob_id, move |blob| async move {
@@ -137,7 +136,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for LoadedBlobs<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
@@ -145,8 +143,9 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.loaded_blobs.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { loaded_blobs } = self;
+        loaded_blobs.async_drop().await?;
         Ok(())
     }
 }

--- a/crates/fsblobstore/src/concurrentfsblobstore/store.rs
+++ b/crates/fsblobstore/src/concurrentfsblobstore/store.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use byte_unit::Byte;
 use std::{fmt::Debug, sync::Arc};
 
@@ -165,7 +164,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for ConcurrentFsBlobStore<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + Sync + 'static,
@@ -173,12 +171,17 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self {
+            blobstore,
+            loaded_blobs,
+        } = self;
+
         // First drop all loaded blobs
-        self.loaded_blobs.async_drop().await?;
+        loaded_blobs.async_drop().await?;
 
         // Then drop the underlying blobstore
-        self.blobstore.async_drop().await?;
+        blobstore.async_drop().await?;
 
         Ok(())
     }

--- a/crates/fsblobstore/src/fsblobstore/fsblob/base_blob.rs
+++ b/crates/fsblobstore/src/fsblobstore/fsblob/base_blob.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, ensure};
-use async_trait::async_trait;
 use binary_layout::Field;
 use futures::stream::BoxStream;
 use std::fmt::Debug;
@@ -197,7 +196,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for BaseBlob<B>
 where
     B: BlobStore + Debug,
@@ -205,8 +203,12 @@ where
 {
     type Error = <B::ConcreteBlob as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.blob.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self {
+            blob,
+            header_cache: _,
+        } = self;
+        blob.async_drop().await
     }
 }
 

--- a/crates/fsblobstore/src/fsblobstore/fsblob/dir_blob.rs
+++ b/crates/fsblobstore/src/fsblobstore/fsblob/dir_blob.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, anyhow};
-use async_trait::async_trait;
 use futures::stream::BoxStream;
 use std::fmt::Debug;
 use std::time::SystemTime;
@@ -342,7 +341,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for DirBlob<B>
 where
     B: BlobStore + Debug,
@@ -350,9 +348,10 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
+    async fn async_drop_impl(mut self) -> Result<()> {
         self.writeback().await?;
-        self.blob.async_drop().await?;
+        let Self { blob, entries: _ } = self;
+        blob.async_drop().await?;
         Ok(())
     }
 }

--- a/crates/fsblobstore/src/fsblobstore/fsblob/file_blob.rs
+++ b/crates/fsblobstore/src/fsblobstore/fsblob/file_blob.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard};
 use futures::stream::BoxStream;
 use std::fmt::Debug;
@@ -104,7 +103,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for FileBlob<B>
 where
     B: BlobStore + Debug,
@@ -112,8 +110,9 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.blob.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { blob } = self;
+        blob.async_drop().await?;
         Ok(())
     }
 }

--- a/crates/fsblobstore/src/fsblobstore/fsblob/mod.rs
+++ b/crates/fsblobstore/src/fsblobstore/fsblob/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, bail};
-use async_trait::async_trait;
 use futures::stream::BoxStream;
 use std::fmt::Debug;
 
@@ -50,7 +49,7 @@ where
     <B as BlobStore>::ConcreteBlob: Send + AsyncDrop<Error = anyhow::Error>,
 {
     pub async fn parse(blob: AsyncDropGuard<B::ConcreteBlob>) -> Result<AsyncDropGuard<FsBlob<B>>> {
-        let mut blob = BaseBlob::parse(blob).await?;
+        let blob = BaseBlob::parse(blob).await?;
         match blob.blob_type() {
             Ok(BlobType::Dir) => Ok(AsyncDropGuard::new(Self::Directory(
                 DirBlob::new(blob).await?,
@@ -180,7 +179,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for FsBlob<B>
 where
     B: BlobStore + Debug + 'static,
@@ -188,8 +186,8 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        match &mut self {
+    async fn async_drop_impl(self) -> Result<()> {
+        match self {
             Self::File(blob) => {
                 blob.async_drop().await?;
             }

--- a/crates/fsblobstore/src/fsblobstore/fsblob/symlink_blob.rs
+++ b/crates/fsblobstore/src/fsblobstore/fsblob/symlink_blob.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard};
 use futures::stream::BoxStream;
 use std::fmt::Debug;
@@ -96,7 +95,6 @@ where
     }
 }
 
-#[async_trait]
 impl<B> AsyncDrop for SymlinkBlob<B>
 where
     B: BlobStore + Debug,
@@ -104,8 +102,9 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.blob.async_drop().await?;
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { blob } = self;
+        blob.async_drop().await?;
         Ok(())
     }
 }

--- a/crates/fsblobstore/src/fsblobstore/mod.rs
+++ b/crates/fsblobstore/src/fsblobstore/mod.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use byte_unit::Byte;
 use std::fmt::Debug;
 
@@ -135,7 +134,6 @@ pub enum FlushBehavior {
     DontFlush,
 }
 
-#[async_trait]
 impl<B> AsyncDrop for FsBlobStore<B>
 where
     B: BlobStore + AsyncDrop<Error = anyhow::Error> + Debug + Send + 'static,
@@ -143,7 +141,8 @@ where
 {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
-        self.blobstore.async_drop().await
+    async fn async_drop_impl(self) -> Result<()> {
+        let Self { blobstore } = self;
+        blobstore.async_drop().await
     }
 }

--- a/crates/rustfs/examples/inmemory/device.rs
+++ b/crates/rustfs/examples/inmemory/device.rs
@@ -77,11 +77,10 @@ impl Debug for InMemoryDevice {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for InMemoryDevice {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/inmemory/dir.rs
+++ b/crates/rustfs/examples/inmemory/dir.rs
@@ -353,11 +353,10 @@ impl Debug for InMemoryDirRef {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for InMemoryDirRef {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/inmemory/file.rs
+++ b/crates/rustfs/examples/inmemory/file.rs
@@ -151,11 +151,10 @@ impl Debug for InMemoryFileRef {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for InMemoryFileRef {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }
@@ -249,11 +248,10 @@ impl Debug for InMemoryOpenFileRef {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for InMemoryOpenFileRef {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/inmemory/node.rs
+++ b/crates/rustfs/examples/inmemory/node.rs
@@ -94,11 +94,10 @@ impl Node for InMemoryNodeRef {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for InMemoryNodeRef {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/inmemory/symlink.rs
+++ b/crates/rustfs/examples/inmemory/symlink.rs
@@ -134,11 +134,10 @@ impl Debug for InMemorySymlinkRef {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for InMemorySymlinkRef {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/passthrough/device.rs
+++ b/crates/rustfs/examples/passthrough/device.rs
@@ -28,11 +28,10 @@ impl PassthroughDevice {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for PassthroughDevice {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
         // TODO Do we need to do anything here?
         Ok(())
     }

--- a/crates/rustfs/examples/passthrough/dir.rs
+++ b/crates/rustfs/examples/passthrough/dir.rs
@@ -253,11 +253,10 @@ fn convert_mode(mode: u32) -> nix::sys::stat::Mode {
         .unwrap()
 }
 
-#[async_trait]
 impl AsyncDrop for PassthroughDir {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/passthrough/file.rs
+++ b/crates/rustfs/examples/passthrough/file.rs
@@ -42,11 +42,10 @@ impl File for PassthroughFile {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for PassthroughFile {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/passthrough/node.rs
+++ b/crates/rustfs/examples/passthrough/node.rs
@@ -176,11 +176,10 @@ impl Node for PassthroughNode {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for PassthroughNode {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/passthrough/openfile.rs
+++ b/crates/rustfs/examples/passthrough/openfile.rs
@@ -206,11 +206,10 @@ impl OpenFile for PassthroughOpenFile {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for PassthroughOpenFile {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/examples/passthrough/symlink.rs
+++ b/crates/rustfs/examples/passthrough/symlink.rs
@@ -42,11 +42,10 @@ impl Symlink for PassthroughSymlink {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for PassthroughSymlink {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
+    async fn async_drop_impl(self) -> Result<(), FsError> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/src/backend/fuse_mt/backend_adapter.rs
+++ b/crates/rustfs/src/backend/fuse_mt/backend_adapter.rs
@@ -38,7 +38,8 @@ where
     Fs: AsyncFilesystem + AsyncDrop<Error = FsError> + Debug + Send + Sync + 'static,
 {
     // TODO RwLock is only needed for async drop. Can we remove it?
-    fs: Arc<tokio::sync::RwLock<AsyncDropGuard<Fs>>>,
+    // `None` once [Self::destroy] dropped the file system. Other handles (see [Self::internal_arc]) can still observe that.
+    fs: Arc<tokio::sync::RwLock<Option<AsyncDropGuard<Fs>>>>,
 
     runtime: tokio::runtime::Handle,
 }
@@ -60,12 +61,12 @@ where
 {
     pub fn new(fs: AsyncDropGuard<Fs>, runtime: tokio::runtime::Handle) -> Self {
         Self {
-            fs: Arc::new(tokio::sync::RwLock::new(fs)),
+            fs: Arc::new(tokio::sync::RwLock::new(Some(fs))),
             runtime,
         }
     }
 
-    pub(super) fn internal_arc(&self) -> Arc<tokio::sync::RwLock<AsyncDropGuard<Fs>>> {
+    pub(super) fn internal_arc(&self) -> Arc<tokio::sync::RwLock<Option<AsyncDropGuard<Fs>>>> {
         Arc::clone(&self.fs)
     }
 
@@ -93,22 +94,24 @@ where
 
     async fn fs(&self) -> FsResult<RwLockReadGuard<'_, AsyncDropGuard<Fs>>> {
         let fs = self.fs.read().await;
-        if fs.is_dropped() {
-            // Gracefully handle if [Self::destroy] was already called. This can happen in corner cases where
-            // a file held open and closed after the file system is already unmounted.
-            // We can't really handle it well or honor those operations,
-            // but at least we can avoid a panic.
-            log::error!(
-                "Received a file system operation after destroy() terminated the file system"
-            );
-            return Err(FsError::FilesystemDestroyed);
+        match RwLockReadGuard::try_map(fs, Option::as_ref) {
+            Ok(fs) => Ok(fs),
+            Err(_) => {
+                // Gracefully handle if [Self::destroy] was already called. This can happen in corner cases where
+                // a file held open and closed after the file system is already unmounted.
+                // We can't really handle it well or honor those operations,
+                // but at least we can avoid a panic.
+                log::error!(
+                    "Received a file system operation after destroy() terminated the file system"
+                );
+                Err(FsError::FilesystemDestroyed)
+            }
         }
-        Ok(fs)
     }
 
-    async fn fs_mut(&self) -> FsResult<RwLockWriteGuard<'_, AsyncDropGuard<Fs>>> {
+    async fn fs_mut(&self) -> FsResult<RwLockWriteGuard<'_, Option<AsyncDropGuard<Fs>>>> {
         let fs = self.fs.write().await;
-        if fs.is_dropped() {
+        if fs.is_none() {
             // Gracefully handle if [Self::destroy] was already called. This can happen in corner cases where
             // a file held open and closed after the file system is already unmounted.
             // We can't really handle it well or honor those operations,
@@ -136,7 +139,11 @@ where
 
     fn destroy(&self) {
         self.run_async(&format!("destroy"), async move || {
-            let mut fs = self.fs_mut().await?;
+            // Keep the write lock (`fs_lock`) until we're done so that no operation runs concurrently with the drop.
+            let mut fs_lock = self.fs_mut().await?;
+            let fs = fs_lock
+                .take()
+                .expect("fs_mut() checked that the file system wasn't destroyed yet");
             fs.destroy().await;
             fs.async_drop().await?;
             Ok(())
@@ -726,7 +733,7 @@ where
     Fs: AsyncFilesystem + AsyncDrop<Error = FsError> + Debug + Send + Sync + 'static,
 {
     fn drop(&mut self) {
-        if !self.fs.blocking_read().is_dropped() {
+        if self.fs.blocking_read().is_some() {
             safe_panic!("BackendAdapter dropped without calling destroy() first");
         }
     }

--- a/crates/rustfs/src/backend/fuse_mt/mount.rs
+++ b/crates/rustfs/src/backend/fuse_mt/mount.rs
@@ -60,9 +60,13 @@ where
             session
         }
         Err(e) => {
-            let mut backend_internal_arc = backend_internal_arc.write().await;
-            backend_internal_arc.destroy().await;
-            backend_internal_arc.async_drop().await.unwrap();
+            // Keep the write lock (`fs_lock`) until we're done so that no operation runs concurrently with the drop.
+            let mut fs_lock = backend_internal_arc.write().await;
+            let fs = fs_lock
+                .take()
+                .expect("spawn_mount2 failed without calling destroy(), so the file system must still be alive");
+            fs.destroy().await;
+            fs.async_drop().await.unwrap();
             return Err(e);
         }
     };

--- a/crates/rustfs/src/backend/fuser/backend_adapter.rs
+++ b/crates/rustfs/src/backend/fuser/backend_adapter.rs
@@ -26,6 +26,9 @@ use crate::low_level_api::{
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard};
 use cryfs_utils::path::{PathComponent, PathComponentBuf};
 
+/// Owned read guard on the file system, mapped past the `Option` slot that [BackendAdapter::destroy] empties.
+type FsReadGuard<Fs> = OwnedRwLockReadGuard<Option<AsyncDropGuard<Fs>>, AsyncDropGuard<Fs>>;
+
 // TODO Check if any of the APIs in the high or low level interface would benefit from replacing Vec<> with impl Iterator
 
 // TODO Fuse has a requirement that (inode, generation) tuples are unique throughout the lifetime of the filesystem, not just the lifetime of the mount.
@@ -47,7 +50,8 @@ where
     Fs: AsyncFilesystemLL + AsyncDrop<Error = FsError> + Debug + Send + Sync + 'static,
 {
     // TODO RwLock is only needed for async drop. Can we remove it? init() and destroy() are called on &mut self so they should be exclusive anyways.
-    fs: Arc<tokio::sync::RwLock<AsyncDropGuard<Fs>>>,
+    // `None` once [Self::destroy] dropped the file system. Other handles (see [Self::internal_arc]) can still observe that.
+    fs: Arc<tokio::sync::RwLock<Option<AsyncDropGuard<Fs>>>>,
 
     runtime: tokio::runtime::Handle,
 }
@@ -67,18 +71,18 @@ where
 {
     pub fn new(fs: AsyncDropGuard<Fs>, runtime: tokio::runtime::Handle) -> Self {
         Self {
-            fs: Arc::new(RwLock::new(fs)),
+            fs: Arc::new(RwLock::new(Some(fs))),
             runtime,
         }
     }
 
-    pub(super) fn internal_arc(&self) -> Arc<RwLock<AsyncDropGuard<Fs>>> {
+    pub(super) fn internal_arc(&self) -> Arc<RwLock<Option<AsyncDropGuard<Fs>>>> {
         Arc::clone(&self.fs)
     }
 
     async fn call_with_fs<F, R>(
-        fs: Arc<tokio::sync::RwLock<AsyncDropGuard<Fs>>>,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        fs: Arc<tokio::sync::RwLock<Option<AsyncDropGuard<Fs>>>>,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) -> FsResult<R>
     where
         F: Future<Output = FsResult<R>> + Send,
@@ -88,25 +92,27 @@ where
     }
 
     async fn fs_read(
-        fs: Arc<tokio::sync::RwLock<AsyncDropGuard<Fs>>>,
-    ) -> FsResult<OwnedRwLockReadGuard<AsyncDropGuard<Fs>>> {
+        fs: Arc<tokio::sync::RwLock<Option<AsyncDropGuard<Fs>>>>,
+    ) -> FsResult<FsReadGuard<Fs>> {
         let fs = RwLock::read_owned(fs).await;
-        if fs.is_dropped() {
-            // Gracefully handle if [Self::destroy] was already called. This can happen in corner cases where
-            // a file held open and closed after the file system is already unmounted.
-            // We can't really handle it well or honor those operations,
-            // but at least we can avoid a panic.
-            log::error!(
-                "Received a file system operation after destroy() terminated the file system"
-            );
-            return Err(FsError::FilesystemDestroyed);
+        match OwnedRwLockReadGuard::try_map(fs, Option::as_ref) {
+            Ok(fs) => Ok(fs),
+            Err(_) => {
+                // Gracefully handle if [Self::destroy] was already called. This can happen in corner cases where
+                // a file held open and closed after the file system is already unmounted.
+                // We can't really handle it well or honor those operations,
+                // but at least we can avoid a panic.
+                log::error!(
+                    "Received a file system operation after destroy() terminated the file system"
+                );
+                Err(FsError::FilesystemDestroyed)
+            }
         }
-        Ok(fs)
     }
 
-    async fn fs_write(&self) -> FsResult<RwLockWriteGuard<'_, AsyncDropGuard<Fs>>> {
+    async fn fs_write(&self) -> FsResult<RwLockWriteGuard<'_, Option<AsyncDropGuard<Fs>>>> {
         let fs = self.fs.write().await;
-        if fs.is_dropped() {
+        if fs.is_none() {
             // Gracefully handle if [Self::destroy] was already called. This can happen in corner cases where
             // a file held open and closed after the file system is already unmounted.
             // We can't really handle it well or honor those operations,
@@ -159,7 +165,7 @@ where
     fn run_async_no_reply<F>(
         &self,
         log_msg: String,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<()>> + Send,
     {
@@ -181,7 +187,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyEmpty,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<()>> + Send,
     {
@@ -205,7 +211,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyEntry,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyEntry>> + Send,
     {
@@ -233,7 +239,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyAttr,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyAttr>> + Send,
     {
@@ -257,7 +263,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyOpen,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyOpen>> + Send,
     {
@@ -282,7 +288,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyWrite,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyWrite>> + Send,
     {
@@ -308,7 +314,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyStatfs,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<Statfs>> + Send,
     {
@@ -342,7 +348,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyCreate,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyCreate>> + Send,
     {
@@ -372,7 +378,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyLock,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyLock>> + Send,
     {
@@ -396,7 +402,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyBmap,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyBmap>> + Send,
     {
@@ -420,7 +426,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyIoctl,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyIoctl>> + Send,
     {
@@ -444,7 +450,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyLseek,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyLseek>> + Send,
     {
@@ -472,7 +478,7 @@ where
         &self,
         log_msg: String,
         fuser_reply: fuser::ReplyXTimes,
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>) -> F,
     ) where
         F: Future<Output = FsResult<low_level_api::ReplyXTimes>> + Send,
     {
@@ -497,7 +503,7 @@ where
         log_msg: String,
         reply: fuser::ReplyData,
         // TODO If we could do `for <Callback: FnOnce> impl ...`, we wouldn't need the DataCallback class
-        func: impl Send + 'static + FnOnce(OwnedRwLockReadGuard<AsyncDropGuard<Fs>>, DataCallback) -> F,
+        func: impl Send + 'static + FnOnce(FsReadGuard<Fs>, DataCallback) -> F,
     ) where
         F: Future<Output = ()> + Send,
     {
@@ -523,14 +529,22 @@ where
 
         let req = RequestInfo::from(req);
         Self::run_blocking(&self.runtime, &format!("init({config:?})"), async || {
-            self.fs_write().await?.init(&req).await
+            let fs = self.fs_write().await?;
+            fs.as_ref()
+                .expect("fs_write() checked that the file system wasn't destroyed yet")
+                .init(&req)
+                .await
         })
         .map_err(std::io::Error::from_raw_os_error)
     }
 
     fn destroy(&mut self) {
         Self::run_blocking(&self.runtime, "destroy", async || {
-            let mut fs = self.fs_write().await?;
+            // Keep the write lock (`fs_lock`) until we're done so that no operation runs concurrently with the drop.
+            let mut fs_lock = self.fs_write().await?;
+            let fs = fs_lock
+                .take()
+                .expect("fs_write() checked that the file system wasn't destroyed yet");
             fs.destroy().await;
             fs.async_drop().await.unwrap();
             Ok(())

--- a/crates/rustfs/src/backend/fuser/mount.rs
+++ b/crates/rustfs/src/backend/fuser/mount.rs
@@ -52,9 +52,13 @@ where
             session
         }
         Err(e) => {
-            let mut backend_internal_arc = backend_internal_arc.write().await;
-            backend_internal_arc.destroy().await;
-            backend_internal_arc.async_drop().await.unwrap();
+            // Keep the write lock (`fs_lock`) until we're done so that no operation runs concurrently with the drop.
+            let mut fs_lock = backend_internal_arc.write().await;
+            let fs = fs_lock
+                .take()
+                .expect("spawn_mount2 failed without calling destroy(), so the file system must still be alive");
+            fs.destroy().await;
+            fs.async_drop().await.unwrap();
             return Err(e);
         }
     };

--- a/crates/rustfs/src/common/handles/handle_map.rs
+++ b/crates/rustfs/src/common/handles/handle_map.rs
@@ -69,7 +69,10 @@ where
     type Error = FsError;
 
     async fn async_drop_impl(self) -> Result<(), FsError> {
-        let Self { objects, .. } = self;
+        let Self {
+            objects,
+            available_handles: _,
+        } = self;
         objects.async_drop().await
     }
 }

--- a/crates/rustfs/src/common/handles/handle_map.rs
+++ b/crates/rustfs/src/common/handles/handle_map.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use std::fmt::Debug;
 
 use super::{HandlePool, HandleWithGeneration};
@@ -62,7 +61,6 @@ where
     }
 }
 
-#[async_trait]
 impl<Handle, T> AsyncDrop for HandleMap<Handle, T>
 where
     Handle: HandleTrait + Send,
@@ -70,8 +68,9 @@ where
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), FsError> {
-        self.objects.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), FsError> {
+        let Self { objects, .. } = self;
+        objects.async_drop().await
     }
 }
 

--- a/crates/rustfs/src/object_based_api/high_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/high_level_adapter.rs
@@ -319,7 +319,7 @@ where
             with_async_drop_2!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_child_dir() ?
                 // TODO No need to return the child dir object to just immediately async_drop it
-                let (new_dir_attrs, mut new_dir) = parent_dir
+                let (new_dir_attrs, new_dir) = parent_dir
                     .create_child_dir(&name, mode, req.uid, req.gid)
                     .await?;
                 new_dir.async_drop().await?;
@@ -388,7 +388,7 @@ where
             with_async_drop_2!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_child_symlink() ?
                 // TODO No need to return the symlink object to just immediately async_drop it
-                let (new_symlink_attrs, mut symlink) = parent_dir
+                let (new_symlink_attrs, symlink) = parent_dir
                     .create_child_symlink(&name, target, req.uid, req.gid)
                     .await?;
                 symlink.async_drop().await?;
@@ -542,7 +542,7 @@ where
     ) -> FsResult<()> {
         self.trigger_on_operation().await?;
 
-        let mut removed = self.open_files.remove(fh);
+        let removed = self.open_files.remove(fh);
         removed.async_drop().await?;
         Ok(())
     }
@@ -735,7 +735,7 @@ where
         let parent_dir = fs.get().lookup(parent).await?;
         with_async_drop_2!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            let (file_attrs, mut node, open_file) = with_async_drop_2!(parent_dir, {
+            let (file_attrs, node, open_file) = with_async_drop_2!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_and_open_file() ?
                 // TODO No need to return the node just to immediately async_drop it below
                 parent_dir
@@ -754,7 +754,6 @@ where
     }
 }
 
-#[async_trait]
 impl<Fs> AsyncDrop for ObjectBasedFsAdapter<Fs>
 where
     Fs: Device + Debug + AsyncDrop<Error = FsError> + Send + Sync + 'static,
@@ -762,12 +761,13 @@ where
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.open_files.async_drop().await?;
-        let mut fs = std::mem::replace(
-            &mut *self.fs.write().unwrap(),
-            AsyncDropGuard::new_invalid(),
-        );
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { fs, open_files } = self;
+        open_files.async_drop().await?;
+        let fs = Arc::into_inner(fs)
+            .expect("ObjectBasedFsAdapter::fs is never shared, so this must be the last reference to it")
+            .into_inner()
+            .unwrap();
         fs.async_drop().await.map_err(|err| err)?;
         Ok(())
     }

--- a/crates/rustfs/src/object_based_api/low_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/low_level_adapter.rs
@@ -353,7 +353,7 @@ where
             }
         }
 
-        let mut inode = match self.get_inode(ino).await {
+        let inode = match self.get_inode(ino).await {
             Ok(inode) => inode,
             Err(err) => return callback.call(Err(err)),
         };
@@ -531,7 +531,7 @@ where
         } else {
             let (oldparent, newparent) =
                 join!(self.get_inode(oldparent_ino), self.get_inode(newparent_ino));
-            let (mut oldparent, mut newparent) =
+            let (oldparent, newparent) =
                 flatten_async_drop::<FsError, _, _, _, _>(oldparent, newparent).await?;
             let result = async {
                 let oldparent_dir = oldparent.as_dir().await?;
@@ -1142,7 +1142,6 @@ where
     }
 }
 
-#[async_trait]
 impl<Fs> AsyncDrop for ObjectBasedFsAdapterLL<Fs>
 where
     Fs: Device + AsyncDrop + Send + Sync + Debug + 'static,
@@ -1151,13 +1150,22 @@ where
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
         // TODO Can we add a check here that inodes are empty? To ensure we've handled them correctly?
         //      Or is it actually allowed fuse behavior to keep files open and/or inodes active on shutdown?
-        self.open_files.async_drop().await.unwrap();
-        self.open_dirs.async_drop().await.unwrap();
-        self.inodes.async_drop().await.unwrap();
-        self.fs.write().await.async_drop().await.unwrap();
+        let Self {
+            fs,
+            inodes,
+            open_files,
+            open_dirs,
+        } = self;
+        open_files.async_drop().await.unwrap();
+        open_dirs.async_drop().await.unwrap();
+        inodes.async_drop().await.unwrap();
+        let fs = Arc::into_inner(fs)
+            .expect("ObjectBasedFsAdapterLL::fs is never shared, so this must be the last reference to it")
+            .into_inner();
+        fs.async_drop().await.unwrap();
         Ok(())
     }
 }

--- a/crates/rustfs/src/object_based_api/utils/dir_cache.rs
+++ b/crates/rustfs/src/object_based_api/utils/dir_cache.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard, SyncDrop};
 use derive_more::{From, Into};
 use std::fmt::Debug;
@@ -65,15 +64,12 @@ impl Debug for DirCache {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for DirCache {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> FsResult<()> {
-        let mut entries = std::mem::replace(
-            &mut *self.entries.lock().unwrap(),
-            AsyncDropGuard::new_invalid(),
-        );
+    async fn async_drop_impl(self) -> FsResult<()> {
+        let Self { entries } = self;
+        let entries = entries.into_inner().unwrap();
         entries.async_drop().await?;
         Ok(())
     }
@@ -118,11 +114,10 @@ impl DirCacheEntry {
     }
 }
 
-#[async_trait]
 impl AsyncDrop for DirCacheEntry {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> FsResult<()> {
+    async fn async_drop_impl(self) -> FsResult<()> {
         // Nothing to do
         Ok(())
     }

--- a/crates/rustfs/src/object_based_api/utils/inode_list/handle_forest/handle_forest.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/handle_forest/handle_forest.rs
@@ -2,7 +2,6 @@ use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use async_trait::async_trait;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard, AsyncDropHashMap};
 use cryfs_utils::containers::OccupiedError;
 use derive_more::{Display, Error};
@@ -126,7 +125,7 @@ where
         &mut self,
         parent_handle: Handle,
         edge: EdgeKey,
-        mut value_fn_input: AsyncDropGuard<I>,
+        value_fn_input: AsyncDropGuard<I>,
         value_fn: impl AsyncFnOnce(
             AsyncDropGuard<I>,
             &HandleWithGeneration<Handle>,
@@ -161,10 +160,7 @@ where
             Node::new(parent_handle, edge, value),
         ) {
             Ok(node) => Ok((new_handle, node)),
-            Err(OccupiedError {
-                entry: _,
-                mut value,
-            }) => {
+            Err(OccupiedError { entry: _, value }) => {
                 value.async_drop().await.unwrap();
                 panic!("Invariant A violated");
             }
@@ -381,7 +377,6 @@ where
     value: AsyncDropGuard<NodeValue>,
 }
 
-#[async_trait]
 impl<Handle, EdgeKey, NodeValue> AsyncDrop for HandleForest<Handle, EdgeKey, NodeValue>
 where
     Handle: HandleTrait + Send,
@@ -391,7 +386,8 @@ where
 {
     type Error = <NodeValue as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.nodes.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { nodes, .. } = self;
+        nodes.async_drop().await
     }
 }

--- a/crates/rustfs/src/object_based_api/utils/inode_list/handle_forest/handle_forest.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/handle_forest/handle_forest.rs
@@ -387,7 +387,7 @@ where
     type Error = <NodeValue as AsyncDrop>::Error;
 
     async fn async_drop_impl(self) -> Result<(), Self::Error> {
-        let Self { nodes, .. } = self;
+        let Self { nodes, handles: _ } = self;
         nodes.async_drop().await
     }
 }

--- a/crates/rustfs/src/object_based_api/utils/inode_list/handle_forest/node.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/handle_forest/node.rs
@@ -145,7 +145,11 @@ where
     type Error = <NodeValue as AsyncDrop>::Error;
 
     async fn async_drop_impl(self) -> Result<(), Self::Error> {
-        let Self { value, .. } = self;
+        let Self {
+            value,
+            parent: _,
+            children: _,
+        } = self;
         value.async_drop().await
     }
 }

--- a/crates/rustfs/src/object_based_api/utils/inode_list/handle_forest/node.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/handle_forest/node.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use std::borrow::Borrow;
 use std::hash::Hash;
 use std::{collections::HashMap, fmt::Debug};
@@ -136,7 +135,6 @@ where
     }
 }
 
-#[async_trait]
 impl<Handle, EdgeKey, NodeValue> AsyncDrop for Node<Handle, EdgeKey, NodeValue>
 where
     Handle: HandleTrait + Send,
@@ -146,8 +144,9 @@ where
 {
     type Error = <NodeValue as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        self.value.async_drop().await
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { value, .. } = self;
+        value.async_drop().await
     }
 }
 

--- a/crates/rustfs/src/object_based_api/utils/inode_list/inode_tree_node.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/inode_tree_node.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use cryfs_concurrent_store::LoadedEntryGuard;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard, AsyncDropResult, AsyncDropShared};
 use futures::future::BoxFuture;
@@ -97,15 +96,15 @@ pub enum RefcountInfo {
     RefcountZero,
 }
 
-#[async_trait]
 impl<Fs> AsyncDrop for InodeTreeNode<Fs>
 where
     Fs: Device + Debug + 'static,
     Fs::Node: 'static,
 {
     type Error = FsError;
-    async fn async_drop_impl(&mut self) -> FsResult<()> {
-        self.inode.async_drop().await?;
+    async fn async_drop_impl(self) -> FsResult<()> {
+        let Self { inode, .. } = self;
+        inode.async_drop().await?;
 
         Ok(())
     }

--- a/crates/rustfs/src/object_based_api/utils/inode_list/inode_tree_node.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/inode_tree_node.rs
@@ -103,7 +103,10 @@ where
 {
     type Error = FsError;
     async fn async_drop_impl(self) -> FsResult<()> {
-        let Self { inode, .. } = self;
+        let Self {
+            inode,
+            kernel_refcount: _,
+        } = self;
         inode.async_drop().await?;
 
         Ok(())

--- a/crates/rustfs/src/object_based_api/utils/inode_list/mod.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/mod.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use core::panic;
 #[cfg(feature = "testutils")]
 use cryfs_concurrent_store::RequestImmediateDropResult;
@@ -384,7 +383,7 @@ where
         F: Future<Output = FsResult<AsyncDropGuard<Fs::Node>>> + Send,
     {
         let parent_node = {
-            let mut parent_node = Self::_lookup_node(&inner, parent_ino)?;
+            let parent_node = Self::_lookup_node(&inner, parent_ino)?;
             let parent_node_value = AsyncDropArc::clone(parent_node.value());
             parent_node.async_drop().await?;
             parent_node_value
@@ -478,7 +477,7 @@ where
                     inner.inodes.is_fully_absent(&new_child_ino.handle),
                     "We just checked that loading failed, so invariant C1 must be violated here"
                 );
-                let (mut removed_node, remove_result, delayed_handle_release) = inner
+                let (removed_node, remove_result, delayed_handle_release) = inner
                     .inode_forest
                     .try_remove(new_child_ino.handle)
                     .expect("This should never happen because we just added the child above");
@@ -592,7 +591,7 @@ where
                 // Now inodes lock is released and we can drop all removed inodes
                 std::mem::drop(inner);
                 let drop_result =
-                    for_each_unordered(removed_inodes.into_iter(), |mut inode| async move {
+                    for_each_unordered(removed_inodes.into_iter(), |inode| async move {
                         inode.async_drop().await?;
                         // We dropped the guard and concurrent_store::LoadedEntryGuard ensures that the entry is removed from self.inodes now.
                         // Even if it's async_drop fails, it still removes the entry.
@@ -833,7 +832,7 @@ where
 
         for_each_unordered(
             inner.inode_forest.drain(),
-            |(_ino, mut inode_info)| async move { inode_info.async_drop().await },
+            |(_ino, inode_info)| async move { inode_info.async_drop().await },
         )
         .await?;
         // Dropping references also drops the corresponding entries in self.inodes
@@ -878,25 +877,28 @@ where
     }
 }
 
-#[async_trait]
 impl<Fs> AsyncDrop for InodeList<Fs>
 where
     Fs: Device + Debug + 'static,
 {
     type Error = FsError;
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
         // The kernel doesn't guarantee that it'll forget all inodes on shutdown, so we can't assert that all inodes are forgotten here.
         // Instead, we just drop all remaining inodes.
-        let inner = self.inner.get_mut();
+        let Self { inner } = self;
+        let InodeListInner {
+            inodes,
+            inode_forest,
+        } = inner.into_inner();
 
         // We don't assert that all inodes were forgotten because the fuse kernl doesn't guarantee that on shutdown.
         // TODO But maybe we still want to assert it when an InodeInfo is dropped in a non-shutdown scenario. Maybe we should add the assertion here and add a [InodeInfo::drop_on_shutdown(self)] that deals with the shutdown case?
-        // assert_eq!(1, inner.inode_forest.num_nodes());
-        // assert!(inner.inode_forest.get(&FUSE_ROOT_ID).is_some());
+        // assert_eq!(1, inode_forest.num_nodes());
+        // assert!(inode_forest.get(&FUSE_ROOT_ID).is_some());
 
-        let result = inner.inode_forest.async_drop().await;
+        let result = inode_forest.async_drop().await;
         // And after all of its references are dropped, we can drop the inode list itself
-        inner.inodes.async_drop().await.infallible_unwrap();
+        inodes.async_drop().await.infallible_unwrap();
 
         result
     }

--- a/crates/rustfs/src/object_based_api/utils/maybe_initialized_fs.rs
+++ b/crates/rustfs/src/object_based_api/utils/maybe_initialized_fs.rs
@@ -2,7 +2,6 @@ use std::fmt::Debug;
 
 use super::super::interface::Device;
 use crate::common::{Gid, Uid};
-use async_trait::async_trait;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard};
 
 #[derive(Debug)]
@@ -74,18 +73,18 @@ where
     }
 }
 
-#[async_trait]
 impl<Fs> AsyncDrop for MaybeInitializedFs<Fs>
 where
     Fs: Device + AsyncDrop + Debug + Send,
 {
     type Error = <Fs as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        match &mut self.inner {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { inner } = self;
+        match inner {
             MaybeInitializedFsImpl::Uninitialized(fs) => {
                 // The function we have captured a filesystem that we need to async drop
-                if let Some(fs) = fs.take() {
+                if let Some(fs) = fs {
                     // We need to call the function with dummy values because we don't have a uid and gid
                     fs(Uid::from(0), Gid::from(0)).async_drop().await?;
                 }

--- a/crates/rustfs/src/object_based_api/utils/open_file_list.rs
+++ b/crates/rustfs/src/object_based_api/utils/open_file_list.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard};
 use std::sync::Mutex;
 
@@ -31,7 +30,7 @@ where
         fh: FileHandle,
         callback: impl AsyncFnOnce(&OF) -> Result<R, FsError>,
     ) -> Result<R, FsError> {
-        let mut open_file = {
+        let open_file = {
             let open_files = self.open_files.lock().unwrap();
             let open_file = open_files.get(fh).ok_or_else(|| {
                 log::error!("no open file with handle {fh}");
@@ -78,19 +77,15 @@ where
     async fn call(&self, file: &OF) -> Result<(), FsError>;
 }
 
-#[async_trait]
 impl<OF> AsyncDrop for OpenFileList<OF>
 where
     OF: OpenFile + AsyncDrop<Error = FsError> + Send + Sync,
 {
     type Error = FsError;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        let open_files = std::mem::replace(
-            &mut self.open_files,
-            Mutex::new(AsyncDropGuard::new_invalid()),
-        );
-        let mut open_files = open_files.into_inner().unwrap();
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { open_files } = self;
+        let open_files = open_files.into_inner().unwrap();
         open_files.async_drop().await.unwrap();
         Ok(())
     }

--- a/crates/rustfs/src/tests/utils/mock_low_level_api.rs
+++ b/crates/rustfs/src/tests/utils/mock_low_level_api.rs
@@ -37,7 +37,9 @@ pub fn make_mock_filesystem() -> MockFilesystem {
         Ok(())
     });
     mock.expect_destroy().once().returning(|| ());
-    mock.expect_async_drop_impl().once().returning(|| Ok(()));
+    mock.expect_async_drop_impl()
+        .once()
+        .returning(|| Box::pin(async { Ok(()) }));
 
     MockFilesystem {
         fs: mock,
@@ -407,10 +409,9 @@ mock! {
         async fn getxtimes(&self, req: &RequestInfo, ino: InodeNumber) -> FsResult<ReplyXTimes>;
     }
 
-    #[async_trait]
     impl AsyncDrop for AsyncFilesystemLL {
         type Error = FsError;
-        async fn async_drop_impl(&mut self) -> Result<(), FsError>;
+        fn async_drop_impl(self) -> impl std::future::Future<Output = Result<(), FsError>> + Send;
     }
 }
 

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -11,7 +11,6 @@ version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 binrw.workspace = true
 cryfs-version = { path = "../cryfs-version" }
 derive_more.workspace = true

--- a/crates/utils/src/async_drop/async_drop.rs
+++ b/crates/utils/src/async_drop/async_drop.rs
@@ -1,9 +1,55 @@
-use async_trait::async_trait;
 use std::fmt::Debug;
+use std::future::Future;
 
 /// Implement this trait to define an async drop behavior for your
 /// type. See [AsyncDropGuard](super::AsyncDropGuard) for more details.
-#[async_trait]
+///
+/// [AsyncDrop::async_drop_impl] takes `self` by value. Destructure `self` to move
+/// [AsyncDropGuard](super::AsyncDropGuard) members out and call
+/// [AsyncDropGuard::async_drop](super::AsyncDropGuard::async_drop) on them:
+///
+/// ```
+/// use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard};
+///
+/// #[derive(Debug)]
+/// struct Connection;
+///
+/// impl AsyncDrop for Connection {
+///     type Error = std::convert::Infallible;
+///
+///     async fn async_drop_impl(self) -> Result<(), Self::Error> {
+///         // close the connection asynchronously
+///         Ok(())
+///     }
+/// }
+///
+/// #[derive(Debug)]
+/// struct Client {
+///     connection: AsyncDropGuard<Connection>,
+///     name: String,
+/// }
+///
+/// impl AsyncDrop for Client {
+///     type Error = std::convert::Infallible;
+///
+///     async fn async_drop_impl(self) -> Result<(), Self::Error> {
+///         let Self { connection, name: _ } = self;
+///         connection.async_drop().await
+///     }
+/// }
+///
+/// # futures::executor::block_on(async {
+/// let client = AsyncDropGuard::new(Client {
+///     connection: AsyncDropGuard::new(Connection),
+///     name: "client".to_string(),
+/// });
+/// client.async_drop().await.unwrap();
+/// # });
+/// ```
+///
+/// A type that also implements [Drop] cannot be destructured. Store its
+/// [AsyncDropGuard](super::AsyncDropGuard) members in an [Option] and use
+/// [Option::take] in [AsyncDrop::async_drop_impl] instead.
 pub trait AsyncDrop {
     type Error: Debug;
 
@@ -12,13 +58,17 @@ pub trait AsyncDrop {
     /// [AsyncDropGuard::async_drop](super::AsyncDropGuard::async_drop)
     /// is executed while wrapping a value of the type implementing [AsyncDrop].
     ///
-    /// If the implementing type also implements [Drop], then [Drop::drop]
-    /// will be executed synchronously and after
-    /// [AsyncDrop::async_drop_impl](super::AsyncDrop::async_drop_impl).
+    /// The returned future must be [Send]. Implementations can use `async fn` syntax,
+    /// the compiler then checks that the resulting future is [Send].
     ///
-    /// [AsyncDrop::async_drop_impl](super::AsyncDrop::async_drop_impl) can return
+    /// If the implementing type also implements [Drop], then [Drop::drop]
+    /// will be executed synchronously when `self` goes out of scope inside
+    /// this method, i.e. for an `async fn` at the end of its body and after
+    /// everything it awaited.
+    ///
+    /// [AsyncDrop::async_drop_impl] can return
     /// an error and that error will be propagated to the caller of
     /// [AsyncDropGuard::async_drop](super::AsyncDropGuard::async_drop).
     /// If such an error happens, [Drop::drop] still gets executed.
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error>;
+    fn async_drop_impl(self) -> impl Future<Output = Result<(), Self::Error>> + Send;
 }

--- a/crates/utils/src/async_drop/async_drop_arc.rs
+++ b/crates/utils/src/async_drop/async_drop_arc.rs
@@ -4,10 +4,9 @@
 //! [`Arc`] for shared ownership. The async drop is only called when the last reference
 //! is dropped.
 
-use async_trait::async_trait;
-use futures::future::BoxFuture;
 use std::borrow::Borrow;
 use std::fmt::Debug;
+use std::future::Future;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -24,8 +23,7 @@ use super::{AsyncDrop, AsyncDropGuard};
 /// [`AsyncDropGuard`].
 #[derive(Debug)]
 pub struct AsyncDropArc<T: AsyncDrop + Debug + Send> {
-    // Always Some except during destruction
-    v: Option<Arc<AsyncDropGuard<T>>>,
+    v: Arc<AsyncDropGuard<T>>,
 }
 
 impl<T: AsyncDrop + Debug + Send> AsyncDropArc<T> {
@@ -33,9 +31,7 @@ impl<T: AsyncDrop + Debug + Send> AsyncDropArc<T> {
     ///
     /// The returned guard must have `async_drop()` called on it before being dropped.
     pub fn new(v: AsyncDropGuard<T>) -> AsyncDropGuard<Self> {
-        AsyncDropGuard::new(Self {
-            v: Some(Arc::new(v)),
-        })
+        AsyncDropGuard::new(Self { v: Arc::new(v) })
     }
 
     /// Creates a new reference to the same underlying value.
@@ -44,13 +40,13 @@ impl<T: AsyncDrop + Debug + Send> AsyncDropArc<T> {
     /// must have `async_drop()` called on it.
     pub fn clone(this: &AsyncDropGuard<Self>) -> AsyncDropGuard<Self> {
         AsyncDropGuard::new(Self {
-            v: this.v.as_ref().map(Arc::clone),
+            v: Arc::clone(&this.v),
         })
     }
 
     /// Returns the number of strong references to the underlying value.
     pub fn strong_count(this: &AsyncDropGuard<Self>) -> usize {
-        Arc::strong_count(this.v.as_ref().expect("Already dropped"))
+        Arc::strong_count(&this.v)
     }
 
     /// Attempts to extract the inner `AsyncDropGuard<T>` if this is the only reference.
@@ -58,42 +54,33 @@ impl<T: AsyncDrop + Debug + Send> AsyncDropArc<T> {
     /// Returns `Some` if this is the last reference, `None` otherwise.
     /// This consumes the `AsyncDropArc` without calling its async drop.
     pub fn into_inner(this: AsyncDropGuard<Self>) -> Option<AsyncDropGuard<T>> {
-        let v = this
-            .unsafe_into_inner_dont_drop()
-            .v
-            .expect("Already dropped");
-        Arc::into_inner(v)
+        Arc::into_inner(this.unsafe_into_inner_dont_drop().v)
     }
 
     /// Returns a raw pointer to the underlying `AsyncDropGuard<T>`.
     pub fn as_ptr(&self) -> *const AsyncDropGuard<T> {
-        Arc::as_ptr(self.v.as_ref().expect("Already dropped"))
+        Arc::as_ptr(&self.v)
     }
 
     /// Returns `true` if both `AsyncDropArc`s point to the same allocation.
     pub fn ptr_eq(a: &AsyncDropGuard<Self>, b: &AsyncDropGuard<Self>) -> bool {
-        let lhs = a.v.as_ref().expect("Already dropped");
-        let rhs = b.v.as_ref().expect("Already dropped");
-        Arc::ptr_eq(lhs, rhs)
+        Arc::ptr_eq(&a.v, &b.v)
     }
 }
 
-#[async_trait]
 impl<T: AsyncDrop + Debug + Send> AsyncDrop for AsyncDropArc<T> {
     type Error = T::Error;
 
-    fn async_drop_impl<'s, 'async_trait>(
-        &'s mut self,
-    ) -> BoxFuture<'async_trait, Result<(), Self::Error>>
-    where
-        's: 'async_trait,
-        Self: 'async_trait,
-    {
-        let v = self.v.take().expect("Already destructed");
-        if let Some(mut v) = Arc::into_inner(v) {
-            Box::pin(async move { v.async_drop().await })
-        } else {
-            Box::pin(async { Ok(()) })
+    fn async_drop_impl(self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        // Unwrap the Arc before creating the future so that the future only holds an
+        // `AsyncDropGuard<T>` (which is `Send` if `T: Send`) and not the `Arc` (which would
+        // additionally require `T: Sync`).
+        let last_reference = Arc::into_inner(self.v);
+        async move {
+            match last_reference {
+                Some(v) => v.async_drop().await,
+                None => Ok(()),
+            }
         }
     }
 }
@@ -101,23 +88,19 @@ impl<T: AsyncDrop + Debug + Send> AsyncDrop for AsyncDropArc<T> {
 impl<T: AsyncDrop + Debug + Send> Deref for AsyncDropArc<T> {
     type Target = T;
     fn deref(&self) -> &T {
-        self.v.as_ref().expect("Already destructed").deref()
+        self.v.deref().deref()
     }
 }
 
 impl<T: AsyncDrop + Debug + Send> Borrow<T> for AsyncDropArc<T> {
     fn borrow(&self) -> &T {
-        Borrow::<AsyncDropGuard<T>>::borrow(Borrow::<Arc<AsyncDropGuard<T>>>::borrow(
-            self.v.as_ref().expect("Already destructed"),
-        ))
-        .borrow()
+        Borrow::<AsyncDropGuard<T>>::borrow(&self.v).borrow()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Debug)]
@@ -135,11 +118,10 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncDrop for TestValue {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
             self.drop_counter.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -149,7 +131,7 @@ mod tests {
     async fn test_new_creates_guard() {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
-        let mut arc = AsyncDropArc::new(inner);
+        let arc = AsyncDropArc::new(inner);
 
         assert_eq!(42, arc.value);
         arc.async_drop().await.unwrap();
@@ -172,8 +154,6 @@ mod tests {
 
         // Clean up - drop both arcs via async_drop
         // The actual value is only dropped when the last reference is dropped
-        let mut arc1 = arc1;
-        let mut arc2 = arc2;
         arc1.async_drop().await.unwrap();
         arc2.async_drop().await.unwrap();
         assert_eq!(1, counter.load(Ordering::SeqCst));
@@ -192,13 +172,11 @@ mod tests {
         assert_eq!(2, AsyncDropArc::strong_count(&arc2));
 
         // Drop one clone
-        let mut arc2 = arc2;
         arc2.async_drop().await.unwrap();
 
         assert_eq!(1, AsyncDropArc::strong_count(&arc1));
 
         // Drop the last one
-        let mut arc1 = arc1;
         arc1.async_drop().await.unwrap();
 
         // async_drop should have been called exactly once (on the last reference)
@@ -211,7 +189,7 @@ mod tests {
         let inner = TestValue::new(42, Arc::clone(&counter));
         let arc = AsyncDropArc::new(inner);
 
-        let mut inner = AsyncDropArc::into_inner(arc).expect("Should return inner when single ref");
+        let inner = AsyncDropArc::into_inner(arc).expect("Should return inner when single ref");
         assert_eq!(42, inner.value);
 
         inner.async_drop().await.unwrap();
@@ -223,7 +201,7 @@ mod tests {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
         let arc1 = AsyncDropArc::new(inner);
-        let mut arc2 = AsyncDropArc::clone(&arc1);
+        let arc2 = AsyncDropArc::clone(&arc1);
 
         // Should return None when there are multiple references
         let result = AsyncDropArc::into_inner(arc1);
@@ -239,10 +217,8 @@ mod tests {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
         let arc1 = AsyncDropArc::new(inner);
-        let mut arc2 = AsyncDropArc::clone(&arc1);
-        let mut arc3 = AsyncDropArc::clone(&arc1);
-        let mut arc1 = arc1;
-
+        let arc2 = AsyncDropArc::clone(&arc1);
+        let arc3 = AsyncDropArc::clone(&arc1);
         // Drop first two - should not call async_drop_impl
         arc1.async_drop().await.unwrap();
         assert_eq!(0, counter.load(Ordering::SeqCst));
@@ -259,7 +235,7 @@ mod tests {
     async fn test_deref() {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
-        let mut arc = AsyncDropArc::new(inner);
+        let arc = AsyncDropArc::new(inner);
 
         // Test Deref
         assert_eq!(42, arc.value);

--- a/crates/utils/src/async_drop/async_drop_guard.rs
+++ b/crates/utils/src/async_drop/async_drop_guard.rs
@@ -1,4 +1,5 @@
 use std::fmt::Debug;
+use std::future::Future;
 use std::ops::{Deref, DerefMut};
 
 use super::AsyncDrop;
@@ -11,6 +12,9 @@ use crate::safe_panic;
 /// [AsyncDropGuard::async_drop]. If the [AsyncDropGuard] leaves scope without a call to
 /// [AsyncDropGuard::async_drop], a safety check will trigger and cause a panic.
 ///
+/// [AsyncDropGuard::async_drop] consumes the guard, so using a value after it was dropped
+/// is a compile error rather than a runtime failure.
+///
 /// Types wrapped in [AsyncDropGuard] must implement [AsyncDrop] to define what exactly
 /// should happen when [AsyncDropGuard::async_drop] gets called.
 ///
@@ -21,17 +25,17 @@ use crate::safe_panic;
 /// call sites might forget to correctly drop `T`.
 #[derive(Debug)]
 #[must_use = "You have to call async_drop() on this value to drop it"]
-pub struct AsyncDropGuard<T: Debug>(Option<T>);
+pub struct AsyncDropGuard<T: Debug>(
+    // Invariant: This is `Some` for the whole lifetime of the guard. The only code that sets it
+    // to `None` consumes the guard, so `None` is only ever observed by the [Drop] impl.
+    Option<T>,
+);
 
 impl<T: Debug> AsyncDropGuard<T> {
     /// Wrap a value into an [AsyncDropGuard]. This enables the safety checks and will enforce
     /// that [AsyncDropGuard::async_drop] gets called before the [AsyncDropGuard] instance leaves scope.
     pub fn new(v: T) -> Self {
         Self(Some(v))
-    }
-
-    pub fn new_invalid() -> Self {
-        Self(None)
     }
 
     pub fn into_box(self) -> AsyncDropGuard<Box<T>> {
@@ -41,36 +45,54 @@ impl<T: Debug> AsyncDropGuard<T> {
     // Warning: The resulting AsyncDropGuard will call async_drop on U instead of T.
     // There will be no call to async_drop for T anymore.
     // Callers of this function need to make sure that this is correct behavior for T, U.
-    pub fn map_unsafe<U: Debug>(mut self, fun: impl FnOnce(T) -> U) -> AsyncDropGuard<U> {
-        AsyncDropGuard(self.0.take().map(fun))
+    pub fn map_unsafe<U: Debug>(self, fun: impl FnOnce(T) -> U) -> AsyncDropGuard<U> {
+        AsyncDropGuard(Some(fun(self.into_inner_unchecked())))
     }
 
     /// Extract the inner value **without** dropping it. This bypasses the protection of the guard.
-    pub fn unsafe_into_inner_dont_drop(mut self) -> T {
-        self.0.take().expect("Value already dropped")
+    pub fn unsafe_into_inner_dont_drop(self) -> T {
+        self.into_inner_unchecked()
     }
 
-    // TODO Test
-    pub fn is_dropped(&self) -> bool {
-        self.0.is_none()
+    /// Take the value out of the guard. This consumes the guard, so the safety check in [Drop]
+    /// sees `None` and passes.
+    fn into_inner_unchecked(mut self) -> T {
+        self.0
+            .take()
+            .expect("Invariant violated: AsyncDropGuard must hold a value for its whole lifetime")
     }
 }
 
 impl<T: Debug + AsyncDrop> AsyncDropGuard<T> {
     /// Asynchronously drop the value. This will call [AsyncDrop::async_drop_impl]
     /// on the contained value.
-    /// Calling code must ensure that the `self` value is dropped after this is called.
+    ///
+    /// This consumes the guard, so the value cannot be used anymore afterwards:
+    ///
+    /// ```compile_fail
+    /// use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard};
+    ///
+    /// #[derive(Debug)]
+    /// struct Value;
+    ///
+    /// impl AsyncDrop for Value {
+    ///     type Error = std::convert::Infallible;
+    ///     async fn async_drop_impl(self) -> Result<(), Self::Error> {
+    ///         Ok(())
+    ///     }
+    /// }
+    ///
+    /// # futures::executor::block_on(async {
+    /// let guard = AsyncDropGuard::new(Value);
+    /// guard.async_drop().await.unwrap();
+    /// let _use_after_drop: &Value = &guard; // error[E0382]: borrow of moved value: `guard`
+    /// # });
+    /// ```
     ///
     /// If this function does not get executed and the [AsyncDropGuard] instance leaves scope,
     /// that will cause a panic.
-    pub async fn async_drop(&mut self) -> Result<(), T::Error> {
-        self.0
-            .take()
-            // This expect cannot fail since the only place where we set it to None
-            // is AsyncDropGuard::async_drop which consumes the whole AsyncDropGuard struct
-            .expect("Value already dropped")
-            .async_drop_impl()
-            .await
+    pub fn async_drop(self) -> impl Future<Output = Result<(), T::Error>> + Send {
+        self.into_inner_unchecked().async_drop_impl()
     }
 }
 
@@ -93,9 +115,7 @@ impl<T: Debug> Deref for AsyncDropGuard<T> {
     fn deref(&self) -> &T {
         self.0
             .as_ref()
-            // This expect cannot fail since the only place where we set it to None
-            // is AsyncDropGuard::async_drop which consumes the whole AsyncDropGuard struct
-            .expect("Value already dropped")
+            .expect("Invariant violated: AsyncDropGuard must hold a value for its whole lifetime")
     }
 }
 
@@ -103,9 +123,7 @@ impl<T: Debug> DerefMut for AsyncDropGuard<T> {
     fn deref_mut(&mut self) -> &mut T {
         self.0
             .as_mut()
-            // This expect cannot fail since the only place where we set it to None
-            // is AsyncDropGuard::async_drop which consumes the whole AsyncDropGuard struct
-            .expect("Value already dropped")
+            .expect("Invariant violated: AsyncDropGuard must hold a value for its whole lifetime")
     }
 }
 
@@ -113,7 +131,6 @@ impl<T: Debug> DerefMut for AsyncDropGuard<T> {
 mod tests {
     use super::{AsyncDrop, AsyncDropGuard};
 
-    use async_trait::async_trait;
     use std::fmt::{self, Debug};
     use std::future::Future;
     use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
@@ -139,7 +156,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl<F, FA, FS> AsyncDrop for MyStructWithDrop<F, FA, FS>
     where
         F: Future<Output = Result<(), &'static str>> + Send,
@@ -148,7 +164,7 @@ mod tests {
     {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), &'static str> {
+        async fn async_drop_impl(self) -> Result<(), &'static str> {
             let r = (self.on_async_drop)();
             r.await
         }
@@ -183,7 +199,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl<F, FA> AsyncDrop for MyStructWithoutDrop<F, FA>
     where
         F: Future<Output = Result<(), &'static str>> + Send,
@@ -191,7 +206,7 @@ mod tests {
     {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), &'static str> {
+        async fn async_drop_impl(self) -> Result<(), &'static str> {
             let r = (self.on_async_drop)();
             r.await
         }
@@ -217,7 +232,7 @@ mod tests {
     #[tokio::test]
     async fn given_type_without_drop_when_calling_async_drop_then_calls_async_drop_impl() {
         let called = AtomicI32::new(0);
-        let mut obj = AsyncDropGuard::new(MyStructWithoutDrop {
+        let obj = AsyncDropGuard::new(MyStructWithoutDrop {
             on_async_drop: async || {
                 let prev_value = called.swap(1, Ordering::SeqCst);
                 assert_eq!(0, prev_value);
@@ -232,7 +247,7 @@ mod tests {
     async fn given_type_with_drop_when_calling_async_drop_then_calls_async_drop_impl_and_then_calls_drop()
      {
         let called = AtomicI32::new(0);
-        let mut obj = AsyncDropGuard::new(MyStructWithDrop {
+        let obj = AsyncDropGuard::new(MyStructWithDrop {
             on_async_drop: async || {
                 let prev_value = called.swap(1, Ordering::SeqCst);
                 assert_eq!(0, prev_value);
@@ -249,7 +264,7 @@ mod tests {
 
     #[tokio::test]
     async fn given_type_without_drop_when_async_drop_fails_then_returns_error() {
-        let mut obj = AsyncDropGuard::new(MyStructWithoutDrop {
+        let obj = AsyncDropGuard::new(MyStructWithoutDrop {
             on_async_drop: async || Err("My error"),
         });
         assert_eq!(Err("My error"), obj.async_drop().await);
@@ -258,7 +273,7 @@ mod tests {
     #[tokio::test]
     async fn given_type_with_drop_when_async_drop_fails_then_returns_error_and_still_calls_drop() {
         let called = AtomicBool::new(false);
-        let mut obj = AsyncDropGuard::new(MyStructWithDrop {
+        let obj = AsyncDropGuard::new(MyStructWithDrop {
             on_async_drop: async || Err("My error"),
             on_sync_drop: || {
                 called.store(true, Ordering::SeqCst);

--- a/crates/utils/src/async_drop/async_drop_tokio_mutex.rs
+++ b/crates/utils/src/async_drop/async_drop_tokio_mutex.rs
@@ -3,7 +3,6 @@
 //! This module provides [`AsyncDropTokioMutex`], which wraps an [`AsyncDropGuard<T>`]
 //! in a [`tokio::sync::Mutex`] for interior mutability in async contexts.
 
-use async_trait::async_trait;
 use std::fmt::Debug;
 use tokio::sync::{Mutex, MutexGuard};
 
@@ -18,8 +17,7 @@ use crate::async_drop::{AsyncDrop, AsyncDropGuard};
 #[derive(Debug)]
 // TODO Why do we need Send? tokio::sync::Mutex doesn't seem to need it
 pub struct AsyncDropTokioMutex<T: AsyncDrop + Debug + Send> {
-    // Always Some except during destruction
-    v: Option<Mutex<AsyncDropGuard<T>>>,
+    v: Mutex<AsyncDropGuard<T>>,
 }
 
 impl<T: AsyncDrop + Debug + Send> AsyncDropTokioMutex<T> {
@@ -27,40 +25,29 @@ impl<T: AsyncDrop + Debug + Send> AsyncDropTokioMutex<T> {
     ///
     /// The returned guard must have `async_drop()` called on it before being dropped.
     pub fn new(v: AsyncDropGuard<T>) -> AsyncDropGuard<Self> {
-        AsyncDropGuard::new(Self {
-            v: Some(Mutex::new(v)),
-        })
+        AsyncDropGuard::new(Self { v: Mutex::new(v) })
     }
 
     /// Acquires the lock asynchronously.
     ///
     /// Returns a guard that provides mutable access to the inner `AsyncDropGuard<T>`.
     pub async fn lock(&self) -> MutexGuard<'_, AsyncDropGuard<T>> {
-        self.v.as_ref().expect("Already destructed").lock().await
+        self.v.lock().await
     }
 
     /// Extracts the inner `AsyncDropGuard<T>`, consuming the mutex.
     ///
     /// This bypasses the mutex's async drop and returns the inner value directly.
     pub fn into_inner(this: AsyncDropGuard<Self>) -> AsyncDropGuard<T> {
-        let inner = this
-            .unsafe_into_inner_dont_drop()
-            .v
-            .take()
-            .expect("Already destructed");
-        inner.into_inner()
+        this.unsafe_into_inner_dont_drop().v.into_inner()
     }
 }
 
-#[async_trait]
 impl<T: AsyncDrop + Debug + Send> AsyncDrop for AsyncDropTokioMutex<T> {
     type Error = T::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        let v = self.v.take().expect("Already destructed");
-        let mut v = v.into_inner();
-        v.async_drop().await?;
-        Ok(())
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        self.v.into_inner().async_drop().await
     }
 }
 
@@ -85,11 +72,10 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncDrop for TestValue {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
             self.drop_counter.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -99,7 +85,7 @@ mod tests {
     async fn test_new_and_lock() {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
-        let mut mutex = AsyncDropTokioMutex::new(inner);
+        let mutex = AsyncDropTokioMutex::new(inner);
 
         {
             let guard = mutex.lock().await;
@@ -114,7 +100,7 @@ mod tests {
     async fn test_lock_allows_mutation() {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
-        let mut mutex = AsyncDropTokioMutex::new(inner);
+        let mutex = AsyncDropTokioMutex::new(inner);
 
         {
             let mut guard = mutex.lock().await;
@@ -135,7 +121,7 @@ mod tests {
         let inner = TestValue::new(42, Arc::clone(&counter));
         let mutex = AsyncDropTokioMutex::new(inner);
 
-        let mut inner = AsyncDropTokioMutex::into_inner(mutex);
+        let inner = AsyncDropTokioMutex::into_inner(mutex);
         assert_eq!(42, inner.value);
 
         inner.async_drop().await.unwrap();
@@ -146,7 +132,7 @@ mod tests {
     async fn test_async_drop_calls_inner_async_drop() {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
-        let mut mutex = AsyncDropTokioMutex::new(inner);
+        let mutex = AsyncDropTokioMutex::new(inner);
 
         assert_eq!(0, counter.load(Ordering::SeqCst));
         mutex.async_drop().await.unwrap();

--- a/crates/utils/src/async_drop/flatten.rs
+++ b/crates/utils/src/async_drop/flatten.rs
@@ -26,12 +26,12 @@ where
 {
     match (first, second) {
         (Ok(first), Ok(second)) => Ok((first, second)),
-        (Ok(mut first), Err(second)) => {
+        (Ok(first), Err(second)) => {
             // TODO Report both errors if async_drop fails
             first.async_drop().await?;
             Err(second.into())
         }
-        (Err(first), Ok(mut second)) => {
+        (Err(first), Ok(second)) => {
             // TODO Report both errors if async_drop fails
             second.async_drop().await?;
             Err(first.into())
@@ -46,7 +46,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -62,11 +61,10 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncDrop for TestValue {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
             self.drop_counter.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -92,7 +90,7 @@ mod tests {
         let result: Result<_, TestError> = flatten_async_drop(first_result, second_result).await;
         assert!(result.is_ok());
 
-        let (mut first, mut second) = result.unwrap();
+        let (first, second) = result.unwrap();
         assert_eq!("first", first.id);
         assert_eq!("second", second.id);
 

--- a/crates/utils/src/async_drop/hash_map.rs
+++ b/crates/utils/src/async_drop/hash_map.rs
@@ -5,7 +5,6 @@
 //! async-dropped concurrently.
 
 use anyhow::Result;
-use async_trait::async_trait;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -94,7 +93,6 @@ where
     }
 }
 
-#[async_trait]
 impl<K, V> AsyncDrop for AsyncDropHashMap<K, V>
 where
     K: PartialEq + Eq + Hash + Debug + Send,
@@ -103,9 +101,8 @@ where
 {
     type Error = <V as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        let values = self.map.drain().map(|(_key, value)| value);
-        for_each_unordered(values, async move |mut value| {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        for_each_unordered(self.map.into_values(), async move |value| {
             value.async_drop().await?;
             Ok(())
         })
@@ -131,11 +128,10 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncDrop for TestValue {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
             self.drop_counter.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -143,7 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_new_creates_empty_map() {
-        let mut map: AsyncDropGuard<AsyncDropHashMap<i32, TestValue>> = AsyncDropHashMap::new();
+        let map: AsyncDropGuard<AsyncDropHashMap<i32, TestValue>> = AsyncDropHashMap::new();
         assert_eq!(0, map.len());
         map.async_drop().await.unwrap();
     }
@@ -177,7 +173,7 @@ mod tests {
         assert!(result.is_err());
 
         // The rejected value needs to be cleaned up manually
-        let mut rejected = result.unwrap_err().value;
+        let rejected = result.unwrap_err().value;
         rejected.async_drop().await.unwrap();
 
         map.async_drop().await.unwrap();
@@ -192,7 +188,7 @@ mod tests {
         let value = TestValue::new(42, Arc::clone(&counter));
         map.try_insert(1, value).unwrap();
 
-        let mut removed = map.remove(&1).unwrap();
+        let removed = map.remove(&1).unwrap();
         assert_eq!(42, removed.id);
         assert_eq!(0, map.len());
 

--- a/crates/utils/src/async_drop/result.rs
+++ b/crates/utils/src/async_drop/result.rs
@@ -3,7 +3,6 @@
 //! This module provides [`AsyncDropResult`], which wraps a `Result<AsyncDropGuard<T>, E>`.
 //! When dropped, it only calls async_drop on the `Ok` variant; the `Err` variant is a no-op.
 
-use async_trait::async_trait;
 use std::fmt::Debug;
 
 use crate::async_drop::{AsyncDrop, AsyncDropGuard};
@@ -62,7 +61,6 @@ where
     }
 }
 
-#[async_trait]
 impl<T, E> AsyncDrop for AsyncDropResult<T, E>
 where
     T: Debug + AsyncDrop + Send,
@@ -70,8 +68,8 @@ where
 {
     type Error = <T as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        match &mut self.v {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        match self.v {
             Ok(v) => v.async_drop().await,
             Err(_) => Ok(()),
         }
@@ -99,11 +97,10 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncDrop for TestValue {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
             self.drop_counter.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -113,7 +110,7 @@ mod tests {
     async fn test_ok_variant_accessors() {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
-        let mut result: AsyncDropGuard<AsyncDropResult<TestValue, &str>> =
+        let result: AsyncDropGuard<AsyncDropResult<TestValue, &str>> =
             AsyncDropResult::new(Ok(inner));
 
         assert!(result.ok().is_some());
@@ -126,7 +123,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_err_variant_accessors() {
-        let mut result: AsyncDropGuard<AsyncDropResult<TestValue, &str>> =
+        let result: AsyncDropGuard<AsyncDropResult<TestValue, &str>> =
             AsyncDropResult::new(Err("error"));
 
         assert!(result.ok().is_none());
@@ -147,7 +144,7 @@ mod tests {
         let inner_result = AsyncDropResult::into_inner(result);
         assert!(inner_result.is_ok());
 
-        let mut inner = inner_result.unwrap();
+        let inner = inner_result.unwrap();
         assert_eq!(42, inner.value);
         inner.async_drop().await.unwrap();
         assert_eq!(1, counter.load(Ordering::SeqCst));
@@ -167,7 +164,7 @@ mod tests {
     async fn test_async_drop_on_ok_calls_inner() {
         let counter = Arc::new(AtomicUsize::new(0));
         let inner = TestValue::new(42, Arc::clone(&counter));
-        let mut result: AsyncDropGuard<AsyncDropResult<TestValue, &str>> =
+        let result: AsyncDropGuard<AsyncDropResult<TestValue, &str>> =
             AsyncDropResult::new(Ok(inner));
 
         assert_eq!(0, counter.load(Ordering::SeqCst));
@@ -177,7 +174,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_async_drop_on_err_succeeds() {
-        let mut result: AsyncDropGuard<AsyncDropResult<TestValue, &str>> =
+        let result: AsyncDropGuard<AsyncDropResult<TestValue, &str>> =
             AsyncDropResult::new(Err("error"));
 
         // Should succeed without doing anything

--- a/crates/utils/src/async_drop/shared.rs
+++ b/crates/utils/src/async_drop/shared.rs
@@ -1,4 +1,3 @@
-use async_trait::async_trait;
 use futures::future::Future;
 use futures::task::{ArcWake, Context, Poll, Waker, waker_ref};
 use slab::Slab;
@@ -45,7 +44,6 @@ where
     notifier: Arc<Notifier>,
 }
 
-#[async_trait]
 impl<O, Fut> AsyncDrop for Inner<O, Fut>
 where
     O: Debug + AsyncDrop + Send + Sync,
@@ -53,19 +51,19 @@ where
 {
     type Error = <O as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        let inner = std::mem::replace(
-            &mut self.future_or_output,
-            UnsafeCell::new(FutureOrOutput::Output(AsyncDropGuard::new_invalid())),
-        );
-        match inner.into_inner() {
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self {
+            future_or_output,
+            notifier,
+        } = self;
+        drop(notifier);
+        match future_or_output.into_inner() {
             FutureOrOutput::Future(future) => {
                 // To ensure that any AsyncDropGuards that may temporarily exist in the future state,
                 // or maybe even are returned from the future, are dropped, we have to await the future here.
-                let mut output = future.await;
-                output.async_drop().await
+                future.await.async_drop().await
             }
-            FutureOrOutput::Output(mut output) => output.async_drop().await,
+            FutureOrOutput::Output(output) => output.async_drop().await,
         }
     }
 }
@@ -397,7 +395,6 @@ where
     }
 }
 
-#[async_trait]
 impl<O, Fut> AsyncDrop for AsyncDropShared<O, Fut>
 where
     O: Debug + AsyncDrop + Send + Sync,
@@ -405,16 +402,18 @@ where
 {
     type Error = <O as AsyncDrop>::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
-        if self.waker_key != NULL_WAKER_KEY
-            && let Some(ref inner) = self.inner
+    async fn async_drop_impl(self) -> Result<(), Self::Error> {
+        let Self { inner, waker_key } = self;
+
+        if waker_key != NULL_WAKER_KEY
+            && let Some(ref inner) = inner
             && let Ok(mut wakers) = inner.notifier.wakers.lock()
             && let Some(wakers) = wakers.as_mut()
         {
-            wakers.remove(self.waker_key);
+            wakers.remove(waker_key);
         }
 
-        if let Some(inner) = &mut self.inner {
+        if let Some(inner) = inner {
             inner.async_drop().await?;
         }
         Ok(())
@@ -437,7 +436,6 @@ impl ArcWake for Notifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use std::sync::Arc as StdArc;
     use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
@@ -447,11 +445,10 @@ mod tests {
         drop_called: StdArc<AtomicBool>,
     }
 
-    #[async_trait]
     impl AsyncDrop for TestValue {
         type Error = ();
 
-        async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
             assert!(
                 !self.drop_called.load(Ordering::SeqCst),
                 "Drop called twice",
@@ -472,7 +469,7 @@ mod tests {
         };
 
         let mut shared = AsyncDropShared::new(future);
-        let mut result = (&mut *shared).await;
+        let result = (&mut *shared).await;
 
         assert!(
             !drop_called.load(Ordering::SeqCst),
@@ -504,7 +501,7 @@ mod tests {
         };
 
         let mut shared = AsyncDropShared::new(future);
-        let mut result = (&mut *shared).await;
+        let result = (&mut *shared).await;
 
         assert!(
             !drop_called.load(Ordering::SeqCst),
@@ -544,7 +541,6 @@ mod tests {
         );
 
         // Clean up
-        let mut result = result;
         result.async_drop().await.unwrap();
         shared.async_drop().await.unwrap();
         assert!(
@@ -564,14 +560,13 @@ mod tests {
         };
 
         let mut shared1 = AsyncDropShared::new(future);
-        let mut shared2 = AsyncDropShared::clone(&shared1);
+        let shared2 = AsyncDropShared::clone(&shared1);
 
         // Poll the first one
         let result = (&mut *shared1).await;
         assert_eq!(result.value, 42);
 
         // Clean up
-        let mut result = result;
         result.async_drop().await.unwrap();
         shared1.async_drop().await.unwrap();
         shared2.async_drop().await.unwrap();
@@ -614,11 +609,11 @@ mod tests {
         assert_eq!(poll_count.load(Ordering::SeqCst), 1);
 
         // Clean up
-        let mut result = result1;
+        let result = result1;
         result.async_drop().await.unwrap();
-        let mut result = result2;
+        let result = result2;
         result.async_drop().await.unwrap();
-        let mut result = result3;
+        let result = result3;
         result.async_drop().await.unwrap();
         shared1.async_drop().await.unwrap();
         shared2.async_drop().await.unwrap();
@@ -639,7 +634,7 @@ mod tests {
         };
 
         let mut shared = AsyncDropShared::new(future);
-        let mut shared2 = AsyncDropShared::clone(&shared);
+        let shared2 = AsyncDropShared::clone(&shared);
 
         // Before polling, peek should return None
         assert!(shared.peek().is_none());
@@ -654,7 +649,6 @@ mod tests {
         assert_eq!(shared2.peek().unwrap().value, 99);
 
         // Clean up - drop result first since it holds the actual value
-        let mut result = result;
         result.async_drop().await.unwrap();
         shared.async_drop().await.unwrap();
         shared2.async_drop().await.unwrap();
@@ -672,11 +666,11 @@ mod tests {
         let mut shared1 = AsyncDropShared::new(future);
         assert_eq!(shared1.strong_count(), Some(1));
 
-        let mut shared2 = AsyncDropShared::clone(&shared1);
+        let shared2 = AsyncDropShared::clone(&shared1);
         assert_eq!(shared1.strong_count(), Some(2));
         assert_eq!(shared2.strong_count(), Some(2));
 
-        let mut shared3 = AsyncDropShared::clone(&shared1);
+        let shared3 = AsyncDropShared::clone(&shared1);
         assert_eq!(shared1.strong_count(), Some(3));
 
         shared2.async_drop().await.unwrap();
@@ -689,7 +683,6 @@ mod tests {
         assert_eq!(shared3.strong_count(), Some(2));
 
         // Clean up
-        let mut result = result;
         result.async_drop().await.unwrap();
         shared1.async_drop().await.unwrap();
         shared3.async_drop().await.unwrap();
@@ -704,9 +697,9 @@ mod tests {
             })
         };
 
-        let mut shared1a = AsyncDropShared::new(future1());
-        let mut shared1b = AsyncDropShared::clone(&shared1a);
-        let mut shared1c = AsyncDropShared::clone(&shared1a);
+        let shared1a = AsyncDropShared::new(future1());
+        let shared1b = AsyncDropShared::clone(&shared1a);
+        let shared1c = AsyncDropShared::clone(&shared1a);
 
         // Clones should point to the same future
         assert!(shared1a.ptr_eq(&*shared1b));
@@ -714,7 +707,7 @@ mod tests {
         assert!(shared1a.ptr_eq(&*shared1c));
 
         // Different futures should not be equal
-        let mut shared2 = AsyncDropShared::new(future1());
+        let shared2 = AsyncDropShared::new(future1());
         assert!(!shared1a.ptr_eq(&*shared2));
         shared2.async_drop().await.unwrap();
 
@@ -735,7 +728,7 @@ mod tests {
         };
 
         let mut shared1 = AsyncDropShared::new(future);
-        let mut shared2 = AsyncDropShared::clone(&shared1);
+        let shared2 = AsyncDropShared::clone(&shared1);
 
         // Poll to completion
         let result = (&mut *shared1).await;
@@ -755,7 +748,6 @@ mod tests {
         );
 
         // Finally drop the result
-        let mut result = result;
         result.async_drop().await.unwrap();
         assert!(
             drop_called.load(Ordering::SeqCst),
@@ -775,8 +767,8 @@ mod tests {
             })
         };
 
-        let mut shared = AsyncDropShared::new(future);
-        let mut clone = AsyncDropShared::clone(&shared);
+        let shared = AsyncDropShared::new(future);
+        let clone = AsyncDropShared::clone(&shared);
 
         // Drop without polling to completion
         shared.async_drop().await.unwrap();
@@ -805,9 +797,7 @@ mod tests {
         assert_eq!(result2.value, 42);
 
         // Clean up - drop results first
-        let mut result1 = result1;
         result1.async_drop().await.unwrap();
-        let mut result2 = result2;
         result2.async_drop().await.unwrap();
         shared1.async_drop().await.unwrap();
         shared2.async_drop().await.unwrap();
@@ -830,9 +820,7 @@ mod tests {
         assert_eq!(result2.value, 42);
 
         // Clean up - drop results first
-        let mut result1 = result1;
         result1.async_drop().await.unwrap();
-        let mut result2 = result2;
         result2.async_drop().await.unwrap();
         shared1.async_drop().await.unwrap();
     }
@@ -851,7 +839,7 @@ mod tests {
         assert!(debug_str.contains("Shared"));
 
         // Clean up
-        let mut result = (&mut *shared).await;
+        let result = (&mut *shared).await;
         result.async_drop().await.unwrap();
         shared.async_drop().await.unwrap();
     }
@@ -869,7 +857,7 @@ mod tests {
         };
 
         let mut shared1a = AsyncDropShared::new(future1);
-        let mut shared1b = AsyncDropShared::clone(&shared1a);
+        let shared1b = AsyncDropShared::clone(&shared1a);
 
         let mut hasher1a = DefaultHasher::new();
         shared1a.ptr_hash(&mut hasher1a);
@@ -884,7 +872,6 @@ mod tests {
 
         // Clean up
         let result1 = (&mut *shared1a).await;
-        let mut result1 = result1;
         result1.async_drop().await.unwrap();
         shared1a.async_drop().await.unwrap();
         shared1b.async_drop().await.unwrap();

--- a/crates/utils/src/async_drop/sync_drop.rs
+++ b/crates/utils/src/async_drop/sync_drop.rs
@@ -49,7 +49,7 @@ impl<T: Debug + AsyncDrop> SyncDrop<T> {
 
 impl<T: Debug + AsyncDrop> Drop for SyncDrop<T> {
     fn drop(&mut self) {
-        if let Some(mut v) = self.0.take() {
+        if let Some(v) = self.0.take() {
             // Use block_in_place if we're inside a tokio runtime to avoid deadlocks.
             // The async_drop code may use tokio::sync primitives that require other
             // tokio tasks to make progress (e.g., releasing contended locks).
@@ -86,7 +86,6 @@ impl<T: Debug + AsyncDrop> DerefMut for SyncDrop<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -105,11 +104,10 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncDrop for TestValue {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
             self.drop_counter.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }
@@ -152,7 +150,7 @@ mod tests {
         let inner = TestValue::new(42, Arc::clone(&counter));
         let sync_drop = SyncDrop::new(inner);
 
-        let mut guard = sync_drop.into_inner_dont_drop();
+        let guard = sync_drop.into_inner_dont_drop();
         assert_eq!(42, guard.value);
 
         // async_drop was not called yet

--- a/crates/utils/src/async_drop/with.rs
+++ b/crates/utils/src/async_drop/with.rs
@@ -28,8 +28,7 @@ macro_rules! with_async_drop_2 {
     ($value:ident, $f:block) => {
         async {
             let result = (async || $f)().await;
-            let mut value = $value;
-            value.async_drop().await?;
+            $value.async_drop().await?;
             result
         }
         .await
@@ -37,8 +36,7 @@ macro_rules! with_async_drop_2 {
     ($value:ident, $f:block, $err_map:expr) => {
         async {
             let result = (async || $f)().await;
-            let mut value = $value;
-            value.async_drop().await.map_err($err_map)?;
+            $value.async_drop().await.map_err($err_map)?;
             result
         }
         .await
@@ -54,8 +52,7 @@ macro_rules! with_async_drop_2_infallible {
         async {
             use lockable::InfallibleUnwrap as _;
             let result = (async || $f)().await;
-            let mut value = $value;
-            value.async_drop().await.infallible_unwrap();
+            $value.async_drop().await.infallible_unwrap();
             result
         }
         .await
@@ -94,7 +91,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -113,11 +109,10 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl AsyncDrop for TestValue {
         type Error = &'static str;
 
-        async fn async_drop_impl(&mut self) -> Result<(), Self::Error> {
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
             self.drop_counter.fetch_add(1, Ordering::SeqCst);
             Ok(())
         }

--- a/crates/utils/src/periodic_task.rs
+++ b/crates/utils/src/periodic_task.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use async_trait::async_trait;
 use std::fmt::Debug;
 use std::future::Future;
 use std::sync::Arc;
@@ -71,11 +70,10 @@ impl PeriodicTask {
 }
 
 // TODO Use Drop instead of AsyncDrop? https://stackoverflow.com/questions/71541765/rust-async-drop
-#[async_trait]
 impl AsyncDrop for PeriodicTask {
     type Error = anyhow::Error;
 
-    async fn async_drop_impl(&mut self) -> Result<()> {
+    async fn async_drop_impl(mut self) -> Result<()> {
         self.terminate().await?;
         Ok(())
     }
@@ -163,7 +161,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_empty_task() {
-        let mut task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), async || Ok(()));
+        let task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), async || Ok(()));
         task.async_drop().await.unwrap();
     }
 
@@ -171,7 +169,7 @@ mod tests {
     async fn runs_several_times() {
         let was_run = Arc::new(AtomicU32::new(0));
         let was_run_clone = Arc::clone(&was_run);
-        let mut task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), move || {
+        let task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), move || {
             let was_run_clone = Arc::clone(&was_run_clone);
             async move {
                 // Add an additional sleep to give control back to the event loop
@@ -220,7 +218,7 @@ mod tests {
     async fn drop_stops_execution() {
         let was_run = Arc::new(AtomicU32::new(0));
         let was_run_clone = Arc::clone(&was_run);
-        let mut task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), move || {
+        let task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), move || {
             let was_run_clone = Arc::clone(&was_run_clone);
             async move {
                 // Add an additional sleep to give control back to the event loop
@@ -246,7 +244,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_panic_task() {
         // TODO Why isn't this panic reported back?
-        let mut task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), async || {
+        let task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), async || {
             panic!("my error")
         });
         task.async_drop().await.unwrap();
@@ -255,7 +253,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn run_error_task() {
         // TODO Why isn't this error reported back?
-        let mut task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), async || {
+        let task = PeriodicTask::spawn("Test Task", Duration::from_millis(1), async || {
             bail!("my error")
         });
         task.async_drop().await.unwrap();


### PR DESCRIPTION
## Summary

Two ergonomic changes to the `AsyncDrop` pattern in `cryfs-utils`, applied across the whole workspace:

1. **`async_drop` consumes the guard.** `AsyncDropGuard::async_drop` now takes `self` instead of `&mut self`, and `AsyncDrop::async_drop_impl` takes `self` by value. Using a guard after dropping it, or dropping it twice, is now a compile error instead of a runtime `expect("Value already dropped")` in `Deref`. A `compile_fail` doctest pins that down. Locals no longer need `mut` just to be dropped (about 300 fewer `let mut` bindings).
2. **No more `#[async_trait]` on `AsyncDrop`.** The trait is declared as `fn async_drop_impl(self) -> impl Future<Output = Result<(), Self::Error>> + Send`, so implementations are plain `async fn async_drop_impl(self)` with no proc-macro and no boxed future per drop.

Because `self` is owned inside `async_drop_impl`, implementations move guard members out by destructuring instead of `std::mem::replace(.., AsyncDropGuard::new_invalid())`. That removed every placeholder guard, so `AsyncDropGuard::new_invalid()` and `is_dropped()` are gone, and `AsyncDropArc`, `AsyncDropTokioMutex`, `LockingBlockStore`, `BlockCache` and `IntegrityData` lost the `Option` fields that only existed to support `&mut self` drop ("always Some except during destruction").

## Notable non-mechanical changes

- `AsyncDrop` is no longer dyn-compatible (return-position `impl Trait`), so `Box<dyn LLBlockStore>` cannot exist. `blockstore` gains a dyn-compatible bridge trait `DynLLBlockStore` (blanket-implemented for every `LLBlockStore`) that `DynBlockStore` boxes instead. Public API change for `DynBlockStore`'s inner type.
- The FUSE backend adapters used `is_dropped()` to detect operations arriving after `destroy()`. That state is now in the type: the shared slot is an `Option<AsyncDropGuard<Fs>>` that `destroy()` takes, and readers map past it with `RwLock` guard `try_map`.
- Types with a `Drop` impl cannot be destructured, so `InodeGuardInner` in e2e-perf-tests keeps its guard in an `Option` and takes it in `Drop`.
- `mockall` mocks declare `fn async_drop_impl(self) -> impl Future<...> + Send` (mockall boxes it), expectations return `Box::pin(async { .. })`.
- `async-trait` is dropped as a dependency from the five crates that only used it for `AsyncDrop`.

Drop order is unchanged everywhere. The skill docs under `.claude/skills/async-drop/` and the `CLAUDE.md` section are updated to the new shape.

## Testing

- `cargo check --workspace --all-targets` with default features, `--no-default-features` and `--all-features`: clean, with the same pre-existing warnings as `main` and no new ones.
- `cargo test --workspace --no-fail-fast --exclude cryfs-cli-utils` plus `cargo test -p cryfs-cli-utils --lib`: 10,758 tests pass, including the FUSE-mounting rustfs tests. The only failures are the two `http_client` tests that fetch example.com, which fail identically on `main` in this sandbox (no outbound network).
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `cargo fmt --all --check`: clean.
- Not run locally: the cli-utils integration suite `tests/arguments.rs` (it builds hundreds of throwaway cargo projects and takes about two hours). It does not touch `AsyncDrop`; CI will cover it.

## Follow-ups

Two smaller PRs will be stacked on this one: a multi-guard, concurrent form of `with_async_drop_2!` to flatten the nested macro pyramids, and a pass over the error-conversion noise after `async_drop` calls.

## AI disclosure

Per `AI_POLICY.md`: this change was drafted with Claude Code. The trait and guard redesign was done by hand, the per-crate call-site migration was done by AI agents, and every crate diff was independently reviewed for drop-order changes, missing drops and unnecessary `Option`/`unwrap` introductions. Please review as a draft to be verified, not a finished result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGpoUYe98AX1tyACHy6Mqt

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGpoUYe98AX1tyACHy6Mqt)_