### PR TITLE
Reduce error-handling noise around async_drop

### DIFF
--- a/.claude/skills/async-drop/SKILL.md
+++ b/.claude/skills/async-drop/SKILL.md
@@ -66,16 +66,16 @@ impl AsyncDrop for MyType {
 | **Factory methods return guards** | `fn new() -> AsyncDropGuard<Self>`, never plain `Self` |
 | **Types with guard members impl AsyncDrop** | `async fn async_drop_impl(self)`: destructure `self`, drop members |
 | **No `#[async_trait]` on AsyncDrop impls** | The trait uses native `async fn` in traits |
-| **Use the macro when possible** | `with_async_drop_2!` handles cleanup automatically |
+| **Use the macro when possible** | `with_async_drop!` handles cleanup automatically |
 | **Panics are exceptions** | It's OK to skip async_drop on panic paths |
 
-## The `with_async_drop_2!` Macro
+## The `with_async_drop!` Macro
 
 Automatically calls `async_drop()` on scope exit:
 
 ```rust
 let resource = get_resource().await?;
-with_async_drop_2!(resource, {
+with_async_drop!(resource, {
     // Use resource here
     resource.do_work().await?;
     Ok(result)
@@ -85,7 +85,7 @@ with_async_drop_2!(resource, {
 Several independent guards can be listed; they are dropped concurrently afterward:
 
 ```rust
-with_async_drop_2!(source, dest, {
+with_async_drop!(source, dest, {
     move_entry(&source, &dest).await
 })
 ```

--- a/.claude/skills/async-drop/gotchas.md
+++ b/.claude/skills/async-drop/gotchas.md
@@ -59,6 +59,14 @@ async fn good(mut resource: AsyncDropGuard<R>) -> Result<Data> {
     resource.async_drop().await?;
     result
 }
+
+// BETTER - if the guard is kept on the success path, let `async_drop_on_err` handle the error paths
+async fn better(resource: AsyncDropGuard<R>) -> Result<(Data, AsyncDropGuard<R>)> {
+    let validated = resource.validate();  // Result<(), Error>
+    let ((), resource) = resource.async_drop_on_err(validated).await?;
+    let data = resource.fetch().await;
+    resource.async_drop_on_err(data).await
+}
 ```
 
 ## Gotcha 3: Allowing Direct Instantiation of AsyncDrop Types

--- a/.claude/skills/async-drop/gotchas.md
+++ b/.claude/skills/async-drop/gotchas.md
@@ -26,7 +26,7 @@ async fn good() -> Result<()> {
 // BETTER - use the macro
 async fn better() -> Result<()> {
     let resource = Resource::new();
-    with_async_drop_2!(resource, {
+    with_async_drop!(resource, {
         resource.do_work().await
     })
 }
@@ -302,4 +302,4 @@ Before submitting code with AsyncDrop:
 - [ ] `unsafe_into_inner_dont_drop()` only used internally, with member cleanup handled
 - [ ] Drop order correct for dependent members (reverse of construction)
 - [ ] Independent members dropped concurrently (Pattern 10)
-- [ ] Using `with_async_drop_2!` where possible
+- [ ] Using `with_async_drop!` where possible

--- a/.claude/skills/async-drop/helpers.md
+++ b/.claude/skills/async-drop/helpers.md
@@ -218,21 +218,6 @@ async_drop is complete and will cause bad performance.
 
 ## Utility Functions
 
-### `with_async_drop()`
-
-Function version of the macro for more complex scenarios.
-
-```rust
-pub async fn with_async_drop<T, R, E, F>(
-    mut value: AsyncDropGuard<T>,
-    f: impl FnOnce(&mut T) -> F,
-) -> Result<R, E>
-where
-    T: AsyncDrop + Debug,
-    E: From<<T as AsyncDrop>::Error>,
-    F: Future<Output = Result<R, E>>,
-```
-
 ### `async_drop_all()`
 
 Drops a tuple of guards concurrently. Waits for all of them even if some fail and returns
@@ -244,7 +229,7 @@ of them.
 async_drop_all((source_parent, dest_parent, maybe_self_blob)).await?;
 ```
 
-This is what the multi-guard form of `with_async_drop_2!` uses after its block.
+This is what the multi-guard form of `with_async_drop!` uses after its block.
 
 ### `flatten_async_drop()`
 

--- a/.claude/skills/async-drop/helpers.md
+++ b/.claude/skills/async-drop/helpers.md
@@ -16,6 +16,7 @@ pub struct AsyncDropGuard<T: Debug>(Option<T>);
 |--------|-------------|
 | `new(v: T)` | Wrap a value |
 | `async_drop(self)` | Perform async cleanup (required!). Consumes the guard |
+| `async_drop_on_err(self, result)` | Drops the guard if `result` is an error and returns the error, otherwise returns `(value, guard)`. Drop failures are logged |
 | `unsafe_into_inner_dont_drop(self)` | Extract inner, bypassing cleanup |
 | `map_unsafe<U>(self, f)` | Transform inner type |
 
@@ -250,13 +251,15 @@ This is what the multi-guard form of `with_async_drop_2!` uses after its block.
 Combines two Results of AsyncDropGuards.
 
 ```rust
-pub async fn flatten_async_drop<E, T, E1, U, E2>(
-    first: Result<AsyncDropGuard<T>, E1>,
-    second: Result<AsyncDropGuard<U>, E2>,
+pub async fn flatten_async_drop<E, T, U>(
+    first: Result<AsyncDropGuard<T>, E>,
+    second: Result<AsyncDropGuard<U>, E>,
 ) -> Result<(AsyncDropGuard<T>, AsyncDropGuard<U>), E>
 ```
 
-Returns tuple of both guards if both are Ok. On error, properly cleans up any successful guard before returning error.
+Returns tuple of both guards if both are Ok. On error, drops any successful guard before
+returning the (first) error. Both inputs share one error type, which is inferred, so no
+turbofish is needed. Drop failures on the error path are logged, not returned.
 
 ---
 

--- a/.claude/skills/async-drop/patterns.md
+++ b/.claude/skills/async-drop/patterns.md
@@ -58,17 +58,17 @@ impl AsyncDrop for CompositeResource {
 A type that also implements `Drop` cannot be destructured. Store its guard members
 in an `Option` and `.take()` them in `async_drop_impl` instead.
 
-## Pattern 3: Using `with_async_drop_2!` Macro
+## Pattern 3: Using `with_async_drop!` Macro
 
 The preferred approach when it fits - automatically handles cleanup:
 
 ```rust
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 
 async fn process_file(path: &Path) -> Result<Data> {
     let file = open_file(path).await?;  // Returns AsyncDropGuard<File>
 
-    with_async_drop_2!(file, {
+    with_async_drop!(file, {
         // Use file here
         let data = file.read_all().await?;
         process(data).await
@@ -81,32 +81,32 @@ async fn process_file(path: &Path) -> Result<Data> {
 
 ```rust
 // Basic - propagates async_drop errors as-is
-with_async_drop_2!(value, {
+with_async_drop!(value, {
     // ... work ...
     Ok(result)
 })
 
 // With error mapping - converts async_drop errors
-with_async_drop_2!(value, {
+with_async_drop!(value, {
     // ... work ...
     Ok(result)
 }, MyError::from)
 
 // Infallible - for types with Error = Never
-with_async_drop_2_infallible!(value, {
+with_async_drop_infallible!(value, {
     // ... work ...
     result
 })
 
 // Several independent guards - all forms accept a list; the guards are dropped
 // concurrently after the block (they must share the same error type)
-with_async_drop_2!(source, dest, {
+with_async_drop!(source, dest, {
     // ... work with source and dest ...
     Ok(result)
 })
 ```
 
-Prefer the multi-guard form over nesting one `with_async_drop_2!` inside another: it
+Prefer the multi-guard form over nesting one `with_async_drop!` inside another: it
 is flatter and drops the guards concurrently.
 
 ## Pattern 4: Keeping the Guard on Success, Dropping It on Error
@@ -362,7 +362,7 @@ async fn good_example(mut resource: AsyncDropGuard<R>) -> Result<()> {
 
 // BETTER - use the macro
 async fn best_example(resource: AsyncDropGuard<R>) -> Result<()> {
-    with_async_drop_2!(resource, {
+    with_async_drop!(resource, {
         resource.step1().await
     })
 }

--- a/.claude/skills/async-drop/patterns.md
+++ b/.claude/skills/async-drop/patterns.md
@@ -109,30 +109,33 @@ with_async_drop_2!(source, dest, {
 Prefer the multi-guard form over nesting one `with_async_drop_2!` inside another: it
 is flatter and drops the guards concurrently.
 
-## Pattern 4: Manual Cleanup on All Exit Paths
+## Pattern 4: Keeping the Guard on Success, Dropping It on Error
 
-When the macro doesn't fit, manually ensure cleanup on every path:
+When a function keeps the guard on its success path (e.g. moves it into a new object) but
+must drop it on every error path, the macro doesn't fit. Use `async_drop_on_err`: it
+drops the guard if the result is an error and returns that error, otherwise it hands the
+value and the guard back. A failure to drop is logged; the original error is what gets returned.
+
+```rust
+async fn create_child(parent: AsyncDropGuard<Dir>) -> Result<Node> {
+    let child_id = create_child_blob().await;
+    // parent is dropped and the error returned if create_child_blob failed
+    let (child_id, parent) = parent.async_drop_on_err(child_id).await?;
+
+    let attrs = parent.add_entry(child_id).await;
+    let (attrs, parent) = parent.async_drop_on_err(attrs).await?;
+
+    Ok(Node::new(parent, child_id, attrs))  // parent moves into the node
+}
+```
+
+Only write the cleanup by hand when neither the macro nor `async_drop_on_err` fits:
 
 ```rust
 async fn complex_operation(mut resource: AsyncDropGuard<Resource>) -> Result<Output> {
-    // Early return path 1
-    if !resource.is_valid() {
-        resource.async_drop().await?;
-        return Err(Error::Invalid);
-    }
-
-    // Main work
-    let result = match resource.process().await {
-        Ok(data) => data,
-        Err(e) => {
-            resource.async_drop().await?;  // Don't forget!
-            return Err(e.into());
-        }
-    };
-
-    // Success path
+    let result = resource.process().await;
     resource.async_drop().await?;
-    Ok(result)
+    result
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Types needing async cleanup use `AsyncDropGuard<T>`. See the async-drop skill fo
 - `async_drop()` consumes the guard: use-after-drop and double-drop are compile errors
 - Factory methods return `AsyncDropGuard<Self>`, never plain `Self`
 - Types with guard members must implement `AsyncDrop` to delegate: `async fn async_drop_impl(self)`, destructure `self` listing every field (no `..`), drop the guard members. No `#[async_trait]` on `AsyncDrop` impls
-- Use `with_async_drop_2!` macro when possible; otherwise call `async_drop()` on all exit paths
+- Use `with_async_drop!` macro when possible; otherwise call `async_drop()` on all exit paths
 - Panics are exceptions - ok to skip `async_drop()` on panic paths
 
 **Implementation**: `crates/utils/src/async_drop/`

--- a/crates/check/tests/common/entry_helpers.rs
+++ b/crates/check/tests/common/entry_helpers.rs
@@ -25,7 +25,7 @@ use cryfs_fsblobstore::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     path::AbsolutePathBuf,
-    with_async_drop_2,
+    with_async_drop,
 };
 use cryfs_utils::{data::Data, testutils::data_fixture::DataFixture};
 
@@ -941,7 +941,7 @@ where
     Box::pin(
         async move {
             let blob = fsblobstore.load(&dir_blob_id).await.unwrap().unwrap();
-            let (children, dir_children) = with_async_drop_2!(blob, {
+            let (children, dir_children) = with_async_drop!(blob, {
                 let blob = blob.as_dir().expect("Expected a directory blob");
                 let children = blob
                     .entries()
@@ -980,7 +980,7 @@ where
     Box::pin(
         async move {
             let blob = fsblobstore.load(&maybe_dir_blob_id).await.unwrap().unwrap();
-            with_async_drop_2!(blob, {
+            with_async_drop!(blob, {
                 if let Ok(blob) = blob.as_dir() {
                     let children = blob
                         .entries()

--- a/crates/check/tests/common/fixture.rs
+++ b/crates/check/tests/common/fixture.rs
@@ -19,7 +19,7 @@ use cryfs_utils::path::AbsolutePathBuf;
 use cryfs_utils::{
     async_drop::{AsyncDropGuard, SyncDrop},
     progress::SilentProgressBarManager,
-    with_async_drop_2,
+    with_async_drop,
 };
 use futures::{Future, future::BoxFuture, stream::StreamExt};
 use rand::{SeedableRng, rngs::SmallRng};
@@ -196,7 +196,7 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let root_blob = blobstore.load(&root_id).await.unwrap().unwrap();
                 let mut root = CreatedDirBlob::new(root_blob, AbsolutePathBuf::root());
-                with_async_drop_2!(root, {
+                with_async_drop!(root, {
                     Ok::<_, anyhow::Error>(
                         super::entry_helpers::create_some_blobs(blobstore, &mut root).await,
                     )
@@ -229,7 +229,7 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let parent_blob = blobstore.load(&parent.blob_id).await.unwrap().unwrap();
                 let mut parent = CreatedDirBlob::new(parent_blob, parent.referenced_as.path);
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let file =
                         super::entry_helpers::create_empty_file(blobstore, &mut parent, &name)
                             .await;
@@ -258,10 +258,10 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let parent_blob = blobstore.load(&parent.blob_id).await.unwrap().unwrap();
                 let mut parent = CreatedDirBlob::new(parent_blob, parent.referenced_as.path);
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let created_dir =
                         super::entry_helpers::create_empty_dir(blobstore, &mut parent, &name).await;
-                    with_async_drop_2!(created_dir, {
+                    with_async_drop!(created_dir, {
                         Ok::<_, anyhow::Error>((&*created_dir).into())
                     })
                 })
@@ -288,7 +288,7 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let parent_blob = blobstore.load(&parent.blob_id).await.unwrap().unwrap();
                 let mut parent_blob = CreatedDirBlob::new(parent_blob, parent.referenced_as.path);
-                with_async_drop_2!(parent_blob, {
+                with_async_drop!(parent_blob, {
                     let symlink = super::entry_helpers::create_symlink(
                         blobstore,
                         &mut parent_blob,
@@ -311,7 +311,7 @@ impl FilesystemFixture {
         self.update_fsblobstore(move |blobstore| {
             Box::pin(async move {
                 let mut parent = blobstore.load(&parent).await.unwrap().unwrap();
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let mut parent = parent.as_dir_mut().unwrap();
                     super::entry_helpers::add_file_entry(&mut parent, &name, blob_id);
                     Ok::<_, anyhow::Error>(())
@@ -327,7 +327,7 @@ impl FilesystemFixture {
         self.update_fsblobstore(move |blobstore| {
             Box::pin(async move {
                 let mut parent = blobstore.load(&parent).await.unwrap().unwrap();
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let mut parent = parent.as_dir_mut().unwrap();
                     super::entry_helpers::add_dir_entry(&mut parent, &name, blob_id);
                     Ok::<_, anyhow::Error>(())
@@ -343,7 +343,7 @@ impl FilesystemFixture {
         self.update_fsblobstore(move |blobstore| {
             Box::pin(async move {
                 let mut parent = blobstore.load(&parent).await.unwrap().unwrap();
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let mut parent = parent.as_dir_mut().unwrap();
                     super::entry_helpers::add_symlink_entry(&mut parent, &name, blob_id);
                     Ok::<_, anyhow::Error>(())
@@ -358,7 +358,7 @@ impl FilesystemFixture {
         self.update_fsblobstore(|fsblobstore| {
             Box::pin(async move {
                 let blob = fsblobstore.load(&dir_blob).await.unwrap().unwrap();
-                with_async_drop_2!(blob, {
+                with_async_drop!(blob, {
                     let blob = blob.as_dir().unwrap();
                     Ok::<_, anyhow::Error>(
                         blob.entries()
@@ -1028,7 +1028,7 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let dir = fsblobstore.load(&blob_info.blob_id).await.unwrap().unwrap();
                 let mut dir = CreatedDirBlob::new(dir, blob_info.referenced_as.path);
-                with_async_drop_2!(dir, {
+                with_async_drop!(dir, {
                     entry_helpers::add_entries_to_make_dir_large(fsblobstore, &mut dir).await;
                     Ok::<_, anyhow::Error>(())
                 })

--- a/crates/concurrent-store/src/inserting.rs
+++ b/crates/concurrent-store/src/inserting.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, hash::Hash};
 
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
-    safe_panic, with_async_drop_2_infallible,
+    safe_panic, with_async_drop_infallible,
 };
 
 use crate::{LoadedEntryGuard, entry::EntryLoadingWaiter, store::ConcurrentStoreInner};
@@ -60,7 +60,7 @@ where
         V: AsyncDrop + Debug + Send + Sync,
     {
         let InsertingInner { waiter, store } = self.inner.take().expect("Already destructed");
-        with_async_drop_2_infallible!(store, {
+        with_async_drop_infallible!(store, {
             Ok(waiter.wait_until_loaded(&store).await?.expect(
                 "Invariant violated: Inserting should never return None from the loading function",
             ))

--- a/crates/concurrent-store/src/loading_or_loaded.rs
+++ b/crates/concurrent-store/src/loading_or_loaded.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, hash::Hash};
 
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
-    safe_panic, with_async_drop_2_infallible,
+    safe_panic, with_async_drop_infallible,
 };
 
 use crate::{LoadedEntryGuard, entry::EntryLoadingWaiter, store::ConcurrentStoreInner};
@@ -69,7 +69,7 @@ where
             LoadingOrLoadedInner::NotFound => Ok(None),
             LoadingOrLoadedInner::Loaded(loaded) => Ok(Some(loaded)),
             LoadingOrLoadedInner::Loading { store, waiter } => {
-                with_async_drop_2_infallible!(store, { waiter.wait_until_loaded(&store).await })
+                with_async_drop_infallible!(store, { waiter.wait_until_loaded(&store).await })
             }
         }
     }

--- a/crates/concurrent-store/src/store.rs
+++ b/crates/concurrent-store/src/store.rs
@@ -17,7 +17,7 @@ use crate::guard::LoadedEntryGuard;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard};
 use cryfs_utils::event::Event;
 use cryfs_utils::stream::for_each_unordered;
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 
 // TODO This is currently not cancellation safe. If a task waiting for an entry to load is cancelled, the num_waiters and num_unfulfilled_waiters counts will be wrong.
 
@@ -379,7 +379,7 @@ where
     ) -> EntryStateLoading<V, E> {
         let inner = AsyncDropArc::clone(&self.inner);
         let loading_task = async move {
-            with_async_drop_2!(inner, {
+            with_async_drop!(inner, {
                 // Run loading_fn concurrently, without a lock on `entries`.
                 let result = loading_fn.await;
 
@@ -620,7 +620,7 @@ where
         let (immediate_drop_request, entry) = loaded.into_inner();
         let this = AsyncDropArc::clone(this);
         async move {
-            with_async_drop_2!(this, {
+            with_async_drop!(this, {
                 // This will be awaited after the lock on entries is released, so we can concurrently drop
                 // the entry without blocking other operations.
                 match immediate_drop_request {
@@ -655,7 +655,7 @@ where
     {
         let this = AsyncDropArc::clone(this);
         async move {
-            with_async_drop_2!(this, {
+            with_async_drop!(this, {
                 Self::_execute_immediate_drop(&this, key, None, drop_fn).await;
                 Ok(())
             })

--- a/crates/cryfs-filesystem/src/filesystem/device.rs
+++ b/crates/cryfs-filesystem/src/filesystem/device.rs
@@ -4,7 +4,7 @@ use atomic_time::AtomicInstant;
 use cryfs_blockstore::RemoveResult;
 use cryfs_rustfs::AtimeUpdateBehavior;
 use cryfs_rustfs::object_based_api::Dir as _;
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 use futures::join;
 use maybe_owned::MaybeOwned;
 use std::sync::Arc;
@@ -85,7 +85,7 @@ where
     pub async fn sanity_check(&self) -> Result<()> {
         // Make sure we can load the root dir and load its children
         let rootdir = self.rootdir().await.context("Didn't find root blob")?;
-        with_async_drop_2!(rootdir, {
+        with_async_drop!(rootdir, {
             rootdir.entries().await.context("Couldn't load root blob")?;
             Ok(())
         })
@@ -371,7 +371,7 @@ where
 
             match self.load_two_blobs(source_parent, dest_parent).await? {
                 LoadTwoBlobsResult::AreSameBlob(blob) => {
-                    with_async_drop_2!(
+                    with_async_drop!(
                         blob,
                         {
                             blob.with_lock(async |blob| {
@@ -402,7 +402,7 @@ where
                     //      blobs at once is risky for deadlocks if not done in a consistent order.
                     // TODO Improve concurrency in this function
 
-                    with_async_drop_2!(
+                    with_async_drop!(
                         source_parent_blob,
                         dest_parent_blob,
                         {
@@ -431,7 +431,7 @@ where
                                 .ok_or(FsError::NodeDoesNotExist)?;
 
                             // TODO Drop self_blob concurrently with source_parent_blob and dest_parent_blob
-                            with_async_drop_2!(
+                            with_async_drop!(
                                 self_blob,
                                 {
                                     source_parent_blob
@@ -589,7 +589,7 @@ where
                 FsError::NodeDoesNotExist,
             )?;
 
-        with_async_drop_2!(
+        with_async_drop!(
             overwritten_blob,
             {
                 overwritten_blob.with_lock(async |overwritten_blob| {

--- a/crates/cryfs-filesystem/src/filesystem/dir.rs
+++ b/crates/cryfs-filesystem/src/filesystem/dir.rs
@@ -21,7 +21,7 @@ use cryfs_rustfs::{DirEntry, FsError, FsResult, NodeAttrs, NodeKind, object_base
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard, flatten_async_drop},
     path::PathComponent,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 #[derive(Debug)]
@@ -253,7 +253,7 @@ where
         self.node_info
             .concurrently_update_modification_timestamp_in_parent(async || {
                 let blob = self.load_blob().await?;
-                with_async_drop_2!(
+                with_async_drop!(
                     blob,
                     {
                         blob.with_lock(async |blob| {
@@ -300,12 +300,12 @@ where
         //      blobs at once is risky for deadlocks if not done in a consistent order.
 
         // TODO Improve concurrency in this function
-        with_async_drop_2!(newparent, {
+        with_async_drop!(newparent, {
             let (source_parent, dest_parent) = join!(self.load_blob(), newparent.load_blob());
             let (source_parent, dest_parent) =
                 flatten_async_drop(source_parent, dest_parent).await?;
             // TODO Drop newparent and self_blob concurrently with source_parent and dest_parent
-            with_async_drop_2!(
+            with_async_drop!(
                 source_parent,
                 dest_parent,
                 {
@@ -341,7 +341,7 @@ where
                             // TODO This branch means there was an entry in the parent dir but the blob itself doesn't exist. How should we handle this?
                             FsError::NodeDoesNotExist,
                         )?;
-                    with_async_drop_2!(
+                    with_async_drop!(
                         self_blob,
                         {
                             let entry = source_parent
@@ -439,7 +439,7 @@ where
         self.node_info
             .concurrently_maybe_update_access_timestamp_in_parent(async || {
                 let blob = self.load_blob().await?;
-                with_async_drop_2!(
+                with_async_drop!(
                     blob,
                     {
                         blob.with_lock(async |blob| {
@@ -561,7 +561,7 @@ where
         self.node_info
             .concurrently_update_modification_timestamp_in_parent( async || {
                 let self_blob = self.load_blob().await?;
-                with_async_drop_2!(self_blob, {
+                with_async_drop!(self_blob, {
                     let child_id = self_blob
                         .with_lock(async |self_blob| {
                             let self_blob = Self::blob_as_dir(&*self_blob)?;
@@ -741,7 +741,7 @@ where
         self.node_info.concurrently_update_modification_timestamp_in_parent( async || {
             let blob = self.load_blob().await?;
 
-            with_async_drop_2!(blob, {
+            with_async_drop!(blob, {
                 let removed = blob.with_lock(async |blob| {
                     let blob = Self::blob_as_dir_mut(&mut *blob)?;
                     // First remove the entry, then flush that change, and only then remove the blob.

--- a/crates/cryfs-filesystem/src/filesystem/dir.rs
+++ b/crates/cryfs-filesystem/src/filesystem/dir.rs
@@ -303,9 +303,7 @@ where
         with_async_drop_2!(newparent, {
             let (source_parent, dest_parent) = join!(self.load_blob(), newparent.load_blob());
             let (source_parent, dest_parent) =
-                flatten_async_drop::<anyhow::Error, _, _, _, _>(source_parent, dest_parent)
-                    .await
-                    .map_err(FsError::internal_error)?;
+                flatten_async_drop(source_parent, dest_parent).await?;
             // TODO Drop newparent and self_blob concurrently with source_parent and dest_parent
             with_async_drop_2!(
                 source_parent,
@@ -491,13 +489,7 @@ where
                 };
                 // TODO Is this possible without to_owned()?
                 let name = name.to_owned();
-                let new_dir_blob_id = match new_dir_blob_id {
-                    Ok(new_dir_blob_id) => new_dir_blob_id,
-                    Err(err) => {
-                        blob.async_drop().await.map_err(FsError::internal_error)?;
-                        return Err(err);
-                    }
-                };
+                let (new_dir_blob_id, blob) = blob.async_drop_on_err(new_dir_blob_id).await?;
 
                 let atime = SystemTime::now();
                 let mtime = atime;
@@ -540,14 +532,14 @@ where
                     })
                     .await;
                 let attrs = match attrs {
-                    Ok(attrs) => attrs,
+                    Ok(attrs) => Ok(attrs),
                     Err(err) => {
                         log::error!("Error adding dir entry: {err:?}");
                         self.remove_just_created_blob(new_dir_blob_id).await;
-                        blob.async_drop().await.map_err(FsError::internal_error)?;
-                        return Err(FsError::UnknownError);
+                        Err(FsError::UnknownError)
                     }
                 };
+                let (attrs, blob) = blob.async_drop_on_err(attrs).await?;
                 let node = CryDir::new(
                     &self.blobstore,
                     AsyncDropArc::new(NodeInfo::new_non_root_dir(
@@ -597,10 +589,7 @@ where
                         }
                         Ok(())
                     }).await;
-                    if let Err(err) = entries_check {
-                        child_blob.async_drop().await.map_err(FsError::internal_error)?;
-                        return Err(err);
-                    }
+                    let ((), child_blob) = child_blob.async_drop_on_err(entries_check).await?;
 
                     // TODO We released the lock on self_blob above and are now re-locking it. There is a race condition here.
 
@@ -624,13 +613,8 @@ where
                             }
                         }
                     }).await;
-                    let removed_entry = match removed_entry {
-                        Ok(removed_entry) => removed_entry,
-                        Err(err) => {
-                            child_blob.async_drop().await.map_err(FsError::internal_error)?;
-                            return Err(err);
-                        }
-                    };
+                    let (removed_entry, child_blob) =
+                        child_blob.async_drop_on_err(removed_entry).await?;
                     assert_eq!(*removed_entry.blob_id(), child_blob.blob_id());
 
                     let remove_result = ConcurrentFsBlob::remove(child_blob).await;
@@ -683,14 +667,10 @@ where
                 };
                 // TODO Is this possible without to_owned()?
                 let name = name.to_owned();
-                let new_symlink_blob_id = match new_symlink_blob_id {
-                    Ok(id) => id,
-                    Err(err) => {
-                        log::error!("Error creating symlink blob: {err:?}");
-                        blob.async_drop().await.map_err(FsError::internal_error)?;
-                        return Err(err);
-                    }
-                };
+                let new_symlink_blob_id = new_symlink_blob_id
+                    .inspect_err(|err| log::error!("Error creating symlink blob: {err:?}"));
+                let (new_symlink_blob_id, blob) =
+                    blob.async_drop_on_err(new_symlink_blob_id).await?;
 
                 let atime = SystemTime::now();
                 let mtime = atime;
@@ -732,14 +712,14 @@ where
                     })
                     .await;
                 let attrs = match attrs {
-                    Ok(attrs) => attrs,
+                    Ok(attrs) => Ok(attrs),
                     Err(err) => {
                         log::error!("Error adding dir entry: {err:?}");
                         self.remove_just_created_blob(new_symlink_blob_id).await;
-                        blob.async_drop().await.map_err(FsError::internal_error)?;
-                        return Err(FsError::UnknownError);
+                        Err(FsError::UnknownError)
                     }
                 };
+                let (attrs, blob) = blob.async_drop_on_err(attrs).await?;
                 let node = CrySymlink::new(
                     &self.blobstore,
                     AsyncDropArc::new(NodeInfo::new_non_root_dir(
@@ -829,13 +809,7 @@ where
                     }
                 };
 
-                let new_file_blob_id = match new_file_blob_id {
-                    Ok(id) => id,
-                    Err(err) => {
-                        blob.async_drop().await.map_err(FsError::internal_error)?;
-                        return Err(err);
-                    }
-                };
+                let (new_file_blob_id, blob) = blob.async_drop_on_err(new_file_blob_id).await?;
 
                 let atime = SystemTime::now();
                 let mtime = atime;
@@ -877,14 +851,14 @@ where
                     })
                     .await;
                 let attrs = match attrs {
-                    Ok(attrs) => attrs,
+                    Ok(attrs) => Ok(attrs),
                     Err(err) => {
                         log::error!("Error adding dir entry: {err:?}");
                         self.remove_just_created_blob(new_file_blob_id).await;
-                        blob.async_drop().await.map_err(FsError::internal_error)?;
-                        return Err(FsError::UnknownError);
+                        Err(FsError::UnknownError)
                     }
                 };
+                let (attrs, blob) = blob.async_drop_on_err(attrs).await?;
                 let node_info = AsyncDropArc::new(NodeInfo::new_non_root_dir(
                     blob,
                     #[cfg(feature = "ancestor_checks_on_move")]

--- a/crates/cryfs-filesystem/src/filesystem/node.rs
+++ b/crates/cryfs-filesystem/src/filesystem/node.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 #[cfg(feature = "testutils")]
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 #[cfg(feature = "testutils")]
 use futures::join;
 use std::fmt::Debug;
@@ -65,7 +65,7 @@ where
     async fn flush_blob(&self) -> FsResult<()> {
         // TODO We'd only have to flush it if it's actually in some cache, but it might be far down the stack in some blockstore cache.
         let blob = self.node_info.load_blob(&self.blobstore).await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |blob| {

--- a/crates/cryfs-filesystem/src/filesystem/node_info.rs
+++ b/crates/cryfs-filesystem/src/filesystem/node_info.rs
@@ -1,4 +1,4 @@
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 use std::fmt::Debug;
 use std::time::SystemTime;
 use tokio::join;
@@ -320,7 +320,7 @@ where
         new_size: NumBytes,
     ) -> FsResult<()> {
         let blob = self.load_blob(blobstore).await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |mut blob| {

--- a/crates/cryfs-filesystem/src/filesystem/open_file.rs
+++ b/crates/cryfs-filesystem/src/filesystem/open_file.rs
@@ -10,7 +10,7 @@ use cryfs_rustfs::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
     data::Data,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 use super::node_info::NodeInfo;
@@ -65,7 +65,7 @@ where
 
     async fn flush_file_contents(&self) -> FsResult<()> {
         let blob = self.load_blob().await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |mut blob| {
@@ -89,7 +89,7 @@ where
 
     async fn _read(&self, offset: NumBytes, size: NumBytes) -> FsResult<Data> {
         let blob = self.load_blob().await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |mut blob| {
@@ -119,7 +119,7 @@ where
 
     async fn _write(&self, offset: NumBytes, data: Data) -> FsResult<()> {
         let blob = self.load_blob().await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |mut blob| {

--- a/crates/cryfs-filesystem/src/filesystem/symlink.rs
+++ b/crates/cryfs-filesystem/src/filesystem/symlink.rs
@@ -11,7 +11,7 @@ use cryfs_blobstore::BlobStore;
 use cryfs_rustfs::{FsError, FsResult, object_based_api::Symlink};
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
-    with_async_drop_2,
+    with_async_drop,
 };
 
 #[derive(Debug)]
@@ -72,7 +72,7 @@ where
         self.node_info
             .concurrently_maybe_update_access_timestamp_in_parent(async || {
                 let blob = self.load_blob().await?;
-                with_async_drop_2!(
+                with_async_drop!(
                     blob,
                     {
                         blob.with_lock(async |mut blob| {

--- a/crates/fsblobstore/src/concurrentfsblobstore/store.rs
+++ b/crates/fsblobstore/src/concurrentfsblobstore/store.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 use cryfs_blobstore::{BlobId, BlobStore, RemoveResult};
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
-    with_async_drop_2,
+    with_async_drop,
 };
 
 use crate::{
@@ -46,7 +46,7 @@ where
         let root_blob_id = *root_blob_id;
         let blobstore = AsyncDropArc::clone(&self.blobstore);
         LoadedBlobs::try_insert_loading(&self.loaded_blobs, root_blob_id, async move || {
-            with_async_drop_2!(blobstore, {
+            with_async_drop!(blobstore, {
                 blobstore.create_root_dir_blob(&root_blob_id).await
             })
             .map_err(Arc::new)
@@ -110,7 +110,7 @@ where
             blob_id,
             &self.blobstore,
             async move |blobstore| {
-                with_async_drop_2!(blobstore, { blobstore.load(&blob_id).await }).map_err(Arc::new)
+                with_async_drop!(blobstore, { blobstore.load(&blob_id).await }).map_err(Arc::new)
             },
         )
         .await?;

--- a/crates/rustfs/examples/inmemory/device.rs
+++ b/crates/rustfs/examples/inmemory/device.rs
@@ -10,7 +10,7 @@ use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     mutex::lock_in_ptr_order,
     path::AbsolutePath,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 use super::dir::{DirInode, InMemoryDirRef};
@@ -118,17 +118,17 @@ impl Device for InMemoryDevice {
                 return Err(FsError::InvalidOperation);
             };
             let new_parent = self.rootdir.load_node(new_parent_path)?;
-            with_async_drop_2!(new_parent, {
+            with_async_drop!(new_parent, {
                 let new_parent = new_parent.as_dir().await?;
-                with_async_drop_2!(new_parent, {
+                with_async_drop!(new_parent, {
                     if old_parent_path == new_parent_path {
                         // We're just renaming it within one directory
                         new_parent.rename(old_name, new_name)
                     } else {
                         let source_parent = self.rootdir.load_node(old_parent_path)?;
-                        with_async_drop_2!(source_parent, {
+                        with_async_drop!(source_parent, {
                             let source_parent = source_parent.as_dir().await?;
-                            with_async_drop_2!(source_parent, {
+                            with_async_drop!(source_parent, {
                                 // We're moving it to another directory
                                 let (mut source_inode, mut target_inode) =
                                     lock_in_ptr_order(&source_parent.inode(), &new_parent.inode());

--- a/crates/rustfs/examples/inmemory/dir.rs
+++ b/crates/rustfs/examples/inmemory/dir.rs
@@ -7,7 +7,7 @@ use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     mutex::lock_in_ptr_order,
     path::{PathComponent, PathComponentBuf},
-    with_async_drop_2,
+    with_async_drop,
 };
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
@@ -194,7 +194,7 @@ impl Dir for InMemoryDirRef {
         newparent: AsyncDropGuard<Self>,
         newname: &PathComponent,
     ) -> FsResult<()> {
-        with_async_drop_2!(newparent, {
+        with_async_drop!(newparent, {
             // We're moving it to another directory
             let (mut source_inode, mut target_inode) =
                 lock_in_ptr_order(&self.inode(), &newparent.inode());

--- a/crates/rustfs/examples/passthrough/dir.rs
+++ b/crates/rustfs/examples/passthrough/dir.rs
@@ -6,7 +6,7 @@ use cryfs_rustfs::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     path::{AbsolutePathBuf, PathComponent},
-    with_async_drop_2,
+    with_async_drop,
 };
 use nix::fcntl::{AT_FDCWD, AtFlags};
 use std::os::unix::fs::OpenOptionsExt;
@@ -63,7 +63,7 @@ impl Dir for PassthroughDir {
         newparent: AsyncDropGuard<Self>,
         newname: &PathComponent,
     ) -> FsResult<()> {
-        with_async_drop_2!(newparent, {
+        with_async_drop!(newparent, {
             let old_path = self.path.clone().push(oldname);
             let new_path = newparent.path.clone().push(newname);
             tokio::fs::rename(old_path, new_path).await.map_error()
@@ -134,7 +134,7 @@ impl Dir for PassthroughDir {
         let node = PassthroughDir::new(path.clone());
         // TODO Return value directly without another call but make sure it returns the same value
         let child_node = PassthroughNode::new(path);
-        let attrs = with_async_drop_2!(child_node, { child_node.getattr().await })?;
+        let attrs = with_async_drop!(child_node, { child_node.getattr().await })?;
         Ok((attrs, AsyncDropGuard::new(node)))
     }
 
@@ -172,7 +172,7 @@ impl Dir for PassthroughDir {
             .map_err(|_: tokio::task::JoinError| FsError::UnknownError)??;
         // TODO Return value directly without another call but make sure it returns the same value
         let node = PassthroughNode::new(path);
-        with_async_drop_2!(node, {
+        with_async_drop!(node, {
             let attrs = node.getattr().await?;
             let symlink = node.as_symlink().await?;
             Ok((attrs, symlink))

--- a/crates/rustfs/src/object_based_api/high_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/high_level_adapter.rs
@@ -768,7 +768,6 @@ where
             .expect("ObjectBasedFsAdapter::fs is never shared, so this must be the last reference to it")
             .into_inner()
             .unwrap();
-        fs.async_drop().await.map_err(|err| err)?;
-        Ok(())
+        fs.async_drop().await
     }
 }

--- a/crates/rustfs/src/object_based_api/high_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/high_level_adapter.rs
@@ -15,7 +15,7 @@ use crate::high_level_api::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     path::AbsolutePath,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 // TODO Make sure each function checks the preconditions on its parameters, e.g. paths must be absolute, here and elsewhere.
@@ -135,7 +135,7 @@ where
             // TODO No unwrap
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, { node.getattr().await })?
+            with_async_drop!(node, { node.getattr().await })?
         };
         Ok(AttrResponse {
             ttl: TTL_GETATTR,
@@ -164,7 +164,7 @@ where
         } else {
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(Some(mode), None, None, None, None, None, None)
                     .await
             })?;
@@ -193,7 +193,7 @@ where
         } else {
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(None, uid, gid, None, None, None, None).await
             })?;
         }
@@ -221,7 +221,7 @@ where
         } else {
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(None, None, None, Some(size), None, None, None)
                     .await
             })?;
@@ -250,7 +250,7 @@ where
         } else {
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(None, None, None, None, atime, mtime, None)
                     .await
             })?;
@@ -279,9 +279,9 @@ where
 
         let fs = self.fs.read().unwrap();
         let link = fs.get().lookup(path).await?;
-        with_async_drop_2!(link, {
+        with_async_drop!(link, {
             let link = link.as_symlink().await?;
-            with_async_drop_2!(link, { link.target().await })
+            with_async_drop!(link, { link.target().await })
         })
     }
 
@@ -314,9 +314,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_child_dir() ?
                 // TODO No need to return the child dir object to just immediately async_drop it
                 let (new_dir_attrs, new_dir) = parent_dir
@@ -341,9 +341,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 parent_dir.remove_child_file_or_symlink(&name).await
             })?;
             Ok(())
@@ -360,9 +360,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            with_async_drop_2!(parent_dir, { parent_dir.remove_child_dir(&name).await })?;
+            with_async_drop!(parent_dir, { parent_dir.remove_child_dir(&name).await })?;
             Ok(())
         })
     }
@@ -383,9 +383,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_child_symlink() ?
                 // TODO No need to return the symlink object to just immediately async_drop it
                 let (new_symlink_attrs, symlink) = parent_dir
@@ -444,7 +444,7 @@ where
 
         let fs = self.fs.read().unwrap();
         let file = fs.get().lookup(path).await?;
-        with_async_drop_2!(file, {
+        with_async_drop!(file, {
             let file = file.as_file().await?;
             let result = match File::into_open(file, flags).await {
                 Err(err) => Err(err),
@@ -589,9 +589,9 @@ where
 
         let fs = self.fs.read().unwrap();
         let dir = fs.get().lookup(path).await?;
-        with_async_drop_2!(dir, {
+        with_async_drop!(dir, {
             let dir = dir.as_dir().await?;
-            let entries = with_async_drop_2!(dir, { dir.entries().await })?;
+            let entries = with_async_drop!(dir, { dir.entries().await })?;
             let parent_entries = [
                 DirEntryOrReference::SelfReference,
                 DirEntryOrReference::ParentReference,
@@ -733,9 +733,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            let (file_attrs, node, open_file) = with_async_drop_2!(parent_dir, {
+            let (file_attrs, node, open_file) = with_async_drop!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_and_open_file() ?
                 // TODO No need to return the node just to immediately async_drop it below
                 parent_dir

--- a/crates/rustfs/src/object_based_api/interface/device.rs
+++ b/crates/rustfs/src/object_based_api/interface/device.rs
@@ -7,7 +7,7 @@ use crate::common::{FsError, FsResult, Statfs};
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     path::AbsolutePath,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 // TODO We only call this `Device` because that's the historical name from the c++ Cryfs version. We should probably rename this to `Filesystem`.
@@ -74,7 +74,7 @@ pub trait Device {
                         match dir {
                             Ok(dir) => {
                                 // TODO Can we avoid the async_drop here by using something like dir.into_lookup_child() ?
-                                with_async_drop_2!(dir, {
+                                with_async_drop!(dir, {
                                     let child = dir.lookup_child(component);
                                     child.await
                                 })
@@ -91,7 +91,7 @@ pub trait Device {
                     match dir {
                         Ok(dir) => {
                             // TODO Can we avoid the async_drop here by using something like dir.into_lookup_child() ?
-                            with_async_drop_2!(dir, {
+                            with_async_drop!(dir, {
                                 let child = dir.lookup_child(node_name);
                                 child.await
                             })

--- a/crates/rustfs/src/object_based_api/low_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/low_level_adapter.rs
@@ -531,8 +531,7 @@ where
         } else {
             let (oldparent, newparent) =
                 join!(self.get_inode(oldparent_ino), self.get_inode(newparent_ino));
-            let (oldparent, newparent) =
-                flatten_async_drop::<FsError, _, _, _, _>(oldparent, newparent).await?;
+            let (oldparent, newparent) = flatten_async_drop(oldparent, newparent).await?;
             let result = async {
                 let oldparent_dir = oldparent.as_dir().await?;
                 with_async_drop_2!(oldparent_dir, {

--- a/crates/rustfs/src/object_based_api/low_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/low_level_adapter.rs
@@ -26,7 +26,7 @@ use crate::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard, async_drop_all, flatten_async_drop},
     path::PathComponent,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 // TODO What are good TTLs here?
@@ -230,12 +230,12 @@ where
         let load_child = move |parent_node: &AsyncDropGuard<AsyncDropArc<Fs::Node>>| {
             let parent_node = AsyncDropArc::clone(parent_node); // TODO Why is this necessary?
             async move {
-                with_async_drop_2!(parent_node, {
+                with_async_drop!(parent_node, {
                     let parent_node_dir = parent_node
                         .as_dir()
                         .await
                         .expect("Error: Inode number is not a directory");
-                    with_async_drop_2!(parent_node_dir, {
+                    with_async_drop!(parent_node_dir, {
                         // TODO Can we avoid the async_drop here by using something like parent_node_dir.into_lookup_child() ?
                         parent_node_dir.lookup_child(&name_clone).await
                     })
@@ -248,7 +248,7 @@ where
             .add_or_increment_refcount(parent_ino, name.to_owned(), load_child)
             .await?;
 
-        with_async_drop_2!(child, {
+        with_async_drop!(child, {
             child.getattr().await.map(|attr| ReplyEntry {
                 ttl: TTL_LOOKUP,
                 ino,
@@ -288,7 +288,7 @@ where
                 .await?
         } else {
             let node = self.get_inode(ino).await?;
-            with_async_drop_2!(node, { node.getattr().await })?
+            with_async_drop!(node, { node.getattr().await })?
         };
 
         Ok(ReplyAttr {
@@ -328,7 +328,7 @@ where
                 .await?
         } else {
             let node = self.get_inode(ino).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(mode, uid, gid, size, atime, mtime, ctime)
                     .await
             })?
@@ -358,7 +358,7 @@ where
             Err(err) => return callback.call(Err(err)),
         };
         let target = match inode.as_symlink().await {
-            Ok(inode_symlink) => with_async_drop_2!(inode_symlink, {
+            Ok(inode_symlink) => with_async_drop!(inode_symlink, {
                 let target = inode_symlink.target();
                 target.await
             }),
@@ -403,11 +403,11 @@ where
         // In my tests with fuser 0.12.0, umask is already auto-applied to mode and the `umask` argument is always `0`.
         // TODO see https://github.com/cberner/fuser/issues/256
         let parent = self.get_inode(parent_ino).await?;
-        let (attr, child) = with_async_drop_2!(parent, {
+        let (attr, child) = with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
 
             // TODO Can we avoid the async_drop here by using something like dir.into_create_child_dir() ?
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 let (attrs, child) = parent_dir
                     .create_child_dir(name, mode, req.uid, req.gid)
                     .await?;
@@ -436,9 +436,9 @@ where
         self.trigger_on_operation().await?;
 
         let parent = self.get_inode(parent_ino).await?;
-        with_async_drop_2!(parent, {
+        with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 parent_dir.remove_child_file_or_symlink(name).await?;
                 self._orphan_inode(parent_ino, name).await;
                 Ok::<_, FsError>(())
@@ -456,9 +456,9 @@ where
         self.trigger_on_operation().await?;
 
         let parent = self.get_inode(parent_ino).await?;
-        with_async_drop_2!(parent, {
+        with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 parent_dir.remove_child_dir(name).await?;
                 self._orphan_inode(parent_ino, name).await;
                 Ok::<_, FsError>(())
@@ -479,10 +479,10 @@ where
         // TODO Here (and maybe also in mkdir / create_file), existing nodes should be overwritten
 
         let parent = self.get_inode(parent_ino).await?;
-        let (attrs, child) = with_async_drop_2!(parent, {
+        let (attrs, child) = with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
             // TODO Can we avoid the async_drop here by using something like dir.into_create_child_symlink()?
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 let (attrs, child) = parent_dir
                     .create_child_symlink(name, link, req.uid, req.gid)
                     .await?;
@@ -518,9 +518,9 @@ where
         // TODO Check that oldparent+oldname/newparent+newname aren't ancestors of each other, or at least write a test that fuse already blocks that
         if oldparent_ino == newparent_ino {
             let shared_parent = self.get_inode(oldparent_ino).await?;
-            with_async_drop_2!(shared_parent, {
+            with_async_drop!(shared_parent, {
                 let parent_dir = shared_parent.as_dir().await?;
-                with_async_drop_2!(parent_dir, {
+                with_async_drop!(parent_dir, {
                     parent_dir.rename_child(oldname, newname).await?;
                     self._move_inode(oldparent_ino, oldname, newparent_ino, newname)
                         .await?;
@@ -534,7 +534,7 @@ where
             let (oldparent, newparent) = flatten_async_drop(oldparent, newparent).await?;
             let result = async {
                 let oldparent_dir = oldparent.as_dir().await?;
-                with_async_drop_2!(oldparent_dir, {
+                with_async_drop!(oldparent_dir, {
                     let newparent_dir = newparent.as_dir().await?;
                     oldparent_dir
                         .move_child_to(oldname, newparent_dir, newname)
@@ -572,7 +572,7 @@ where
         self.trigger_on_operation().await?;
 
         let inode = self.get_inode(ino).await?;
-        with_async_drop_2!(inode, {
+        with_async_drop!(inode, {
             let file = inode.as_file().await?;
             let open_file = File::into_open(file, flags);
             let open_file = open_file.await?;
@@ -674,7 +674,7 @@ where
 
         // TODO What to do with flags, lock_owner?
         let open_file = self.open_files.remove(fh);
-        with_async_drop_2!(open_file, {
+        with_async_drop!(open_file, {
             if flush {
                 // TODO Is this actually what the `flush` parameter should do?
                 open_file.flush().await?;
@@ -738,9 +738,9 @@ where
 
         let (node, parent_ino) = self.get_inode_and_parent_ino(ino).await?;
 
-        with_async_drop_2!(node, {
+        with_async_drop!(node, {
             let dir = node.as_dir().await?;
-            with_async_drop_2!(dir, {
+            with_async_drop!(dir, {
                 let offset = usize::try_from(offset).unwrap(); // TODO No unwrap
 
                 if offset == 0 {
@@ -954,10 +954,10 @@ where
         // In my tests with fuser 0.12.0, umask is already auto-applied to mode and the `umask` argument is always `0`.
         // TODO see https://github.com/cberner/fuser/issues/256
         let parent = self.get_inode(parent_ino).await?;
-        with_async_drop_2!(parent, {
+        with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
             // TODO Can we avoid the async_drop here by using something like dir.into_create_and_open_file() ?
-            let (attr, child_node, open_file) = with_async_drop_2!(parent_dir, {
+            let (attr, child_node, open_file) = with_async_drop!(parent_dir, {
                 parent_dir
                     .create_and_open_file(name, mode, req.uid, req.gid, flags)
                     .await

--- a/crates/rustfs/src/object_based_api/utils/inode_list/mod.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/mod.rs
@@ -3,7 +3,7 @@ use core::panic;
 use cryfs_concurrent_store::RequestImmediateDropResult;
 use cryfs_concurrent_store::{ConcurrentStore, LoadedEntryGuard};
 use cryfs_utils::stream::for_each_unordered;
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 use derive_more::{Display, Error};
 use futures::future::BoxFuture;
 use futures::{FutureExt, future};
@@ -212,7 +212,7 @@ where
         ino: InodeNumber,
     ) -> FsResult<AsyncDropGuard<AsyncDropArc<Fs::Node>>> {
         let node = Self::_lookup_node(inner, ino)?;
-        with_async_drop_2!(node, {
+        with_async_drop!(node, {
             let inode_entry = AsyncDropArc::clone(node.value());
             Ok(inode_entry)
         })
@@ -229,7 +229,7 @@ where
 
         // TODO This Arc::clone is only necessary because MutexGuard can't project and get &mut on both inner.inodes and inner.inode_forest at the same time. Once Rust supports that, we can avoid this clone.
         let inodes = inner.inodes.clone_ref();
-        with_async_drop_2!(inodes, {
+        with_async_drop!(inodes, {
             let insert_result = inner
                 .inode_forest
                 .try_insert(parent_ino, name, node, async |node, new_child_ino| {
@@ -357,9 +357,9 @@ where
             >,
         >,
     ) -> FsResult<AsyncDropGuard<AsyncDropArc<Fs::Node>>> {
-        with_async_drop_2!(node_future, {
+        with_async_drop!(node_future, {
             let node = (&mut *node_future).await;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 match node.as_inner() {
                     Err(err) => Err(err.clone()),
                     Ok(node) => Ok(AsyncDropArc::clone(node.value())),
@@ -399,7 +399,7 @@ where
 
         // TODO This Arc::clone is only necessary because MutexGuard can't project and get &mut on both inner.inodes and inner.inode_forest at the same time. Once Rust supports that, we can avoid this clone.
         let inodes = inner.inodes.clone_ref();
-        let (new_child_ino, new_node) = with_async_drop_2!(inodes, {
+        let (new_child_ino, new_node) = with_async_drop!(inodes, {
             let insert_result =
                 inner
                     .inode_forest
@@ -413,7 +413,7 @@ where
                                 // It's ok to capture the parent_node in this lambda, because
                                 // * If try_insert returns Ok, it always executes the lambda and we async_drop it here
                                 // * If try_insert returns Err, the lambda is never executed, but we panic below anyways.
-                                with_async_drop_2!(parent_node, {
+                                with_async_drop!(parent_node, {
                                     let node = loading_fn(&parent_node).await?;
                                     Ok(node)
                                 })
@@ -861,7 +861,7 @@ where
             use crate::object_based_api::Node as _;
 
             let guard = inode.wait_until_loaded().await.unwrap().unwrap();
-            with_async_drop_2!(guard, { guard.value().fsync(false).await })
+            with_async_drop!(guard, { guard.value().fsync(false).await })
         })
         .await?;
         Ok(())

--- a/crates/utils/src/async_drop/all.rs
+++ b/crates/utils/src/async_drop/all.rs
@@ -1,7 +1,7 @@
 //! Dropping several [AsyncDropGuard]s at once.
 //!
 //! [async_drop_all] takes a tuple of guards, drops all of them concurrently, and waits for
-//! all of them even if some fail. See [with_async_drop_2!](crate::with_async_drop_2) for the
+//! all of them even if some fail. See [with_async_drop!](crate::with_async_drop) for the
 //! macro form that also runs a block of code before dropping.
 
 use std::fmt::Debug;

--- a/crates/utils/src/async_drop/async_drop_guard.rs
+++ b/crates/utils/src/async_drop/async_drop_guard.rs
@@ -94,6 +94,52 @@ impl<T: Debug + AsyncDrop> AsyncDropGuard<T> {
     pub fn async_drop(self) -> impl Future<Output = Result<(), T::Error>> + Send {
         self.into_inner_unchecked().async_drop_impl()
     }
+
+    /// Drops the guard if `result` is an error, otherwise hands the value and the guard back.
+    ///
+    /// This is for functions that keep the guard on their success path (e.g. move it into a
+    /// new object) but have to drop it on every error path:
+    ///
+    /// ```
+    /// # use cryfs_utils::async_drop::{AsyncDrop, AsyncDropGuard};
+    /// # #[derive(Debug)] struct Blob;
+    /// # impl AsyncDrop for Blob {
+    /// #     type Error = std::convert::Infallible;
+    /// #     async fn async_drop_impl(self) -> Result<(), Self::Error> { Ok(()) }
+    /// # }
+    /// # struct Node { blob: AsyncDropGuard<Blob> }
+    /// # async fn load_blob() -> AsyncDropGuard<Blob> { AsyncDropGuard::new(Blob) }
+    /// # async fn create_child() -> Result<u32, &'static str> { Ok(1) }
+    /// # async fn example() -> Result<Node, &'static str> {
+    /// let blob = load_blob().await;
+    /// // If `create_child` failed, `blob` is dropped and the error is returned here.
+    /// let (child_id, blob) = blob.async_drop_on_err(create_child().await).await?;
+    /// Ok(Node { blob })
+    /// # }
+    /// # futures::executor::block_on(async { example().await.unwrap().blob.async_drop().await.unwrap() });
+    /// ```
+    ///
+    /// If dropping fails on the error path, the drop error is logged and the original error
+    /// is still returned, because that is the error the caller needs to know about.
+    pub async fn async_drop_on_err<R, E>(self, result: Result<R, E>) -> Result<(R, Self), E> {
+        match result {
+            Ok(value) => Ok((value, self)),
+            Err(error) => {
+                self.async_drop_on_error_path().await;
+                Err(error)
+            }
+        }
+    }
+
+    /// Drops the guard while already handling another error. A failure to drop is logged
+    /// instead of returned, so that the original error stays the one that gets reported.
+    pub(super) async fn async_drop_on_error_path(self) {
+        if let Err(drop_error) = self.async_drop().await {
+            log::error!(
+                "Error while dropping a value on an error path. Reporting the original error instead. Drop error: {drop_error:?}"
+            );
+        }
+    }
 }
 
 impl<T: Debug> Drop for AsyncDropGuard<T> {
@@ -133,7 +179,8 @@ mod tests {
 
     use std::fmt::{self, Debug};
     use std::future::Future;
-    use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicI32, AtomicUsize, Ordering};
 
     struct MyStructWithDrop<F, FA, FS>
     where
@@ -281,5 +328,78 @@ mod tests {
         });
         assert_eq!(Err("My error"), obj.async_drop().await);
         assert_eq!(true, called.load(Ordering::SeqCst));
+    }
+
+    #[derive(Debug)]
+    struct CountingValue {
+        drop_counter: Arc<AtomicUsize>,
+        fail_drop: bool,
+    }
+
+    impl AsyncDrop for CountingValue {
+        type Error = &'static str;
+
+        async fn async_drop_impl(self) -> Result<(), Self::Error> {
+            self.drop_counter.fetch_add(1, Ordering::SeqCst);
+            if self.fail_drop {
+                Err("drop error")
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn given_ok_result_when_async_drop_on_err_then_value_and_guard_are_returned_undropped() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let guard = AsyncDropGuard::new(CountingValue {
+            drop_counter: Arc::clone(&counter),
+            fail_drop: false,
+        });
+
+        let (value, guard) = guard
+            .async_drop_on_err(Ok::<_, &'static str>(42))
+            .await
+            .unwrap();
+
+        assert_eq!(42, value);
+        assert_eq!(0, counter.load(Ordering::SeqCst));
+
+        guard.async_drop().await.unwrap();
+        assert_eq!(1, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_err_result_when_async_drop_on_err_then_guard_is_dropped_and_error_returned() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let guard = AsyncDropGuard::new(CountingValue {
+            drop_counter: Arc::clone(&counter),
+            fail_drop: false,
+        });
+
+        let result = guard
+            .async_drop_on_err(Err::<i32, _>("original error"))
+            .await;
+
+        assert_eq!("original error", result.unwrap_err());
+        assert_eq!(1, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn given_err_result_and_failing_drop_when_async_drop_on_err_then_original_error_returned()
+    {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let guard = AsyncDropGuard::new(CountingValue {
+            drop_counter: Arc::clone(&counter),
+            fail_drop: true,
+        });
+
+        let result = guard
+            .async_drop_on_err(Err::<i32, _>("original error"))
+            .await;
+
+        // The drop error is only logged, the original error is what the caller gets
+        assert_eq!("original error", result.unwrap_err());
+        assert_eq!(1, counter.load(Ordering::SeqCst));
     }
 }

--- a/crates/utils/src/async_drop/flatten.rs
+++ b/crates/utils/src/async_drop/flatten.rs
@@ -14,31 +14,34 @@ use super::{AsyncDrop, AsyncDropGuard};
 /// - Both Ok: returns both values as a tuple
 /// - First Ok, Second Err: drops the first value, returns the second error
 /// - First Err, Second Ok: drops the second value, returns the first error
-/// - Both Err: returns the first error (second error is currently lost)
-pub async fn flatten_async_drop<E, T, E1, U, E2>(
-    first: Result<AsyncDropGuard<T>, E1>,
-    second: Result<AsyncDropGuard<U>, E2>,
+/// - Both Err: returns the first error and logs the second one
+///
+/// The error type is the one of the two inputs. If dropping a value fails while an error
+/// is already being returned, the drop error is logged and the original error is returned.
+pub async fn flatten_async_drop<E, T, U>(
+    first: Result<AsyncDropGuard<T>, E>,
+    second: Result<AsyncDropGuard<U>, E>,
 ) -> Result<(AsyncDropGuard<T>, AsyncDropGuard<U>), E>
 where
+    E: Debug,
     T: AsyncDrop + Debug,
     U: AsyncDrop + Debug,
-    E: From<E1> + From<E2> + From<<T as AsyncDrop>::Error> + From<<U as AsyncDrop>::Error>,
 {
     match (first, second) {
         (Ok(first), Ok(second)) => Ok((first, second)),
-        (Ok(first), Err(second)) => {
-            // TODO Report both errors if async_drop fails
-            first.async_drop().await?;
-            Err(second.into())
+        (Ok(first), Err(second_error)) => {
+            first.async_drop_on_error_path().await;
+            Err(second_error)
         }
-        (Err(first), Ok(second)) => {
-            // TODO Report both errors if async_drop fails
-            second.async_drop().await?;
-            Err(first.into())
+        (Err(first_error), Ok(second)) => {
+            second.async_drop_on_error_path().await;
+            Err(first_error)
         }
-        (Err(first), Err(_second)) => {
-            // TODO Report both errors
-            Err(first.into())
+        (Err(first_error), Err(second_error)) => {
+            log::error!(
+                "Two operations failed. Reporting only the first error. Second error: {second_error:?}"
+            );
+            Err(first_error)
         }
     }
 }
@@ -53,11 +56,27 @@ mod tests {
     struct TestValue {
         id: &'static str,
         drop_counter: Arc<AtomicUsize>,
+        fail_drop: bool,
     }
 
     impl TestValue {
-        fn new(id: &'static str, drop_counter: Arc<AtomicUsize>) -> AsyncDropGuard<Self> {
-            AsyncDropGuard::new(Self { id, drop_counter })
+        fn new(id: &'static str, drop_counter: &Arc<AtomicUsize>) -> AsyncDropGuard<Self> {
+            AsyncDropGuard::new(Self {
+                id,
+                drop_counter: Arc::clone(drop_counter),
+                fail_drop: false,
+            })
+        }
+
+        fn with_failing_drop(
+            id: &'static str,
+            drop_counter: &Arc<AtomicUsize>,
+        ) -> AsyncDropGuard<Self> {
+            AsyncDropGuard::new(Self {
+                id,
+                drop_counter: Arc::clone(drop_counter),
+                fail_drop: true,
+            })
         }
     }
 
@@ -66,33 +85,31 @@ mod tests {
 
         async fn async_drop_impl(self) -> Result<(), Self::Error> {
             self.drop_counter.fetch_add(1, Ordering::SeqCst);
-            Ok(())
+            if self.fail_drop {
+                Err("drop error")
+            } else {
+                Ok(())
+            }
         }
     }
 
-    #[derive(Debug)]
+    /// An error type that is unrelated to the guards' `&'static str` drop error,
+    /// so the tests show that the error type is taken from the inputs alone.
+    #[derive(Debug, PartialEq, Eq)]
     struct TestError(&'static str);
-
-    impl From<&'static str> for TestError {
-        fn from(s: &'static str) -> Self {
-            TestError(s)
-        }
-    }
 
     #[tokio::test]
     async fn test_both_ok() {
         let counter = Arc::new(AtomicUsize::new(0));
-        let first = TestValue::new("first", Arc::clone(&counter));
-        let second = TestValue::new("second", Arc::clone(&counter));
+        let first = TestValue::new("first", &counter);
+        let second = TestValue::new("second", &counter);
 
-        let first_result: Result<_, &'static str> = Ok(first);
-        let second_result: Result<_, &'static str> = Ok(second);
-        let result: Result<_, TestError> = flatten_async_drop(first_result, second_result).await;
-        assert!(result.is_ok());
-
-        let (first, second) = result.unwrap();
+        let (first, second) = flatten_async_drop(Ok::<_, TestError>(first), Ok(second))
+            .await
+            .unwrap();
         assert_eq!("first", first.id);
         assert_eq!("second", second.id);
+        assert_eq!(0, counter.load(Ordering::SeqCst));
 
         // Clean up
         first.async_drop().await.unwrap();
@@ -103,15 +120,12 @@ mod tests {
     #[tokio::test]
     async fn test_first_ok_second_err() {
         let counter = Arc::new(AtomicUsize::new(0));
-        let first = TestValue::new("first", Arc::clone(&counter));
+        let first = TestValue::new("first", &counter);
+        let second: Result<AsyncDropGuard<TestValue>, _> = Err(TestError("second error"));
 
-        let first_result: Result<_, &'static str> = Ok(first);
-        let second_result: Result<AsyncDropGuard<TestValue>, _> = Err("second error");
-        let result: Result<(AsyncDropGuard<TestValue>, AsyncDropGuard<TestValue>), TestError> =
-            flatten_async_drop(first_result, second_result).await;
+        let result = flatten_async_drop(Ok(first), second).await;
 
-        assert!(result.is_err());
-        assert_eq!("second error", result.unwrap_err().0);
+        assert_eq!(TestError("second error"), result.unwrap_err());
         // First value should have been dropped
         assert_eq!(1, counter.load(Ordering::SeqCst));
     }
@@ -119,26 +133,49 @@ mod tests {
     #[tokio::test]
     async fn test_first_err_second_ok() {
         let counter = Arc::new(AtomicUsize::new(0));
-        let second = TestValue::new("second", Arc::clone(&counter));
+        let first: Result<AsyncDropGuard<TestValue>, _> = Err(TestError("first error"));
+        let second = TestValue::new("second", &counter);
 
-        let first_result: Result<AsyncDropGuard<TestValue>, _> = Err("first error");
-        let second_result: Result<_, &'static str> = Ok(second);
-        let result: Result<(AsyncDropGuard<TestValue>, AsyncDropGuard<TestValue>), TestError> =
-            flatten_async_drop(first_result, second_result).await;
+        let result = flatten_async_drop(first, Ok(second)).await;
 
-        assert!(result.is_err());
-        assert_eq!("first error", result.unwrap_err().0);
+        assert_eq!(TestError("first error"), result.unwrap_err());
         // Second value should have been dropped
         assert_eq!(1, counter.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
     async fn test_both_err() {
-        let result: Result<(AsyncDropGuard<TestValue>, AsyncDropGuard<TestValue>), TestError> =
-            flatten_async_drop(Err("first error"), Err("second error")).await;
+        let first: Result<AsyncDropGuard<TestValue>, _> = Err(TestError("first error"));
+        let second: Result<AsyncDropGuard<TestValue>, _> = Err(TestError("second error"));
 
-        assert!(result.is_err());
+        let result = flatten_async_drop(first, second).await;
+
         // Returns the first error
-        assert_eq!("first error", result.unwrap_err().0);
+        assert_eq!(TestError("first error"), result.unwrap_err());
+    }
+
+    #[tokio::test]
+    async fn test_first_ok_second_err_and_dropping_first_fails() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let first = TestValue::with_failing_drop("first", &counter);
+        let second: Result<AsyncDropGuard<TestValue>, _> = Err(TestError("second error"));
+
+        let result = flatten_async_drop(Ok(first), second).await;
+
+        // The original error is returned, the drop error is only logged
+        assert_eq!(TestError("second error"), result.unwrap_err());
+        assert_eq!(1, counter.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_first_err_second_ok_and_dropping_second_fails() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let first: Result<AsyncDropGuard<TestValue>, _> = Err(TestError("first error"));
+        let second = TestValue::with_failing_drop("second", &counter);
+
+        let result = flatten_async_drop(first, Ok(second)).await;
+
+        assert_eq!(TestError("first error"), result.unwrap_err());
+        assert_eq!(1, counter.load(Ordering::SeqCst));
     }
 }

--- a/crates/utils/src/async_drop/mod.rs
+++ b/crates/utils/src/async_drop/mod.rs
@@ -17,7 +17,6 @@ mod hash_map;
 pub use hash_map::AsyncDropHashMap;
 
 mod with;
-pub use with::with_async_drop;
 
 mod all;
 pub use all::{AsyncDropAllElement, AsyncDropTuple, async_drop_all};

--- a/crates/utils/src/async_drop/with.rs
+++ b/crates/utils/src/async_drop/with.rs
@@ -1,34 +1,26 @@
 //! RAII-style helpers for ensuring async_drop is called.
 //!
-//! This module provides macros and functions that ensure `async_drop` is called
-//! on an `AsyncDropGuard` even if the callback returns early or fails.
-
-use std::fmt::Debug;
-use std::future::Future;
-
-use super::{AsyncDrop, AsyncDropGuard};
-
-// TODO It seems that actually most of our call sites only use sync callbacks
-//      and have quite a hard time calling this because they need to wrap their callbacks into future::ready.
-//      Offer sync versions instead.
-
-// TODO Why does this need to be a macro? Can't call sites just use the function version?
+//! This module provides the [with_async_drop!](crate::with_async_drop) and
+//! [with_async_drop_infallible!](crate::with_async_drop_infallible) macros, which ensure
+//! `async_drop` is called on `AsyncDropGuard`s even if the block returns early or fails.
 
 /// Executes a block of code and ensures `async_drop` is called on the values afterward.
 ///
 /// This macro takes one or more `AsyncDropGuard`s and a block of code to execute. After the
 /// block completes (whether successfully or with an error), it calls `async_drop` on the values.
+/// It is a macro rather than a function so that the block can use the guards by name (and
+/// borrow them) while the macro still owns them and can consume them afterwards.
 /// Several values are dropped concurrently via [async_drop_all](crate::async_drop::async_drop_all),
 /// so they must be independent of each other and share the same error type.
 ///
 /// # Forms
 ///
-/// - `with_async_drop_2!(value, { ... })` - Propagates async_drop errors directly
-/// - `with_async_drop_2!(value, { ... }, err_map)` - Maps async_drop errors using `err_map`
-/// - `with_async_drop_2!(first, second, ..., { ... })` - Drops all values concurrently afterward
-/// - `with_async_drop_2!(first, second, ..., { ... }, err_map)` - Same, mapping async_drop errors
+/// - `with_async_drop!(value, { ... })` - Propagates async_drop errors directly
+/// - `with_async_drop!(value, { ... }, err_map)` - Maps async_drop errors using `err_map`
+/// - `with_async_drop!(first, second, ..., { ... })` - Drops all values concurrently afterward
+/// - `with_async_drop!(first, second, ..., { ... }, err_map)` - Same, mapping async_drop errors
 #[macro_export]
-macro_rules! with_async_drop_2 {
+macro_rules! with_async_drop {
     ($($value:ident),+ , $f:block) => {
         async {
             let result = (async || $f)().await;
@@ -49,11 +41,11 @@ macro_rules! with_async_drop_2 {
     };
 }
 
-/// Variant of [`with_async_drop_2!`] for types that return a `Never` error in their async_drop.
+/// Variant of [`with_async_drop!`] for types that return a `Never` error in their async_drop.
 ///
 /// Since the error type is `Never` (infallible), this macro unwraps the result directly.
 #[macro_export]
-macro_rules! with_async_drop_2_infallible {
+macro_rules! with_async_drop_infallible {
     ($($value:ident),+ , $f:block) => {
         async {
             use lockable::InfallibleUnwrap as _;
@@ -67,38 +59,9 @@ macro_rules! with_async_drop_2_infallible {
     };
 }
 
-/// Executes a callback with a reference to the contained value, then calls async_drop.
-///
-/// This function provides a more functional approach to ensuring cleanup. The callback
-/// receives a mutable reference to the inner value and can perform any operations needed.
-/// After the callback completes, `async_drop` is called automatically.
-///
-/// # Arguments
-///
-/// * `value` - The `AsyncDropGuard` containing the value to operate on
-/// * `f` - A callback that receives a mutable reference to the inner value
-///
-/// # Returns
-///
-/// Returns the result of the callback if both the callback and async_drop succeed.
-/// Returns an error if either the callback or async_drop fails.
-pub async fn with_async_drop<T, R, E, F>(
-    mut value: AsyncDropGuard<T>,
-    f: impl FnOnce(&mut T) -> F,
-) -> Result<R, E>
-where
-    T: AsyncDrop + Debug,
-    E: From<<T as AsyncDrop>::Error>,
-    F: Future<Output = Result<R, E>>,
-{
-    let result = f(&mut value).await;
-    value.async_drop().await?;
-    result
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::async_drop::{AsyncDrop, AsyncDropGuard};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -127,41 +90,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_success() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let guard = TestValue::new(42, Arc::clone(&counter));
-
-        let result: Result<i32, &'static str> = with_async_drop(guard, |v| {
-            let val = v.value;
-            async move { Ok(val * 2) }
-        })
-        .await;
-
-        assert_eq!(Ok(84), result);
-        assert_eq!(1, counter.load(Ordering::SeqCst));
-    }
-
-    #[tokio::test]
-    async fn test_with_async_drop_callback_error() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let guard = TestValue::new(42, Arc::clone(&counter));
-
-        let result: Result<i32, &'static str> =
-            with_async_drop(guard, |_v| async move { Err("callback error") }).await;
-
-        assert_eq!(Err("callback error"), result);
-        // async_drop should still be called
-        assert_eq!(1, counter.load(Ordering::SeqCst));
-    }
-
-    #[tokio::test]
-    async fn test_with_async_drop_2_macro_multiple_guards_success() {
+    async fn test_with_async_drop_macro_multiple_guards_success() {
         let counter = Arc::new(AtomicUsize::new(0));
         let first = TestValue::new(1, Arc::clone(&counter));
         let second = TestValue::new(2, Arc::clone(&counter));
         let third = TestValue::new(3, Arc::clone(&counter));
 
-        let result: Result<i32, &'static str> = with_async_drop_2!(first, second, third, {
+        let result: Result<i32, &'static str> = with_async_drop!(first, second, third, {
             Ok(first.value + second.value + third.value)
         });
 
@@ -170,13 +105,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_macro_multiple_guards_block_error() {
+    async fn test_with_async_drop_macro_multiple_guards_block_error() {
         let counter = Arc::new(AtomicUsize::new(0));
         let first = TestValue::new(1, Arc::clone(&counter));
         let second = TestValue::new(2, Arc::clone(&counter));
 
         let result: Result<i32, &'static str> =
-            with_async_drop_2!(first, second, { Err("block error") });
+            with_async_drop!(first, second, { Err("block error") });
 
         assert_eq!(Err("block error"), result);
         // Both guards are dropped even though the block failed
@@ -184,20 +119,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_macro_multiple_guards_with_error_map() {
+    async fn test_with_async_drop_macro_multiple_guards_with_error_map() {
         let counter = Arc::new(AtomicUsize::new(0));
         let first = TestValue::new(1, Arc::clone(&counter));
         let second = TestValue::new(2, Arc::clone(&counter));
 
         let result: Result<i32, String> =
-            with_async_drop_2!(first, second, { Ok(84) }, |e: &str| e.to_string());
+            with_async_drop!(first, second, { Ok(84) }, |e: &str| e.to_string());
 
         assert_eq!(Ok(84), result);
         assert_eq!(2, counter.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_infallible_macro_multiple_guards() {
+    async fn test_with_async_drop_infallible_macro_multiple_guards() {
         #[derive(Debug)]
         struct InfallibleValue(Arc<AtomicUsize>);
         impl AsyncDrop for InfallibleValue {
@@ -212,30 +147,30 @@ mod tests {
         let first = AsyncDropGuard::new(InfallibleValue(Arc::clone(&counter)));
         let second = AsyncDropGuard::new(InfallibleValue(Arc::clone(&counter)));
 
-        let result: i32 = with_async_drop_2_infallible!(first, second, { 42 });
+        let result: i32 = with_async_drop_infallible!(first, second, { 42 });
 
         assert_eq!(42, result);
         assert_eq!(2, counter.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_macro_success() {
+    async fn test_with_async_drop_macro_success() {
         let counter = Arc::new(AtomicUsize::new(0));
         let value = TestValue::new(42, Arc::clone(&counter));
 
-        let result: Result<i32, &'static str> = with_async_drop_2!(value, { Ok(84) });
+        let result: Result<i32, &'static str> = with_async_drop!(value, { Ok(84) });
 
         assert_eq!(Ok(84), result);
         assert_eq!(1, counter.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_macro_with_error_map() {
+    async fn test_with_async_drop_macro_with_error_map() {
         let counter = Arc::new(AtomicUsize::new(0));
         let value = TestValue::new(42, Arc::clone(&counter));
 
         let result: Result<i32, String> =
-            with_async_drop_2!(value, { Ok(84) }, |e: &str| e.to_string());
+            with_async_drop!(value, { Ok(84) }, |e: &str| e.to_string());
 
         assert_eq!(Ok(84), result);
         assert_eq!(1, counter.load(Ordering::SeqCst));


### PR DESCRIPTION
Follow-up to #641 and #642 (both merged; this PR is rebased onto main).

**Intended for a rebase merge.** This PR has two commits that should land on main separately:

| Commit | Review status |
|---|---|
| `7ff01a0` Reduce error-handling noise around async_drop | **needs review** (the change described below) |
| `80e942d` Merge with_async_drop_2! and the with_async_drop function into with_async_drop! (#653) | already reviewed and approved as #653, which was accidentally merged into this branch instead of main |

## Summary of `7ff01a0`

- **`flatten_async_drop` infers its error type.** It now takes two `Result<AsyncDropGuard<_>, E>` with the same `E` and returns `E`, so the call sites lose their `::<anyhow::Error, _, _, _, _>` turbofish. On its error paths a failing drop is logged rather than converted into the returned error, and when both inputs fail the second error is logged instead of silently lost (that was a TODO).
  - Side effect worth a look: `CryDir::move_child_to` used `E = anyhow::Error` and then `map_err(FsError::internal_error)`, so an `FsError` from `load_blob` (e.g. `NodeDoesNotExist`) was wrapped in `anyhow` and came back out as `FsError::InternalError`. With the error type taken from the inputs, the original `FsError` is returned unchanged.
- **`AsyncDropGuard::async_drop_on_err(self, result)`**: drops the guard if `result` is an error and returns that error, otherwise returns `(value, guard)`. It replaces the eight hand-written arms in `CryDir::create_child_dir`, `create_child_symlink`, `create_and_open_file` and `remove_child_dir` that did `guard.async_drop().await.map_err(FsError::internal_error)?; return Err(err);`, i.e. the places where the guard is kept on the success path so the `with_async_drop!` macro cannot be used.
- Removes a no-op `.map_err(|err| err)` in `ObjectBasedFsAdapter`'s drop.

## Behavior change to review

On these error paths the drop error used to take precedence (the original error was lost, not even logged). Now the original error is returned and the drop error is logged with `log::error!`. That matches what `LockingBlockStore::into_inner_block_store` already does on its error path, and it is what a caller of e.g. `create_child_dir` needs (`NodeAlreadyExists` rather than `InternalError`). Say if you would rather keep the old precedence and I will add a variant.

The remaining `.map_err(FsError::internal_error)` after `async_drop` calls (in `AsyncDrop` impls and the macro's error-mapping form) are single, explicit conversions and are left as they are.

## Testing

- New unit tests: `async_drop_on_err` on Ok, Err, and Err with a failing drop; `flatten_async_drop` in all four combinations plus failing drops on both error paths, written so the error type is inferred without annotations. A doctest shows the intended `let (id, blob) = blob.async_drop_on_err(..).await?;` shape.
- `cargo test` for cryfs-utils (360 unit + 21 doc), cryfs-rustfs (41), cryfs-e2e-perf-tests (4,060), cryfs-check (236), cryfs-cli (65): all pass. `cargo check --workspace --all-targets`, `cargo fmt --all --check` and `RUSTDOCFLAGS=-Dwarnings cargo doc -p cryfs-utils` are clean.
- CI on the combined head `80e942d` was fully green (all 47 check runs incl. macOS, codecov, CodeQL).

## AI disclosure

Per `AI_POLICY.md`: drafted with Claude Code; please review as a draft to be verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGpoUYe98AX1tyACHy6Mqt