### PR TITLE
Stop building Boost.Serialization

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -69,7 +69,7 @@ class CryFSConan(ConanFile):
         "boost/*:without_python": True,
         "boost/*:without_random": True,
         "boost/*:without_regex": True,
-        "boost/*:without_serialization": False,  # needed by boost date_time
+        "boost/*:without_serialization": True,
         # Stacktrace is needed by CryFS. Stacktrace is a header-only library and linking against its static version actually **disables** stacktraces,
         # see https://www.boost.org/doc/libs/1_65_0/doc/html/stacktrace/getting_started.html#stacktrace.getting_started.enabling_and_disabling_stacktrac
         # This is why we need to **not** link against the static version of stacktrace.


### PR DESCRIPTION
`conanfile.py` sets `without_serialization: False` with the comment *"needed by boost date_time"*. That isn't true, and nothing else in the graph needs it either.

## Why it isn't needed

conan-center's own dependency manifest for the boost recipe lists **no dependencies at all** for `date_time` — in `dependencies-1.91.0.yml` and in `dependencies-1.84.0.yml` before it. The libraries that genuinely depend on `serialization` are `graph`, `graph_parallel`, `mpi`, `wave` and `wserialization`, and all five are already off.

Taking the transitive closure of what CryFS actually asks for:

```
chrono           deps=[]
filesystem       deps=[atomic]
program_options  deps=[]
thread           deps=[atomic, chrono, container, date_time, exception]
```

gives `atomic, chrono, container, date_time, exception, filesystem, program_options, thread`. `serialization` is not in it, and every one of those eight is already enabled.

## The empirical confirmation

The from-source CI path never built it in the first place. Its bootstrap line is

```
./bootstrap.sh --with-libraries=filesystem,thread,chrono,program_options
```

so the `Local dependencies` job has been building and testing CryFS against a Boost containing no `serialization` whatsoever — and passing. Alongside that, there are no `boost/serialization` or `boost/archive` includes anywhere in `src/` or `test/`, and `cmake-utils/Dependencies.cmake` requests only those same four components.

## Effect

One fewer compiled Boost library on every cold Boost build. No functional change — nothing links against it today.

No ChangeLog entry: this changes how we build a dependency, not which version ships or what CryFS does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj


---
_Generated by [Claude Code](https://claude.ai/code/session_012ENHG4oM4bWuSzX39KMYpj)_