### PR TITLE
Make the CLI tests fail instead of hanging when the file system throws

### DIFF
--- a/test/cryfs-cli/testutils/CliTest.h
+++ b/test/cryfs-cli/testutils/CliTest.h
@@ -143,7 +143,7 @@ public:
                     *exited = true;
                     barrier->release();
                 }
-            } releaseBarrier{&exited, &isMountedOrFailedBarrier};
+            } const releaseBarrier{&exited, &isMountedOrFailedBarrier};
             return run(args, [&] { isMountedOrFailedBarrier.release(); });
         });
 

--- a/test/cryfs-cli/testutils/CliTest.h
+++ b/test/cryfs-cli/testutils/CliTest.h
@@ -113,17 +113,38 @@ public:
     FilesystemOutput run_filesystem(const std::vector<std::string>& args, boost::optional<boost::filesystem::path> mountDirForUnmounting, std::function<void()> onMounted) {
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
+        try {
+            return _run_filesystem_with_captured_output(args, std::move(mountDirForUnmounting), std::move(onMounted));
+        } catch (...) {
+            // The exception is reported by gtest once it propagates out of the test body, but
+            // gtest prints that report to stdout, which is still being captured here. Stop
+            // capturing first, and show what the file system printed, because that is where
+            // the reason usually is.
+            std::cerr << "Running the file system threw an exception.\nSTDOUT:\n" << testing::internal::GetCapturedStdout()
+                      << "STDERR:\n" << testing::internal::GetCapturedStderr() << std::endl;
+            throw;
+        }
+    }
 
+    FilesystemOutput _run_filesystem_with_captured_output(const std::vector<std::string>& args, boost::optional<boost::filesystem::path> mountDirForUnmounting, std::function<void()> onMounted) {
         bool exited = false;
         cpputils::ConditionBarrier isMountedOrFailedBarrier;
 
         std::future<int> exit_code = std::async(std::launch::async, [&] {
-            const int exit_code = run(args, [&] { isMountedOrFailedBarrier.release(); });
-            // just in case it fails, we also want to release the barrier.
-            // if it succeeds, this will release it a second time, which doesn't hurt.
-            exited = true;
-            isMountedOrFailedBarrier.release();
-            return exit_code;
+            // Release the barrier however run() ends, also when it throws. If it fails before
+            // mounting, this releases the barrier the mount would have released. If it mounted,
+            // this releases it a second time, which doesn't hurt. Without the release on an
+            // exception, the thread below would wait for the whole timeout and then abort the
+            // test binary, and the exception would never be reported.
+            struct ReleaseBarrier final {
+                bool* exited;
+                cpputils::ConditionBarrier* barrier;
+                ~ReleaseBarrier() {
+                    *exited = true;
+                    barrier->release();
+                }
+            } releaseBarrier{&exited, &isMountedOrFailedBarrier};
+            return run(args, [&] { isMountedOrFailedBarrier.release(); });
         });
 
         std::future<bool> on_mounted_success = std::async(std::launch::async, [&] {


### PR DESCRIPTION
`CliTest::run_filesystem` runs `Cli::main` on a second thread and waits on a barrier that either the mount or the end of `Cli::main` releases. When `Cli::main` threw instead, nothing released it: the waiting thread sat there for the whole 1000 second timeout, after which the harness aborted the entire test binary with `exit(EXIT_FAILURE)`, taking every later test down with it and never showing the exception.

This came up while running the binary on a checkout whose version string gitversion couldn't parse (`Cli::_showVersion` throws a `std::logic_error` there), and the test binary just appeared to hang. It is what happens on any platform where something inside `Cli::main` throws, which is what enabling the CLI tests on macOS and Windows is likely to run into, so it is worth fixing on its own before those changes.

Now the barrier is released however `Cli::main` ends, and the exception propagates through the future into the test, where gtest reports it. gtest prints that report to stdout, which the harness is capturing at that point, so the capture is stopped first and what the file system printed is shown, because that is usually where the reason is.

## Verification

- Injected a `throw std::logic_error("injected for a harness test")` into `Cli::_showVersion`: the test now fails within a millisecond with `C++ exception with description "injected for a harness test" thrown in the test body.` instead of hanging for 1000 seconds and aborting the binary.
- Without the injected throw, the CLI tests pass unchanged on Linux (262 tests; the permission tests were excluded because the check ran as root, where they can't apply).

Part of a series of small pull requests that enable the test binaries CI currently skips on macOS and Windows, one issue per pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uPAugV9TZN8nZckjda4Pz

---
_Generated by [Claude Code](https://claude.ai/code/session_012uPAugV9TZN8nZckjda4Pz)_