### PR TITLE
Run the CLI tests on Windows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -835,8 +835,7 @@ jobs:
           ./blockstore/blockstore-test.exe
           ./blobstore/blobstore-test.exe
           ./cryfs/cryfs-test.exe
-          # TODO Enable cryfs-cli-test on Windows
-          # ./cryfs-cli/cryfs-cli-test.exe
+          ./cryfs-cli/cryfs-cli-test.exe
       - name: CPack
         uses: ./.github/workflows/actions/cpack
         # Release installers are built with Visual Studio 2026, which windows-2025 ships.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -429,7 +429,9 @@ Configuration in `.clang-tidy`:
   `windows-2025`, which ships Visual Studio 2026. The workflow selects the conan compiler
   version per image. Release packages are built on `windows-2025`, so they are compiled with
   Visual Studio 2026.
-- Some tests are disabled on Windows (see CI config)
+- The FUSE integration tests in fspp-test are not built on Windows, because they drive a mounted
+  file system through the POSIX file API (see test/fspp/CMakeLists.txt). The CLI tests mount to a
+  free drive letter on Windows, and the few that need the mount directory to be a directory skip.
 
 ### macOS
 

--- a/test/cryfs-cli/CliTest_IntegrityCheck.cpp
+++ b/test/cryfs-cli/CliTest_IntegrityCheck.cpp
@@ -84,9 +84,9 @@ public:
 };
 
 TEST_F(CliTest_IntegrityCheck, givenIncorrectFilesystemId_thenFails) {
-  const vector<string> args{basedir.string().c_str(), mountdir.string().c_str(), "--cipher", "aes-256-gcm", "-f"};
+  const vector<string> args{basedir.string().c_str(), mountpoint.string().c_str(), "--cipher", "aes-256-gcm", "-f"};
   //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
-  EXPECT_RUN_SUCCESS(args, mountdir);
+  EXPECT_RUN_SUCCESS(args, mountpoint);
   modifyFilesystemId();
   EXPECT_RUN_ERROR(
       args,
@@ -96,9 +96,9 @@ TEST_F(CliTest_IntegrityCheck, givenIncorrectFilesystemId_thenFails) {
 }
 
 TEST_F(CliTest_IntegrityCheck, givenIncorrectFilesystemKey_thenFails) {
-  const vector<string> args{basedir.string().c_str(), mountdir.string().c_str(), "--cipher", "aes-256-gcm", "-f"};
+  const vector<string> args{basedir.string().c_str(), mountpoint.string().c_str(), "--cipher", "aes-256-gcm", "-f"};
   //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
-  EXPECT_RUN_SUCCESS(args, mountdir);
+  EXPECT_RUN_SUCCESS(args, mountpoint);
   modifyFilesystemKey();
   EXPECT_RUN_ERROR(
       args,
@@ -109,12 +109,12 @@ TEST_F(CliTest_IntegrityCheck, givenIncorrectFilesystemKey_thenFails) {
 
 // TODO Also enable this
 TEST_F(CliTest_IntegrityCheck, givenFilesystemWithRolledBackBasedir_whenMounting_thenFails) {
-  const vector<string> args{basedir.string().c_str(), mountdir.string().c_str(), "--cipher", "aes-256-gcm", "-f"};
+  const vector<string> args{basedir.string().c_str(), mountpoint.string().c_str(), "--cipher", "aes-256-gcm", "-f"};
   //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS/EXPECT_RUN_ERROR can handle that
 
   // create a filesystem with one file
-  EXPECT_RUN_SUCCESS(args, mountdir, [&] {
-    writeFile(mountdir / "myfile", "hello world");
+  EXPECT_RUN_SUCCESS(args, mountpoint, [&] {
+    writeFile(in_mountpoint("myfile"), "hello world");
   });
 
   // backup the base directory
@@ -122,8 +122,8 @@ TEST_F(CliTest_IntegrityCheck, givenFilesystemWithRolledBackBasedir_whenMounting
   recursive_copy(basedir, backup.path() / "basedir");
 
   // modify the file system contents
-  EXPECT_RUN_SUCCESS(args, mountdir, [&] {
-    writeFile(mountdir / "myfile", "hello world 2");
+  EXPECT_RUN_SUCCESS(args, mountpoint, [&] {
+    writeFile(in_mountpoint("myfile"), "hello world 2");
   });
 
   // roll back base directory
@@ -132,20 +132,20 @@ TEST_F(CliTest_IntegrityCheck, givenFilesystemWithRolledBackBasedir_whenMounting
 
   // error code is success because it unmounts normally
   EXPECT_RUN_ERROR(args, "Integrity violation detected. Unmounting.", ErrorCode::IntegrityViolation, [&] {
-    EXPECT_FALSE(readingFileIsSuccessful(mountdir / "myfile"));
-  });
+    EXPECT_FALSE(readingFileIsSuccessful(in_mountpoint("myfile")));
+  }, mountpoint);
 
   // Test it doesn't mount anymore now because it's marked with an integrity violation
   EXPECT_RUN_ERROR(args, "There was an integrity violation detected. Preventing any further access to the file system.", ErrorCode::IntegrityViolationOnPreviousRun);
 }
 
 TEST_F(CliTest_IntegrityCheck, whenRollingBackBasedirWhileMounted_thenUnmounts) {
-  const vector<string> args{basedir.string().c_str(), mountdir.string().c_str(), "--cipher", "aes-256-gcm", "-f"};
+  const vector<string> args{basedir.string().c_str(), mountpoint.string().c_str(), "--cipher", "aes-256-gcm", "-f"};
   //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS/EXPECT_RUN_ERROR can handle that
 
   // create a filesystem with one file
-  EXPECT_RUN_SUCCESS(args, mountdir, [&] {
-    writeFile(mountdir / "myfile", "hello world");
+  EXPECT_RUN_SUCCESS(args, mountpoint, [&] {
+    writeFile(in_mountpoint("myfile"), "hello world");
   });
 
   // backup the base directory
@@ -154,8 +154,8 @@ TEST_F(CliTest_IntegrityCheck, whenRollingBackBasedirWhileMounted_thenUnmounts) 
 
   EXPECT_RUN_ERROR(args, "Integrity violation detected. Unmounting.", ErrorCode::IntegrityViolation, [&] {
     // modify the file system contents
-    writeFile(mountdir / "myfile", "hello world 2");
-    ASSERT(readingFileIsSuccessful(mountdir / "myfile"), ""); // just to make sure reading usually works
+    writeFile(in_mountpoint("myfile"), "hello world 2");
+    ASSERT(readingFileIsSuccessful(in_mountpoint("myfile")), ""); // just to make sure reading usually works
 
     // wait for cache timeout (i.e. flush file system to disk)
     constexpr auto cache_timeout = blockstore::caching::CachingBlockStore2::MAX_LIFETIME_SEC + cryfs::cachingfsblobstore::CachingFsBlobStore::MAX_LIFETIME_SEC;
@@ -166,8 +166,8 @@ TEST_F(CliTest_IntegrityCheck, whenRollingBackBasedirWhileMounted_thenUnmounts) 
     recursive_copy(backup.path() / "basedir", basedir);
 
     // expect reading now fails
-    EXPECT_FALSE(readingFileIsSuccessful(mountdir / "myfile"));
-  });
+    EXPECT_FALSE(readingFileIsSuccessful(in_mountpoint("myfile")));
+  }, mountpoint);
 
   // Test it doesn't mount anymore now because it's marked with an integrity violation
   EXPECT_RUN_ERROR(args, "There was an integrity violation detected. Preventing any further access to the file system.", ErrorCode::IntegrityViolationOnPreviousRun);

--- a/test/cryfs-cli/CliTest_MountFailure.cpp
+++ b/test/cryfs-cli/CliTest_MountFailure.cpp
@@ -8,10 +8,17 @@ using std::vector;
 class CliTest_MountFailure: public CliTest {
 public:
     // libfuse parses 'entry_timeout' as a double, so it rejects this while setting up the file
-    // system and refuses the mount before anything gets mounted.
+    // system and refuses the mount before anything gets mounted. Dokany's FUSE wrapper on Windows
+    // doesn't know 'entry_timeout' and silently ignores options it doesn't know, but it parses
+    // 'daemon_timeout' as an integer and rejects this the same way.
     vector<string> argsWithUnparseableFuseOption() {
-        return {basedir.string(), mountdir.string(), "-f", "--cipher", "aes-256-gcm",
-                "-o", "entry_timeout=not_a_number"};
+#if defined(_MSC_VER)
+        const char* option = "daemon_timeout=not_a_number";
+#else
+        const char* option = "entry_timeout=not_a_number";
+#endif
+        return {basedir.string(), mountpoint.string(), "-f", "--cipher", "aes-256-gcm",
+                "-o", option};
     }
 };
 

--- a/test/cryfs-cli/CliTest_NonEmptyMountdir.cpp
+++ b/test/cryfs-cli/CliTest_NonEmptyMountdir.cpp
@@ -39,6 +39,9 @@ TEST_F(CliTest_NonEmptyMountdir, WhenMountdirIsNotEmpty_ThenMountingIsRefused) {
 }
 
 TEST_F(CliTest_NonEmptyMountdir, WhenMountdirIsNotEmptyAndNonemptyOptionIsGiven_ThenMountingSucceeds) {
+#if defined(_MSC_VER)
+    GTEST_SKIP() << "CryFS on Windows mounts to a drive letter, not into a directory";
+#endif
     PutFileIntoMountdir();
     bool wasHiddenWhileMounted = false;
     EXPECT_RUN_SUCCESS(args({"-o", "nonempty"}), mountdir, [&] {
@@ -49,6 +52,9 @@ TEST_F(CliTest_NonEmptyMountdir, WhenMountdirIsNotEmptyAndNonemptyOptionIsGiven_
 
 // Counter-test: an empty mount directory keeps working without the option.
 TEST_F(CliTest_NonEmptyMountdir, WhenMountdirIsEmpty_ThenMountingSucceeds) {
+#if defined(_MSC_VER)
+    GTEST_SKIP() << "CryFS on Windows mounts to a drive letter, not into a directory";
+#endif
     ASSERT_TRUE(MountdirIsEmpty());
     EXPECT_RUN_SUCCESS(args(), mountdir);
 }

--- a/test/cryfs-cli/CliTest_Setup.cpp
+++ b/test/cryfs-cli/CliTest_Setup.cpp
@@ -11,35 +11,35 @@ using CliTest_Setup = CliTest;
 TEST_F(CliTest_Setup, NoSpecialOptions) {
     //Specify --cipher parameter to make it non-interactive
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
-    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountdir.string().c_str(), "--cipher", "aes-256-gcm", "-f"}, mountdir);
+    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountpoint.string().c_str(), "--cipher", "aes-256-gcm", "-f"}, mountpoint);
 }
 
 TEST_F(CliTest_Setup, NotexistingLogfileGiven) {
     const TempFile notexisting_logfile(false);
     //Specify --cipher parameter to make it non-interactive
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
-    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountdir.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--logfile", notexisting_logfile.path().string().c_str()}, mountdir);
+    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountpoint.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--logfile", notexisting_logfile.path().string().c_str()}, mountpoint);
     //TODO Expect logfile is used (check logfile content)
 }
 
 TEST_F(CliTest_Setup, ExistingLogfileGiven) {
     //Specify --cipher parameter to make it non-interactive
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
-    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountdir.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--logfile", logfile.path().string().c_str()}, mountdir);
+    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountpoint.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--logfile", logfile.path().string().c_str()}, mountpoint);
     //TODO Expect logfile is used (check logfile content)
 }
 
 TEST_F(CliTest_Setup, ConfigfileGiven) {
     //Specify --cipher parameter to make it non-interactive
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
-    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountdir.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--config", configfile.path().string().c_str()}, mountdir);
+    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountpoint.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--config", configfile.path().string().c_str()}, mountpoint);
 }
 
 TEST_F(CliTest_Setup, AutocreateBasedir) {
     const TempFile notexisting_basedir(false);
     //Specify --cipher parameter to make it non-interactive
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
-    EXPECT_RUN_SUCCESS({notexisting_basedir.path().string().c_str(), mountdir.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--create-missing-basedir"}, mountdir);
+    EXPECT_RUN_SUCCESS({notexisting_basedir.path().string().c_str(), mountpoint.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--create-missing-basedir"}, mountpoint);
 }
 
 TEST_F(CliTest_Setup, AutocreateBasedirFail) {
@@ -54,6 +54,9 @@ TEST_F(CliTest_Setup, AutocreateBasedirFail) {
 }
 
 TEST_F(CliTest_Setup, AutocreateMountpoint) {
+#if defined(_MSC_VER)
+    GTEST_SKIP() << "CryFS on Windows mounts to a drive letter, which can't be created";
+#endif
     const TempFile notexisting_mountpoint(false);
     //Specify --cipher parameter to make it non-interactive
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
@@ -74,7 +77,7 @@ TEST_F(CliTest_Setup, AutocreateMountdirFail) {
 TEST_F(CliTest_Setup, FuseOptionGiven) {
     //Specify --cipher parameter to make it non-interactive
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
-    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountdir.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--", "-f"}, mountdir);
+    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountpoint.string().c_str(), "-f", "--cipher", "aes-256-gcm", "--", "-f"}, mountpoint);
 }
 
 TEST_F(CliTest, WorksWithCommasInBasedir) {
@@ -82,5 +85,5 @@ TEST_F(CliTest, WorksWithCommasInBasedir) {
     //TODO Remove "-f" parameter, once EXPECT_RUN_SUCCESS can handle that
     auto basedir_ = basedir / "pathname,with,commas";
     bf::create_directory(basedir_);
-    EXPECT_RUN_SUCCESS({basedir_.string().c_str(), mountdir.string().c_str(), "-f"}, mountdir);
+    EXPECT_RUN_SUCCESS({basedir_.string().c_str(), mountpoint.string().c_str(), "-f"}, mountpoint);
 }

--- a/test/cryfs-cli/CliTest_WrongEnvironment.cpp
+++ b/test/cryfs-cli/CliTest_WrongEnvironment.cpp
@@ -40,19 +40,19 @@ public:
     }
 
     void Test_Run_Success() {
-        EXPECT_RUN_SUCCESS(args(), mountdir);
+        EXPECT_RUN_SUCCESS(args(mountpoint), mountpoint);
     }
 
     void Test_Run_Error(const char *expectedError, cryfs::ErrorCode errorCode) {
         EXPECT_RUN_ERROR(
-            args(),
+            args(mountdir),
             expectedError,
             errorCode
         );
     }
 
-    vector<string> args() {
-        vector<string> result = {basedir.string(), mountdir.string()};
+    vector<string> args(const bf::path &mountdir_) {
+        vector<string> result = {basedir.string(), mountdir_.string()};
         if (GetParam().externalConfigfile) {
             result.push_back("--config");
             result.push_back(configfile.path().string());
@@ -91,29 +91,38 @@ TEST_P(CliTest_WrongEnvironment, MountDirIsBaseDir) {
     Test_Run_Error("Error 18: base directory can't be inside the mount directory", ErrorCode::BaseDirInsideMountDir);
 }
 
-bf::path make_relative(const bf::path &path) {
-    bf::path result;
-    const bf::path cwd = bf::current_path();
-    for(auto iter = ++cwd.begin(); iter!=cwd.end(); ++iter) {
-        result /= "..";
+// The path to `path`, relative to the current working directory. On Windows there is no such path
+// when the two are on different drives, which they are on the CI runners, where the working
+// directory is on D: and the temporary directory on C:. The tests below skip in that case.
+boost::optional<bf::path> make_relative(const bf::path &path) {
+    const bf::path result = bf::relative(path, bf::current_path());
+    if (result.empty()) {
+        return boost::none;
     }
-    result /= path.relative_path();
     return result;
 }
 
+#define SKIP_IF_THERE_IS_NO_RELATIVE_PATH_TO(path) \
+    if (make_relative(path) == boost::none) { \
+        GTEST_SKIP() << "There is no relative path to " << (path) << " because it is on a different drive than the working directory " << bf::current_path(); \
+    }
+
 TEST_P(CliTest_WrongEnvironment, MountDirIsBaseDir_MountDirRelative) {
-    mountdir = make_relative(basedir);
+    SKIP_IF_THERE_IS_NO_RELATIVE_PATH_TO(basedir);
+    mountdir = *make_relative(basedir);
     Test_Run_Error("Error 18: base directory can't be inside the mount directory", ErrorCode::BaseDirInsideMountDir);
 }
 
 TEST_P(CliTest_WrongEnvironment, MountDirIsBaseDir_BaseDirRelative) {
+    SKIP_IF_THERE_IS_NO_RELATIVE_PATH_TO(basedir);
     mountdir = basedir;
-    basedir = make_relative(basedir);
+    basedir = *make_relative(basedir);
     Test_Run_Error("Error 18: base directory can't be inside the mount directory", ErrorCode::BaseDirInsideMountDir);
 }
 
 TEST_P(CliTest_WrongEnvironment, MountDirIsBaseDir_BothRelative) {
-    basedir = make_relative(basedir);
+    SKIP_IF_THERE_IS_NO_RELATIVE_PATH_TO(basedir);
+    basedir = *make_relative(basedir);
     mountdir = basedir;
     Test_Run_Error("Error 18: base directory can't be inside the mount directory", ErrorCode::BaseDirInsideMountDir);
 }
@@ -198,6 +207,9 @@ TEST_P(CliTest_WrongEnvironment, MountDir_DoesntExist_Noninteractive) {
 
 TEST_P(CliTest_WrongEnvironment, MountDir_DoesntExist_Create) {
     if (!GetParam().runningInForeground) {return;} // TODO Make this work also if run in background (see CliTest::EXPECT_RUN_SUCCESS)
+#if defined(_MSC_VER)
+    GTEST_SKIP() << "CryFS on Windows mounts to a drive letter, which can't be created";
+#endif
     _mountdir.remove();
     ON_CALL(*console, askYesNo("Could not find mount directory. Do you want to create it?", testing::_)).WillByDefault(Return(true));
     Test_Run_Success();
@@ -212,6 +224,9 @@ TEST_P(CliTest_WrongEnvironment, MountDir_IsNotDirectory) {
 
 TEST_P(CliTest_WrongEnvironment, MountDir_AllPermissions) {
     if (!GetParam().runningInForeground) {return;} // TODO Make this work also if run in background (see CliTest::EXPECT_RUN_SUCCESS)
+#if defined(_MSC_VER)
+    GTEST_SKIP() << "CryFS on Windows mounts to a drive letter, which has no permissions to set";
+#endif
     //Counter-Test. Test it doesn't fail if permissions are there.
     SetAllPermissions(mountdir);
     Test_Run_Success();

--- a/test/cryfs-cli/CryfsUnmountTest.cpp
+++ b/test/cryfs-cli/CryfsUnmountTest.cpp
@@ -7,17 +7,21 @@ namespace bf = boost::filesystem;
 
 namespace {
 void unmount(const bf::path& mountdir) {
-    std::vector<const char*> _args = {"cryfs-unmount", mountdir.string().c_str()};
+    // On Windows, path::string() returns a copy, so it has to be kept alive while the arguments
+    // point into it. On Linux and macOS it returns a reference to the path's own string, which is
+    // why the temporary this used to point into went unnoticed there.
+    const std::string mountdir_string = mountdir.string();
+    std::vector<const char*> _args = {"cryfs-unmount", mountdir_string.c_str()};
     cryfs_unmount::Cli().main(2, _args.data());
 }
 
 TEST_F(CliTest_Unmount, givenMountedFilesystem_whenUnmounting_thenSucceeds) {
-    // we're passing in boost::none as mountdir so EXPECT_RUN_SUCCESS doesn't unmount itself.
+    // This test unmounts itself, so EXPECT_RUN_SUCCESS must not do it as well.
     // if the unmount we're calling here in the onMounted callback wouldn't work, EXPECT_RUN_SUCCESS
     // would never return and this would be a deadlock.
-    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountdir.string().c_str(), "-f"}, boost::none, [this] () {
-        unmount(mountdir);
-    });
+    EXPECT_RUN_SUCCESS({basedir.string().c_str(), mountpoint.string().c_str(), "-f"}, mountpoint, [this] () {
+        unmount(mountpoint);
+    }, UnmountAfterwards::No);
 }
 
 // TODO Test calling with invalid args, valid '--version' or '--help' args, with a non-mounted mountdir and a nonexisting mountdir.

--- a/test/cryfs-cli/program_options/ParserTest.cpp
+++ b/test/cryfs-cli/program_options/ParserTest.cpp
@@ -111,7 +111,13 @@ TEST_F(ProgramOptionsParserTest, MountDir_Relative) {
 
 TEST_F(ProgramOptionsParserTest, Foreground_False) {
     const ProgramOptions options = parse({"./myExecutable", basedir, "mountdir"});
+#if defined(_MSC_VER)
+    // CryFS can't run in the background on Windows yet, so the parser always reports foreground
+    // there, see Parser.cpp.
+    EXPECT_TRUE(options.foreground());
+#else
     EXPECT_FALSE(options.foreground());
+#endif
 }
 
 TEST_F(ProgramOptionsParserTest, Foreground_True) {

--- a/test/cryfs-cli/program_options/ProgramOptionsTest.cpp
+++ b/test/cryfs-cli/program_options/ProgramOptionsTest.cpp
@@ -19,16 +19,25 @@ namespace boost {
     }
 }
 
+// ProgramOptions makes the base and mount directories absolute, so a path that already is absolute
+// has to come back unchanged. On Windows a path starting with a slash isn't absolute, it is
+// relative to the current drive, so the test uses a path with a drive letter there.
+#if defined(_MSC_VER)
+constexpr const char* absolute_dir = "C:\\home\\user\\mydir";
+#else
+constexpr const char* absolute_dir = "/home/user/mydir";
+#endif
+
 class ProgramOptionsTest: public ProgramOptionsTestBase {};
 
 TEST_F(ProgramOptionsTest, BaseDir) {
-    const ProgramOptions testobj("/home/user/mydir", "", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
-    EXPECT_EQ("/home/user/mydir", testobj.baseDir());
+    const ProgramOptions testobj(absolute_dir, "", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    EXPECT_EQ(absolute_dir, testobj.baseDir());
 }
 
 TEST_F(ProgramOptionsTest, MountDir) {
-    const ProgramOptions testobj("", "/home/user/mydir", none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
-    EXPECT_EQ("/home/user/mydir", testobj.mountDir());
+    const ProgramOptions testobj("", absolute_dir, none, false, false, false, false, false, none, none, none, none, false, none, {"./myExecutable"});
+    EXPECT_EQ(absolute_dir, testobj.mountDir());
 }
 
 TEST_F(ProgramOptionsTest, ConfigfileNone) {

--- a/test/cryfs-cli/testutils/CliTest.h
+++ b/test/cryfs-cli/testutils/CliTest.h
@@ -241,8 +241,10 @@ public:
               if (mountDir.is_initialized()) {
                 try {
                   _unmount(*mountDir);
-                } catch (...) {
-                  // the original exception is the one worth reporting
+                } catch (const std::exception &e) {
+                  // The original exception is the one worth reporting; this goes to the captured
+                  // stderr, which run_filesystem() prints along with it.
+                  std::cerr << "Unmounting after the failure threw as well: " << e.what() << std::endl;
                 }
               }
               throw;

--- a/test/cryfs-cli/testutils/CliTest.h
+++ b/test/cryfs-cli/testutils/CliTest.h
@@ -143,7 +143,7 @@ public:
                     *exited = true;
                     barrier->release();
                 }
-            } releaseBarrier{&exited, &isMountedOrFailedBarrier};
+            } const releaseBarrier{&exited, &isMountedOrFailedBarrier};
             return run(args, [&] { isMountedOrFailedBarrier.release(); });
         });
 

--- a/test/cryfs-cli/testutils/CliTest.h
+++ b/test/cryfs-cli/testutils/CliTest.h
@@ -24,18 +24,59 @@
 #include <cpp-utils/testutils/CaptureStderrRAII.h>
 #include <regex>
 #include <string>
+#include <thread>
+#include <chrono>
+
+#if defined(_MSC_VER)
+namespace {
+// CryFS on Windows mounts to a drive letter, not into a directory (see Fuse::_run), so a test that
+// expects a mount to succeed needs a drive letter nothing else is using.
+inline boost::filesystem::path find_free_drive_letter() {
+    const DWORD used = GetLogicalDrives();
+    for (char letter = 'Z'; letter >= 'D'; --letter) {
+        if (0 == (used & (1u << (letter - 'A')))) {
+            return boost::filesystem::path(std::string(1, letter) + ":");
+        }
+    }
+    throw std::runtime_error("Didn't find a free drive letter to mount the test file system to");
+}
+}
+#endif
 
 class CliTest : public ::testing::Test, TestWithFakeHomeDirectory {
 public:
-    CliTest(): _basedir(), _mountdir(), basedir(_basedir.path()), mountdir(_mountdir.path()), logfile(), configfile(false), console(std::make_shared<MockConsole>()) {}
+    CliTest(): _basedir(), _mountdir(), basedir(_basedir.path()), mountdir(_mountdir.path()),
+#if defined(_MSC_VER)
+        mountpoint(find_free_drive_letter()),
+#else
+        mountpoint(_mountdir.path()),
+#endif
+        logfile(), configfile(false), console(std::make_shared<MockConsole>()) {}
 
     cpputils::TempDir _basedir;
     cpputils::TempDir _mountdir;
     boost::filesystem::path basedir;
+    // A directory to test the checks CryFS does on its mount directory with. On Linux and macOS
+    // the tests that expect the mount to succeed also mount into it. On Windows, CryFS can only
+    // mount to a drive letter (see Fuse::_run), so there they mount to `mountpoint` instead and
+    // the tests that need the mount directory to be a directory are skipped.
     boost::filesystem::path mountdir;
+    // Where a test that expects the mount to succeed mounts to: `mountdir` on Linux and macOS, a
+    // free drive letter on Windows.
+    boost::filesystem::path mountpoint;
     cpputils::TempFile logfile;
     cpputils::TempFile configfile;
     std::shared_ptr<MockConsole> console;
+
+    // A path inside the mounted file system. On Windows `mountpoint` is a bare drive letter, and
+    // "X:myfile" would be relative to that drive's current directory rather than to its root.
+    boost::filesystem::path in_mountpoint(const std::string& name) const {
+#if defined(_MSC_VER)
+        return boost::filesystem::path(mountpoint.string() + "\\") / name;
+#else
+        return mountpoint / name;
+#endif
+    }
 
     cpputils::unique_ref<cpputils::HttpClient> _httpClient() {
         cpputils::unique_ref<cpputils::FakeHttpClient> httpClient = cpputils::make_unique_ref<cpputils::FakeHttpClient>();
@@ -68,8 +109,12 @@ public:
         EXPECT_RUN_ERROR(args, "Usage:[^\\x00]*"+message, errorCode);
     }
 
-    void EXPECT_RUN_ERROR(const std::vector<std::string>& args, const std::string& message, cryfs::ErrorCode errorCode, std::function<void ()> onMounted = [] {}) {
-        const FilesystemOutput filesystem_output = run_filesystem(args, boost::none, std::move(onMounted));
+    enum class UnmountAfterwards { Yes, No };
+
+    // `mountDir` is where the file system gets mounted if the run gets that far. It is only needed
+    // when `onMounted` accesses the mounted file system, see run_filesystem().
+    void EXPECT_RUN_ERROR(const std::vector<std::string>& args, const std::string& message, cryfs::ErrorCode errorCode, std::function<void ()> onMounted = [] {}, const boost::optional<boost::filesystem::path> &mountDir = boost::none) {
+        const FilesystemOutput filesystem_output = run_filesystem(args, mountDir, UnmountAfterwards::No, std::move(onMounted));
 
         EXPECT_EQ(exitCode(errorCode), filesystem_output.exit_code);
         if (!std::regex_search(filesystem_output.stderr_, std::regex(message))) {
@@ -78,13 +123,15 @@ public:
         }
     }
 
-    void EXPECT_RUN_SUCCESS(const std::vector<std::string>& args, const boost::optional<boost::filesystem::path> &mountDir, std::function<void ()> onMounted = [] {}) {
+    // `mountDir` is where the file system gets mounted. It gets unmounted after `onMounted` ran,
+    // unless the test unmounts it itself and says so with UnmountAfterwards::No.
+    void EXPECT_RUN_SUCCESS(const std::vector<std::string>& args, const boost::filesystem::path &mountDir, std::function<void ()> onMounted = [] {}, UnmountAfterwards unmountAfterwards = UnmountAfterwards::Yes) {
         //TODO Make this work when run in background
         ASSERT(std::find(args.begin(), args.end(), string("-f")) != args.end(), "Currently only works if run in foreground");
 
         bool successfully_mounted = false;
 
-        const FilesystemOutput filesystem_output = run_filesystem(args, mountDir, [&] {
+        const FilesystemOutput filesystem_output = run_filesystem(args, mountDir, unmountAfterwards, [&] {
             successfully_mounted = true;
             onMounted();
         });
@@ -110,11 +157,35 @@ public:
         fspp::fuse::Fuse::unmount(mountDir, true);
     }
 
-    FilesystemOutput run_filesystem(const std::vector<std::string>& args, boost::optional<boost::filesystem::path> mountDirForUnmounting, std::function<void()> onMounted) {
+    // Waits until the mounted file system shows up at `mountDir`. The onMounted callback that
+    // releases the barrier below is called from Fuse::init(). libfuse calls that once the mount is
+    // live, so on Linux and macOS this returns right away. Dokany calls it while it is still
+    // setting the mount up: for a moment after it the drive letter isn't there yet, and both
+    // accessing the file system and DokanRemoveMountPoint() fail until it is.
+    static void _waitUntilMounted(const boost::filesystem::path &mountDir) {
+#if defined(_MSC_VER)
+        // `mountDir` is a bare drive letter, and "Z:" alone is relative to that drive's current directory
+        const boost::filesystem::path root = mountDir.string() + "\\";
+#else
+        const boost::filesystem::path &root = mountDir;
+#endif
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (!boost::filesystem::exists(root)) {
+            if (std::chrono::steady_clock::now() > deadline) {
+                throw std::runtime_error("Timeout waiting for the file system to show up at " + mountDir.string());
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    // `mountDir` is where the file system gets mounted, if it does. When it is given, the file
+    // system is unmounted after `onMounted` ran, unless `unmountAfterwards` says the test does that
+    // itself.
+    FilesystemOutput run_filesystem(const std::vector<std::string>& args, boost::optional<boost::filesystem::path> mountDir, UnmountAfterwards unmountAfterwards, std::function<void()> onMounted) {
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
         try {
-            return _run_filesystem_with_captured_output(args, std::move(mountDirForUnmounting), std::move(onMounted));
+            return _run_filesystem_with_captured_output(args, std::move(mountDir), unmountAfterwards, std::move(onMounted));
         } catch (...) {
             // The exception is reported by gtest once it propagates out of the test body, but
             // gtest prints that report to stdout, which is still being captured here. Stop
@@ -126,7 +197,7 @@ public:
         }
     }
 
-    FilesystemOutput _run_filesystem_with_captured_output(const std::vector<std::string>& args, boost::optional<boost::filesystem::path> mountDirForUnmounting, std::function<void()> onMounted) {
+    FilesystemOutput _run_filesystem_with_captured_output(const std::vector<std::string>& args, boost::optional<boost::filesystem::path> mountDir, UnmountAfterwards unmountAfterwards, std::function<void()> onMounted) {
         bool exited = false;
         cpputils::ConditionBarrier isMountedOrFailedBarrier;
 
@@ -156,10 +227,29 @@ public:
               return true;
             }
             // now we know the filesystem stayed online, so we can call the onMounted callback
-            onMounted();
+            const bool unmount = mountDir.is_initialized() && unmountAfterwards == UnmountAfterwards::Yes;
+            try {
+              if (mountDir.is_initialized()) {
+                _waitUntilMounted(*mountDir);
+              }
+              onMounted();
+            } catch (...) {
+              // Unmount anyway if we can, otherwise Cli::main() never returns and instead of
+              // reporting this exception, the test would wait for the timeout below. This also
+              // applies to a test that unmounts itself, because the exception may well have come
+              // from that unmount failing.
+              if (mountDir.is_initialized()) {
+                try {
+                  _unmount(*mountDir);
+                } catch (...) {
+                  // the original exception is the one worth reporting
+                }
+              }
+              throw;
+            }
             // and unmount it afterwards
-            if (mountDirForUnmounting.is_initialized()) {
-              _unmount(*mountDirForUnmounting);
+            if (unmount) {
+              _unmount(*mountDir);
             }
             return true;
         });

--- a/test/cryfs-cli/testutils/CliTest.h
+++ b/test/cryfs-cli/testutils/CliTest.h
@@ -113,17 +113,38 @@ public:
     FilesystemOutput run_filesystem(const std::vector<std::string>& args, boost::optional<boost::filesystem::path> mountDirForUnmounting, std::function<void()> onMounted) {
         testing::internal::CaptureStdout();
         testing::internal::CaptureStderr();
+        try {
+            return _run_filesystem_with_captured_output(args, std::move(mountDirForUnmounting), std::move(onMounted));
+        } catch (...) {
+            // The exception is reported by gtest once it propagates out of the test body, but
+            // gtest prints that report to stdout, which is still being captured here. Stop
+            // capturing first, and show what the file system printed, because that is where
+            // the reason usually is.
+            std::cerr << "Running the file system threw an exception.\nSTDOUT:\n" << testing::internal::GetCapturedStdout()
+                      << "STDERR:\n" << testing::internal::GetCapturedStderr() << std::endl;
+            throw;
+        }
+    }
 
+    FilesystemOutput _run_filesystem_with_captured_output(const std::vector<std::string>& args, boost::optional<boost::filesystem::path> mountDirForUnmounting, std::function<void()> onMounted) {
         bool exited = false;
         cpputils::ConditionBarrier isMountedOrFailedBarrier;
 
         std::future<int> exit_code = std::async(std::launch::async, [&] {
-            const int exit_code = run(args, [&] { isMountedOrFailedBarrier.release(); });
-            // just in case it fails, we also want to release the barrier.
-            // if it succeeds, this will release it a second time, which doesn't hurt.
-            exited = true;
-            isMountedOrFailedBarrier.release();
-            return exit_code;
+            // Release the barrier however run() ends, also when it throws. If it fails before
+            // mounting, this releases the barrier the mount would have released. If it mounted,
+            // this releases it a second time, which doesn't hurt. Without the release on an
+            // exception, the thread below would wait for the whole timeout and then abort the
+            // test binary, and the exception would never be reported.
+            struct ReleaseBarrier final {
+                bool* exited;
+                cpputils::ConditionBarrier* barrier;
+                ~ReleaseBarrier() {
+                    *exited = true;
+                    barrier->release();
+                }
+            } releaseBarrier{&exited, &isMountedOrFailedBarrier};
+            return run(args, [&] { isMountedOrFailedBarrier.release(); });
         });
 
         std::future<bool> on_mounted_success = std::async(std::launch::async, [&] {


### PR DESCRIPTION
`cryfs-cli-test` was built on Windows but never run (a TODO in the CI config). Running it there, one test per process, showed four things, all in the tests rather than in CryFS:

1. **Mount point.** The tests that expect a mount to succeed mounted into a temporary directory, and CryFS on Windows only mounts to a drive letter (`Fuse::_run` refuses anything else). They now mount to a free drive letter on Windows (`mountpoint`), while `mountdir` stays a directory for the tests of the checks CryFS does on its mount directory. The tests that need the mount directory to be a directory (creating it, filling it beforehand, setting its permissions) skip on Windows and say why.

2. **The mount isn't visible yet when `init()` runs.** Dokany calls `Fuse::init()`, which is what tells the harness the file system is mounted, while it is still setting the mount up. Right after it, the drive letter isn't there yet: accessing the file system fails, and so does `DokanRemoveMountPoint()`, which left the file system mounted and the test waiting for `Cli::main()` to return, which it never did (34 tests hung this way). The harness now waits for the mount point to show up before it calls the test's `onMounted` callback or unmounts; libfuse calls `init()` once the mount is live, so on Linux and macOS this returns immediately. If the callback throws, the harness unmounts anyway, so the failure is reported instead of turning into a hang.

3. **A dangling argument.** `CryfsUnmountTest` built its argument list from `mountdir.string().c_str()`, a pointer into a temporary. On Linux and macOS `path::string()` returns a reference to the path's own string, so this worked by accident; on Windows it returns a copy and the argument was garbage.

4. **Linux assumptions in three tests.** `ProgramOptionsTest` used `/home/user/mydir` as an absolute path, which `bf::absolute()` turns into `D:/home/user/mydir` on Windows. `ParserTest` expected foreground to be off by default, while the Windows parser forces it on. The `MountDirIsBaseDir_*Relative` tests computed a path relative to the working directory by hand, which can't reach a directory on another drive, as it is on the CI runners (working directory on `D:`, temporary directory on `C:`); they use `bf::relative` now and skip when there is no relative path.

The first commit here is #649 (this branch is stacked on it, because both change the same harness); this pull request's own change is the last commit.

## Verification

- `windows-2022` and `windows-2025` runners, each test in its own process (#650): 243 tests pass, 35 skip for the reasons above, none fail. Before the fixes 51 failed or hung.
- Linux unchanged: 262 tests pass (the permission tests were excluded locally because the check ran as root).
- The note in `AGENTS.md` describes the state after this and #648.

Part of a series of small pull requests that enable the test binaries CI currently skips on macOS and Windows, one issue per pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012uPAugV9TZN8nZckjda4Pz

---
_Generated by [Claude Code](https://claude.ai/code/session_012uPAugV9TZN8nZckjda4Pz)_