### PR TITLE
Add async_drop_all and a multi-guard form of with_async_drop_2!

### DIFF
--- a/.claude/skills/async-drop/SKILL.md
+++ b/.claude/skills/async-drop/SKILL.md
@@ -82,6 +82,16 @@ with_async_drop_2!(resource, {
 })
 ```
 
+Several independent guards can be listed; they are dropped concurrently afterward:
+
+```rust
+with_async_drop_2!(source, dest, {
+    move_entry(&source, &dest).await
+})
+```
+
+To drop several independent guards without running a block, use `async_drop_all((a, b, c)).await?`.
+
 ## Additional References
 
 - [patterns.md](patterns.md) - Implementation patterns and examples

--- a/.claude/skills/async-drop/helpers.md
+++ b/.claude/skills/async-drop/helpers.md
@@ -232,6 +232,19 @@ where
     F: Future<Output = Result<R, E>>,
 ```
 
+### `async_drop_all()`
+
+Drops a tuple of guards concurrently. Waits for all of them even if some fail and returns
+the first error; further errors are logged. Elements can be `AsyncDropGuard<T>` or
+`Option<AsyncDropGuard<T>>` (`None` is a no-op), all with the same error type, up to eight
+of them.
+
+```rust
+async_drop_all((source_parent, dest_parent, maybe_self_blob)).await?;
+```
+
+This is what the multi-guard form of `with_async_drop_2!` uses after its block.
+
 ### `flatten_async_drop()`
 
 Combines two Results of AsyncDropGuards.

--- a/.claude/skills/async-drop/patterns.md
+++ b/.claude/skills/async-drop/patterns.md
@@ -97,7 +97,17 @@ with_async_drop_2_infallible!(value, {
     // ... work ...
     result
 })
+
+// Several independent guards - all forms accept a list; the guards are dropped
+// concurrently after the block (they must share the same error type)
+with_async_drop_2!(source, dest, {
+    // ... work with source and dest ...
+    Ok(result)
+})
 ```
+
+Prefer the multi-guard form over nesting one `with_async_drop_2!` inside another: it
+is flatter and drops the guards concurrently.
 
 ## Pattern 4: Manual Cleanup on All Exit Paths
 
@@ -275,20 +285,14 @@ impl AsyncDrop for ConnectionPool {
     async fn async_drop_impl(self) -> Result<(), Self::Error> {
         let Self { conn_a, conn_b, conn_c } = self;
         // GOOD - concurrent drop for independent resources
-        let (a, b, c) = tokio::join!(
-            conn_a.async_drop(),
-            conn_b.async_drop(),
-            conn_c.async_drop()
-        );
-        a?;
-        b?;
-        c?;
-        Ok(())
+        async_drop_all((conn_a, conn_b, conn_c)).await
     }
 }
 ```
 
-Use `tokio::join!` to run async_drop calls concurrently when members don't depend on each other.
+`async_drop_all` takes a tuple of guards (or `Option<AsyncDropGuard<_>>`s) sharing one error
+type, drops them concurrently, waits for all of them even if some fail, and returns the first
+error (the others are logged). Use it whenever members don't depend on each other.
 
 ## Pattern 11: Shared Ownership with AsyncDropArc
 

--- a/crates/blockstore/src/low_level/implementations/integrity/mod.rs
+++ b/crates/blockstore/src/low_level/implementations/integrity/mod.rs
@@ -26,7 +26,7 @@ use crate::{
 mod integrity_data;
 
 use cryfs_utils::{
-    async_drop::{AsyncDrop, AsyncDropGuard},
+    async_drop::{AsyncDrop, AsyncDropGuard, async_drop_all},
     data::Data,
 };
 use integrity_data::{
@@ -496,13 +496,7 @@ impl<B: Sync + Send + Debug + AsyncDrop<Error = anyhow::Error>> AsyncDrop
             config: _,
             integrity_data,
         } = self;
-        let (drop1, drop2) = join!(
-            underlying_block_store.async_drop(),
-            integrity_data.async_drop(),
-        );
-        drop1?;
-        drop2?;
-        Ok(())
+        async_drop_all((underlying_block_store, integrity_data)).await
     }
 }
 

--- a/crates/cryfs-filesystem/src/filesystem/device.rs
+++ b/crates/cryfs-filesystem/src/filesystem/device.rs
@@ -14,7 +14,7 @@ use std::{fmt::Debug, time::Instant};
 use cryfs_blobstore::{BlobId, BlobStore};
 use cryfs_rustfs::{FsError, FsResult, Statfs, object_based_api::Device};
 use cryfs_utils::{
-    async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
+    async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard, async_drop_all},
     path::{AbsolutePath, PathComponent},
 };
 
@@ -228,33 +228,15 @@ where
                 Err(err1)
             }
             (Err(err1), Ok(blob2)) => {
-                // TODO async_drop blob2 and shared_blob concurrently
-                match blob2 {
-                    MaybeOwned::Owned(blob2) => {
-                        blob2.async_drop().await.map_err(FsError::internal_error)?;
-                    }
-                    MaybeOwned::Borrowed(_) => {
-                        // blob2 is borrowed. No need to drop it
-                    }
-                }
-                shared_blob
-                    .async_drop()
+                // A borrowed blob2 is shared_blob itself and doesn't need to be dropped
+                async_drop_all((into_owned(blob2), shared_blob))
                     .await
                     .map_err(FsError::internal_error)?;
                 Err(err1)
             }
             (Ok(blob1), Err(err2)) => {
-                // TODO async_drop blob1 and shared_blob concurrently
-                match blob1 {
-                    MaybeOwned::Owned(blob1) => {
-                        blob1.async_drop().await.map_err(FsError::internal_error)?;
-                    }
-                    MaybeOwned::Borrowed(_) => {
-                        // blob1 is borrowed. No need to drop it
-                    }
-                }
-                shared_blob
-                    .async_drop()
+                // A borrowed blob1 is shared_blob itself and doesn't need to be dropped
+                async_drop_all((into_owned(blob1), shared_blob))
                     .await
                     .map_err(FsError::internal_error)?;
                 Err(err2)
@@ -420,55 +402,52 @@ where
                     //      blobs at once is risky for deadlocks if not done in a consistent order.
                     // TODO Improve concurrency in this function
 
-                    // TODO Concurrently drop source_parent_blob and dest_parent_blob
                     with_async_drop_2!(
                         source_parent_blob,
+                        dest_parent_blob,
                         {
+                            let entry = source_parent_blob
+                                .with_lock(async |source_parent: &mut FsBlob<B>| {
+                                    source_parent
+                                        .as_dir_mut()
+                                        .map_err(|_| FsError::NodeIsNotADirectory)?
+                                        .entry_by_name(source_name)
+                                        .ok_or(FsError::NodeDoesNotExist)
+                                        .cloned() // TODO No cloned?
+                                })
+                                .await?;
+                            let self_blob_id = entry.blob_id();
+
+                            // TODO In theory, we could load self_blob concurrently with dest_parent_blob. No need to only do it after dest_parent_blob loaded.
+                            //      But it likely has some dependency with source_parent_blob.
+                            let self_blob = self
+                                .blobstore
+                                .load(self_blob_id)
+                                .await
+                                .map_err(|err| {
+                                    log::error!("Error loading blob: {:?}", err);
+                                    FsError::UnknownError
+                                })?
+                                .ok_or(FsError::NodeDoesNotExist)?;
+
+                            // TODO Drop self_blob concurrently with source_parent_blob and dest_parent_blob
                             with_async_drop_2!(
-                                dest_parent_blob,
+                                self_blob,
                                 {
-                                    let entry = source_parent_blob
-                                        .with_lock(async |source_parent: &mut FsBlob<B>| {
+                                    source_parent_blob
+                                        .with_lock(async |source_parent| {
                                             source_parent
                                                 .as_dir_mut()
                                                 .map_err(|_| FsError::NodeIsNotADirectory)?
-                                                .entry_by_name(source_name)
-                                                .ok_or(FsError::NodeDoesNotExist)
-                                                .cloned() // TODO No cloned?
+                                                .remove_entry_by_name(source_name)
+                                                .map_err(|err| match err {
+                                                    RemoveError::NodeDoesNotExist => {
+                                                        FsError::NodeDoesNotExist
+                                                    }
+                                                })
                                         })
                                         .await?;
-                                    let self_blob_id = entry.blob_id();
-
-                                    // TODO In theory, we could load self_blob concurrently with dest_parent_blob. No need to only do it after dest_parent_blob loaded.
-                                    //      But it likely has some dependency with source_parent_blob.
-                                    let self_blob = self
-                                        .blobstore
-                                        .load(self_blob_id)
-                                        .await
-                                        .map_err(|err| {
-                                            log::error!("Error loading blob: {:?}", err);
-                                            FsError::UnknownError
-                                        })?
-                                        .ok_or(FsError::NodeDoesNotExist)?;
-
-                                    // TODO Concurrently drop source_parent_blob, dest_parent_blob and self_blob
-                                    with_async_drop_2!(
-                                        self_blob,
-                                        {
-                                            source_parent_blob
-                                                .with_lock(async |source_parent| {
-                                                    source_parent
-                                                        .as_dir_mut()
-                                                        .map_err(|_| FsError::NodeIsNotADirectory)?
-                                                        .remove_entry_by_name(source_name)
-                                                        .map_err(|err| match err {
-                                                            RemoveError::NodeDoesNotExist => {
-                                                                FsError::NodeDoesNotExist
-                                                            }
-                                                        })
-                                                })
-                                                .await?;
-                                            dest_parent_blob
+                                    dest_parent_blob
                                                 .with_lock(async |source_parent| {
                                                     source_parent
                                                         .as_dir_mut()
@@ -500,22 +479,17 @@ where
                                                         })
                                                 }).await?;
 
-                                            self_blob
-                                                .with_lock(async |self_blob| {
-                                                    self_blob
-                                                        .set_parent(&dest_parent_blob.blob_id())
-                                                        .await
-                                                })
-                                                .await
-                                                .map_err(|err| {
-                                                    // TODO Exception safety - we already changed parent dir entries but couldn't update the parent pointer. We should probably try to undo the parent dir entry changes.
-                                                    log::error!("Error setting parent: {err:?}");
-                                                    FsError::UnknownError
-                                                })?;
-                                            Ok::<(), FsError>(())
-                                        },
-                                        FsError::internal_error
-                                    )
+                                    self_blob
+                                        .with_lock(async |self_blob| {
+                                            self_blob.set_parent(&dest_parent_blob.blob_id()).await
+                                        })
+                                        .await
+                                        .map_err(|err| {
+                                            // TODO Exception safety - we already changed parent dir entries but couldn't update the parent pointer. We should probably try to undo the parent dir entry changes.
+                                            log::error!("Error setting parent: {err:?}");
+                                            FsError::UnknownError
+                                        })?;
+                                    Ok::<(), FsError>(())
                                 },
                                 FsError::internal_error
                             )
@@ -651,6 +625,14 @@ where
             .async_drop()
             .await
             .map_err(FsError::internal_error)
+    }
+}
+
+/// Returns the blob if it is owned, or [None] if it is only borrowed and therefore owned by someone else.
+fn into_owned<T>(blob: MaybeOwned<'_, T>) -> Option<T> {
+    match blob {
+        MaybeOwned::Owned(blob) => Some(blob),
+        MaybeOwned::Borrowed(_) => None,
     }
 }
 

--- a/crates/cryfs-filesystem/src/filesystem/dir.rs
+++ b/crates/cryfs-filesystem/src/filesystem/dir.rs
@@ -306,61 +306,58 @@ where
                 flatten_async_drop::<anyhow::Error, _, _, _, _>(source_parent, dest_parent)
                     .await
                     .map_err(FsError::internal_error)?;
-            // TODO Drop source_parent, dest_parent, newparent and self_blob concurrently
+            // TODO Drop newparent and self_blob concurrently with source_parent and dest_parent
             with_async_drop_2!(
                 source_parent,
+                dest_parent,
                 {
+                    let entry = source_parent
+                        .with_lock(async |source_parent_dir| {
+                            let source_parent_dir = Self::blob_as_dir_mut(&mut *source_parent_dir)?;
+                            let entry = source_parent_dir
+                                .entry_by_name(oldname)
+                                .ok_or(FsError::NodeDoesNotExist)?;
+                            Ok::<_, FsError>(entry.clone()) // TODO No clone
+                        })
+                        .await?;
+
+                    let self_blob_id = entry.blob_id();
+                    #[cfg(feature = "ancestor_checks_on_move")]
+                    {
+                        // TODO This can happen concurrently with the load_blob above
+                        self.validate_move_doesnt_cause_cycle(self_blob_id, &newparent)
+                            .await?;
+                    }
+
+                    // TODO In theory, we could load self_blob concurrently with dest_parent_blob. No need to only do it after dest_parent_blob loaded.
+                    //      But it likely has some dependency with source_parent_blob.
+                    let self_blob = self
+                        .blobstore
+                        .load(self_blob_id)
+                        .await
+                        .map_err(|err| {
+                            log::error!("Error loading blob: {:?}", err);
+                            FsError::UnknownError
+                        })?
+                        .ok_or(
+                            // TODO This branch means there was an entry in the parent dir but the blob itself doesn't exist. How should we handle this?
+                            FsError::NodeDoesNotExist,
+                        )?;
                     with_async_drop_2!(
-                        dest_parent,
+                        self_blob,
                         {
                             let entry = source_parent
                                 .with_lock(async |source_parent_dir| {
-                                    let source_parent_dir =
-                                        Self::blob_as_dir_mut(&mut *source_parent_dir)?;
-                                    let entry = source_parent_dir
-                                        .entry_by_name(oldname)
-                                        .ok_or(FsError::NodeDoesNotExist)?;
-                                    Ok::<_, FsError>(entry.clone()) // TODO No clone
+                                    Self::blob_as_dir_mut(source_parent_dir)?
+                                        .remove_entry_by_name(oldname)
+                                        .map_err(|err| match err {
+                                            RemoveError::NodeDoesNotExist => {
+                                                FsError::NodeDoesNotExist
+                                            }
+                                        })
                                 })
                                 .await?;
-
-                            let self_blob_id = entry.blob_id();
-                            #[cfg(feature = "ancestor_checks_on_move")]
-                            {
-                                // TODO This can happen concurrently with the load_blob above
-                                self.validate_move_doesnt_cause_cycle(self_blob_id, &newparent)
-                                    .await?;
-                            }
-
-                            // TODO In theory, we could load self_blob concurrently with dest_parent_blob. No need to only do it after dest_parent_blob loaded.
-                            //      But it likely has some dependency with source_parent_blob.
-                            let self_blob = self
-                                .blobstore
-                                .load(self_blob_id)
-                                .await
-                                .map_err(|err| {
-                                    log::error!("Error loading blob: {:?}", err);
-                                    FsError::UnknownError
-                                })?
-                                .ok_or(
-                                    // TODO This branch means there was an entry in the parent dir but the blob itself doesn't exist. How should we handle this?
-                                    FsError::NodeDoesNotExist,
-                                )?;
-                            with_async_drop_2!(
-                                self_blob,
-                                {
-                                    let entry = source_parent
-                                        .with_lock(async |source_parent_dir| {
-                                            Self::blob_as_dir_mut(source_parent_dir)?
-                                                .remove_entry_by_name(oldname)
-                                                .map_err(|err| match err {
-                                                    RemoveError::NodeDoesNotExist => {
-                                                        FsError::NodeDoesNotExist
-                                                    }
-                                                })
-                                        })
-                                        .await?;
-                                    dest_parent
+                            dest_parent
                                         .with_lock(async |dest_parent_dir| {
                                             Self::blob_as_dir_mut(dest_parent_dir)?
                                                 .add_or_overwrite_entry(
@@ -403,34 +400,31 @@ where
                                                 })
                                         }).await?;
 
-                                    self_blob
-                                        .with_lock(async |self_blob| {
-                                            self_blob.set_parent(&dest_parent.blob_id()).await
-                                        })
-                                        .await
-                                        .map_err(|err| {
-                                            // TODO Exception safety - we already changed parent dir entries but couldn't update the parent pointer. We should probably try to undo the parent dir entry changes.
-                                            log::error!("Error setting parent: {err:?}");
-                                            FsError::UnknownError
-                                        })?;
+                            self_blob
+                                .with_lock(async |self_blob| {
+                                    self_blob.set_parent(&dest_parent.blob_id()).await
+                                })
+                                .await
+                                .map_err(|err| {
+                                    // TODO Exception safety - we already changed parent dir entries but couldn't update the parent pointer. We should probably try to undo the parent dir entry changes.
+                                    log::error!("Error setting parent: {err:?}");
+                                    FsError::UnknownError
+                                })?;
 
-                                    // TODO We can probably do this concurrently with the other modifications further up
-                                    // TODO This requires loading the grandparent blobs so we can update the parent blob's timestamps.
-                                    //      Can this cause a deadlock? What if one of the grandparents is already loaded as one of the parents?
-                                    let (source_update, dest_update) = join!(
-                                        self.node_info.update_modification_timestamp_in_parent(),
-                                        newparent
-                                            .node_info
-                                            .update_modification_timestamp_in_parent(),
-                                    );
+                            // TODO We can probably do this concurrently with the other modifications further up
+                            // TODO This requires loading the grandparent blobs so we can update the parent blob's timestamps.
+                            //      Can this cause a deadlock? What if one of the grandparents is already loaded as one of the parents?
+                            let (source_update, dest_update) = join!(
+                                self.node_info.update_modification_timestamp_in_parent(),
+                                newparent
+                                    .node_info
+                                    .update_modification_timestamp_in_parent(),
+                            );
 
-                                    source_update?;
-                                    dest_update?;
+                            source_update?;
+                            dest_update?;
 
-                                    Ok::<(), FsError>(())
-                                },
-                                FsError::internal_error
-                            )
+                            Ok::<(), FsError>(())
                         },
                         FsError::internal_error
                     )

--- a/crates/rustfs/src/object_based_api/low_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/low_level_adapter.rs
@@ -24,7 +24,7 @@ use crate::{
     object_based_api::utils::{DirCache, InodeList, OpenDirHandle},
 };
 use cryfs_utils::{
-    async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard, flatten_async_drop},
+    async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard, async_drop_all, flatten_async_drop},
     path::PathComponent,
     with_async_drop_2,
 };
@@ -546,9 +546,7 @@ where
                 })
             }
             .await;
-            // TODO Drop concurrently and drop latter even if first one fails
-            oldparent.async_drop().await?;
-            newparent.async_drop().await?;
+            async_drop_all((oldparent, newparent)).await?;
             result
         }
     }

--- a/crates/utils/src/async_drop/all.rs
+++ b/crates/utils/src/async_drop/all.rs
@@ -1,0 +1,341 @@
+//! Dropping several [AsyncDropGuard]s at once.
+//!
+//! [async_drop_all] takes a tuple of guards, drops all of them concurrently, and waits for
+//! all of them even if some fail. See [with_async_drop_2!](crate::with_async_drop_2) for the
+//! macro form that also runs a block of code before dropping.
+
+use std::fmt::Debug;
+use std::future::Future;
+
+use super::{AsyncDrop, AsyncDropGuard};
+
+/// An element that [async_drop_all] can drop: an [AsyncDropGuard], or an [Option] of one
+/// where [None] means there is nothing to drop.
+pub trait AsyncDropAllElement {
+    type Error: Debug;
+
+    fn async_drop_element(self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+impl<T: AsyncDrop + Debug> AsyncDropAllElement for AsyncDropGuard<T> {
+    type Error = T::Error;
+
+    fn async_drop_element(self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        self.async_drop()
+    }
+}
+
+impl<T: AsyncDrop + Debug> AsyncDropAllElement for Option<AsyncDropGuard<T>> {
+    type Error = T::Error;
+
+    fn async_drop_element(self) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        let drop_future = self.map(AsyncDropGuard::async_drop);
+        async move {
+            match drop_future {
+                Some(drop_future) => drop_future.await,
+                None => Ok(()),
+            }
+        }
+    }
+}
+
+/// A tuple of [AsyncDropAllElement]s that all share the same error type.
+///
+/// Implemented for tuples of one to eight elements.
+pub trait AsyncDropTuple {
+    type Error: Debug;
+
+    /// See [async_drop_all].
+    fn async_drop_all(self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+}
+
+/// Drops all guards in the tuple concurrently.
+///
+/// All drops are started together and all of them are awaited, even if some of them fail.
+/// If several fail, the first error in tuple order is returned and the others are logged.
+///
+/// Elements can be [AsyncDropGuard]s or `Option<AsyncDropGuard<_>>`s, and all of them
+/// must have the same [AsyncDrop::Error] type.
+///
+/// ```
+/// use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard, async_drop_all};
+///
+/// #[derive(Debug)]
+/// struct Connection;
+///
+/// impl AsyncDrop for Connection {
+///     type Error = std::convert::Infallible;
+///
+///     async fn async_drop_impl(self) -> Result<(), Self::Error> {
+///         Ok(())
+///     }
+/// }
+///
+/// # futures::executor::block_on(async {
+/// let first = AsyncDropGuard::new(Connection);
+/// let second = AsyncDropGuard::new(Connection);
+/// let maybe_third: Option<AsyncDropGuard<Connection>> = None;
+/// async_drop_all((first, second, maybe_third)).await.unwrap();
+/// # });
+/// ```
+pub fn async_drop_all<T: AsyncDropTuple>(
+    guards: T,
+) -> impl Future<Output = Result<(), T::Error>> + Send {
+    guards.async_drop_all()
+}
+
+fn record_error<E: Debug>(first_error: &mut Option<E>, result: Result<(), E>) {
+    if let Err(error) = result {
+        if first_error.is_none() {
+            *first_error = Some(error);
+        } else {
+            log::error!(
+                "Error while dropping several values at once. Only the first error is returned, this one is dropped: {error:?}"
+            );
+        }
+    }
+}
+
+macro_rules! impl_async_drop_tuple {
+    ($($element:ident . $index:tt),+) => {
+        impl<E: Debug + Send, $($element: AsyncDropAllElement<Error = E>),+> AsyncDropTuple
+            for ($($element,)+)
+        {
+            type Error = E;
+
+            fn async_drop_all(self) -> impl Future<Output = Result<(), E>> + Send {
+                // Create all futures before the async block so that it only captures the
+                // futures (which are `Send` by the contract of `AsyncDrop`) and not the guards.
+                let futures = ($(self.$index.async_drop_element(),)+);
+                async move {
+                    let results = futures::join!($(futures.$index),+);
+                    let mut first_error = None;
+                    $(record_error(&mut first_error, results.$index);)+
+                    match first_error {
+                        Some(error) => Err(error),
+                        None => Ok(()),
+                    }
+                }
+            }
+        }
+    };
+}
+
+impl_async_drop_tuple!(A.0);
+impl_async_drop_tuple!(A.0, B.1);
+impl_async_drop_tuple!(A.0, B.1, C.2);
+impl_async_drop_tuple!(A.0, B.1, C.2, D.3);
+impl_async_drop_tuple!(A.0, B.1, C.2, D.3, F.4);
+impl_async_drop_tuple!(A.0, B.1, C.2, D.3, F.4, G.5);
+impl_async_drop_tuple!(A.0, B.1, C.2, D.3, F.4, G.5, H.6);
+impl_async_drop_tuple!(A.0, B.1, C.2, D.3, F.4, G.5, H.6, I.7);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tokio::sync::Barrier;
+
+    #[derive(Debug)]
+    struct TestValue {
+        drop_counter: Arc<AtomicUsize>,
+        fail_with: Option<&'static str>,
+        barrier: Option<Arc<Barrier>>,
+    }
+
+    impl TestValue {
+        fn new(drop_counter: &Arc<AtomicUsize>) -> AsyncDropGuard<Self> {
+            AsyncDropGuard::new(Self {
+                drop_counter: Arc::clone(drop_counter),
+                fail_with: None,
+                barrier: None,
+            })
+        }
+
+        fn failing(drop_counter: &Arc<AtomicUsize>, error: &'static str) -> AsyncDropGuard<Self> {
+            AsyncDropGuard::new(Self {
+                drop_counter: Arc::clone(drop_counter),
+                fail_with: Some(error),
+                barrier: None,
+            })
+        }
+
+        fn waiting_on(
+            drop_counter: &Arc<AtomicUsize>,
+            barrier: &Arc<Barrier>,
+        ) -> AsyncDropGuard<Self> {
+            AsyncDropGuard::new(Self {
+                drop_counter: Arc::clone(drop_counter),
+                fail_with: None,
+                barrier: Some(Arc::clone(barrier)),
+            })
+        }
+    }
+
+    impl AsyncDrop for TestValue {
+        type Error = &'static str;
+
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
+            if let Some(barrier) = &self.barrier {
+                barrier.wait().await;
+            }
+            self.drop_counter.fetch_add(1, Ordering::SeqCst);
+            match self.fail_with {
+                Some(error) => Err(error),
+                None => Ok(()),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn given_two_guards_when_dropping_all_then_both_are_dropped() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let a = TestValue::new(&counter);
+        let b = TestValue::new(&counter);
+
+        let result = async_drop_all((a, b)).await;
+
+        assert_eq!(Ok(()), result);
+        assert_eq!(2, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_single_guard_when_dropping_all_then_it_is_dropped() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let a = TestValue::new(&counter);
+
+        let result = async_drop_all((a,)).await;
+
+        assert_eq!(Ok(()), result);
+        assert_eq!(1, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_eight_guards_when_dropping_all_then_all_are_dropped() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let guards = (
+            TestValue::new(&counter),
+            TestValue::new(&counter),
+            TestValue::new(&counter),
+            TestValue::new(&counter),
+            TestValue::new(&counter),
+            TestValue::new(&counter),
+            TestValue::new(&counter),
+            TestValue::new(&counter),
+        );
+
+        let result = async_drop_all(guards).await;
+
+        assert_eq!(Ok(()), result);
+        assert_eq!(8, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_first_drop_fails_when_dropping_all_then_second_is_still_dropped_and_error_is_returned()
+     {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let a = TestValue::failing(&counter, "error a");
+        let b = TestValue::new(&counter);
+
+        let result = async_drop_all((a, b)).await;
+
+        assert_eq!(Err("error a"), result);
+        assert_eq!(2, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_last_drop_fails_when_dropping_all_then_first_is_still_dropped_and_error_is_returned()
+     {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let a = TestValue::new(&counter);
+        let b = TestValue::failing(&counter, "error b");
+
+        let result = async_drop_all((a, b)).await;
+
+        assert_eq!(Err("error b"), result);
+        assert_eq!(2, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_all_drops_fail_when_dropping_all_then_first_error_in_tuple_order_is_returned() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let a = TestValue::failing(&counter, "error a");
+        let b = TestValue::failing(&counter, "error b");
+        let c = TestValue::failing(&counter, "error c");
+
+        let result = async_drop_all((a, b, c)).await;
+
+        assert_eq!(Err("error a"), result);
+        assert_eq!(3, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_optional_guards_when_dropping_all_then_some_is_dropped_and_none_is_ok() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let a: Option<AsyncDropGuard<TestValue>> = None;
+        let b = Some(TestValue::new(&counter));
+        let c = TestValue::new(&counter);
+
+        let result = async_drop_all((a, b, c)).await;
+
+        assert_eq!(Ok(()), result);
+        assert_eq!(2, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_guards_that_wait_for_each_other_when_dropping_all_then_they_are_dropped_concurrently()
+     {
+        // Each drop blocks until both drops have started. This only completes if the two drops
+        // run concurrently, so a sequential implementation would hit the timeout.
+        let counter = Arc::new(AtomicUsize::new(0));
+        let barrier = Arc::new(Barrier::new(2));
+        let a = TestValue::waiting_on(&counter, &barrier);
+        let b = TestValue::waiting_on(&counter, &barrier);
+
+        let result = tokio::time::timeout(Duration::from_secs(10), async_drop_all((a, b)))
+            .await
+            .expect("drops did not run concurrently");
+
+        assert_eq!(Ok(()), result);
+        assert_eq!(2, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_guard_and_optional_guard_with_different_value_types_when_dropping_all_then_both_dropped()
+     {
+        #[derive(Debug)]
+        struct OtherValue(Arc<AtomicUsize>);
+        impl AsyncDrop for OtherValue {
+            type Error = &'static str;
+            async fn async_drop_impl(self) -> Result<(), Self::Error> {
+                self.0.fetch_add(10, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let a = TestValue::new(&counter);
+        let b = AsyncDropGuard::new(OtherValue(Arc::clone(&counter)));
+
+        let result = async_drop_all((a, b)).await;
+
+        assert_eq!(Ok(()), result);
+        assert_eq!(11, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_guards_when_dropping_all_then_future_is_send() {
+        fn assert_send<T: Send>(_: &T) {}
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let a = TestValue::new(&counter);
+        let b = Some(TestValue::new(&counter));
+
+        let future = async_drop_all((a, b));
+        assert_send(&future);
+        future.await.unwrap();
+        assert_eq!(2, counter.load(Ordering::SeqCst));
+    }
+}

--- a/crates/utils/src/async_drop/all.rs
+++ b/crates/utils/src/async_drop/all.rs
@@ -84,6 +84,8 @@ pub fn async_drop_all<T: AsyncDropTuple>(
     guards.async_drop_all()
 }
 
+// TODO Instead of only returning the first error and logging the others, we might want to
+//      return all of them, e.g. with a list error type.
 fn record_error<E: Debug>(first_error: &mut Option<E>, result: Result<(), E>) {
     if let Err(error) = result {
         if first_error.is_none() {

--- a/crates/utils/src/async_drop/mod.rs
+++ b/crates/utils/src/async_drop/mod.rs
@@ -19,6 +19,9 @@ pub use hash_map::AsyncDropHashMap;
 mod with;
 pub use with::with_async_drop;
 
+mod all;
+pub use all::{AsyncDropAllElement, AsyncDropTuple, async_drop_all};
+
 mod flatten;
 pub use flatten::flatten_async_drop;
 

--- a/crates/utils/src/async_drop/with.rs
+++ b/crates/utils/src/async_drop/with.rs
@@ -14,29 +14,35 @@ use super::{AsyncDrop, AsyncDropGuard};
 
 // TODO Why does this need to be a macro? Can't call sites just use the function version?
 
-/// Executes a block of code and ensures `async_drop` is called on the value afterward.
+/// Executes a block of code and ensures `async_drop` is called on the values afterward.
 ///
-/// This macro takes an `AsyncDropGuard` and a block of code to execute. After the block
-/// completes (whether successfully or with an error), it calls `async_drop` on the value.
+/// This macro takes one or more `AsyncDropGuard`s and a block of code to execute. After the
+/// block completes (whether successfully or with an error), it calls `async_drop` on the values.
+/// Several values are dropped concurrently via [async_drop_all](crate::async_drop::async_drop_all),
+/// so they must be independent of each other and share the same error type.
 ///
 /// # Forms
 ///
 /// - `with_async_drop_2!(value, { ... })` - Propagates async_drop errors directly
 /// - `with_async_drop_2!(value, { ... }, err_map)` - Maps async_drop errors using `err_map`
+/// - `with_async_drop_2!(first, second, ..., { ... })` - Drops all values concurrently afterward
+/// - `with_async_drop_2!(first, second, ..., { ... }, err_map)` - Same, mapping async_drop errors
 #[macro_export]
 macro_rules! with_async_drop_2 {
-    ($value:ident, $f:block) => {
+    ($($value:ident),+ , $f:block) => {
         async {
             let result = (async || $f)().await;
-            $value.async_drop().await?;
+            $crate::async_drop::async_drop_all(($($value,)+)).await?;
             result
         }
         .await
     };
-    ($value:ident, $f:block, $err_map:expr) => {
+    ($($value:ident),+ , $f:block, $err_map:expr) => {
         async {
             let result = (async || $f)().await;
-            $value.async_drop().await.map_err($err_map)?;
+            $crate::async_drop::async_drop_all(($($value,)+))
+                .await
+                .map_err($err_map)?;
             result
         }
         .await
@@ -48,11 +54,13 @@ macro_rules! with_async_drop_2 {
 /// Since the error type is `Never` (infallible), this macro unwraps the result directly.
 #[macro_export]
 macro_rules! with_async_drop_2_infallible {
-    ($value:ident, $f:block) => {
+    ($($value:ident),+ , $f:block) => {
         async {
             use lockable::InfallibleUnwrap as _;
             let result = (async || $f)().await;
-            $value.async_drop().await.infallible_unwrap();
+            $crate::async_drop::async_drop_all(($($value,)+))
+                .await
+                .infallible_unwrap();
             result
         }
         .await
@@ -144,6 +152,70 @@ mod tests {
         assert_eq!(Err("callback error"), result);
         // async_drop should still be called
         assert_eq!(1, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_with_async_drop_2_macro_multiple_guards_success() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let first = TestValue::new(1, Arc::clone(&counter));
+        let second = TestValue::new(2, Arc::clone(&counter));
+        let third = TestValue::new(3, Arc::clone(&counter));
+
+        let result: Result<i32, &'static str> = with_async_drop_2!(first, second, third, {
+            Ok(first.value + second.value + third.value)
+        });
+
+        assert_eq!(Ok(6), result);
+        assert_eq!(3, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_with_async_drop_2_macro_multiple_guards_block_error() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let first = TestValue::new(1, Arc::clone(&counter));
+        let second = TestValue::new(2, Arc::clone(&counter));
+
+        let result: Result<i32, &'static str> =
+            with_async_drop_2!(first, second, { Err("block error") });
+
+        assert_eq!(Err("block error"), result);
+        // Both guards are dropped even though the block failed
+        assert_eq!(2, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_with_async_drop_2_macro_multiple_guards_with_error_map() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let first = TestValue::new(1, Arc::clone(&counter));
+        let second = TestValue::new(2, Arc::clone(&counter));
+
+        let result: Result<i32, String> =
+            with_async_drop_2!(first, second, { Ok(84) }, |e: &str| e.to_string());
+
+        assert_eq!(Ok(84), result);
+        assert_eq!(2, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_with_async_drop_2_infallible_macro_multiple_guards() {
+        #[derive(Debug)]
+        struct InfallibleValue(Arc<AtomicUsize>);
+        impl AsyncDrop for InfallibleValue {
+            type Error = lockable::Never;
+            async fn async_drop_impl(self) -> Result<(), Self::Error> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let first = AsyncDropGuard::new(InfallibleValue(Arc::clone(&counter)));
+        let second = AsyncDropGuard::new(InfallibleValue(Arc::clone(&counter)));
+
+        let result: i32 = with_async_drop_2_infallible!(first, second, { 42 });
+
+        assert_eq!(42, result);
+        assert_eq!(2, counter.load(Ordering::SeqCst));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Follow-up to #641 (now merged; this PR is rebased onto main and contains a single commit).

## Summary

- **`async_drop_all((a, b, c))`** in `cryfs-utils`: drops a tuple of up to eight `AsyncDropGuard`s (or `Option<AsyncDropGuard<_>>`s, where `None` is a no-op) that share an error type. All drops are started together and all are awaited even if some fail; the first error in tuple order is returned and the others are logged. Built on a small `AsyncDropTuple` / `AsyncDropAllElement` trait pair so the error type is inferred from the elements.
- **`with_async_drop_2!(a, b, c, { .. })`**: the macro (and its `_infallible` and error-mapping forms) now accepts several guards and drops them concurrently after the block via `async_drop_all`. The single-guard form is unchanged.

## Call sites

- `CryDir::rename` and `CryDevice::rename`: the `with_async_drop_2!(source, { with_async_drop_2!(dest, { .. }) })` pyramids are flattened one level into the multi-guard form. The innermost `self_blob` guard is still nested because it is only loaded inside the block; the TODOs are updated accordingly.
- `CryDevice::load_two_blobs`: the two error arms that dropped a `MaybeOwned` blob and then the shared blob sequentially now use `async_drop_all((into_owned(blob), shared_blob))`.
- `ObjectBasedFsAdapterLL::rename`: `oldparent`/`newparent` are dropped concurrently, and the second one is now dropped even if the first drop fails (that was the TODO there).
- `IntegrityBlockStore::async_drop_impl`: the manual `join!` + `drop1?; drop2?` becomes `async_drop_all`, so a second error is logged instead of silently lost.

Skill docs updated.

## Testing

- New unit tests in `crates/utils/src/async_drop/all.rs` and `with.rs`: all elements dropped, single and eight-element tuples, first error returned while later elements are still dropped, first error in tuple order, `Option` elements, a barrier-based test that only completes if the drops really run concurrently, a `Send` assertion, and the multi-guard macro in all three forms. Plus a doctest on `async_drop_all`.
- `cargo test` for cryfs-utils (355 unit + 20 doc), cryfs-blockstore integrity tests (817), cryfs-rustfs (41), cryfs-e2e-perf-tests (4,060), cryfs-check (236) and cryfs-cli (65): all pass.
- `cargo check --workspace --all-targets` and `cargo fmt --all`: clean.

## AI disclosure

Per `AI_POLICY.md`: drafted with Claude Code; please review as a draft to be verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGpoUYe98AX1tyACHy6Mqt