### PR TITLE
Merge with_async_drop_2! and the with_async_drop function into with_async_drop!

### DIFF
--- a/.claude/skills/async-drop/SKILL.md
+++ b/.claude/skills/async-drop/SKILL.md
@@ -66,16 +66,16 @@ impl AsyncDrop for MyType {
 | **Factory methods return guards** | `fn new() -> AsyncDropGuard<Self>`, never plain `Self` |
 | **Types with guard members impl AsyncDrop** | `async fn async_drop_impl(self)`: destructure `self`, drop members |
 | **No `#[async_trait]` on AsyncDrop impls** | The trait uses native `async fn` in traits |
-| **Use the macro when possible** | `with_async_drop_2!` handles cleanup automatically |
+| **Use the macro when possible** | `with_async_drop!` handles cleanup automatically |
 | **Panics are exceptions** | It's OK to skip async_drop on panic paths |
 
-## The `with_async_drop_2!` Macro
+## The `with_async_drop!` Macro
 
 Automatically calls `async_drop()` on scope exit:
 
 ```rust
 let resource = get_resource().await?;
-with_async_drop_2!(resource, {
+with_async_drop!(resource, {
     // Use resource here
     resource.do_work().await?;
     Ok(result)
@@ -85,7 +85,7 @@ with_async_drop_2!(resource, {
 Several independent guards can be listed; they are dropped concurrently afterward:
 
 ```rust
-with_async_drop_2!(source, dest, {
+with_async_drop!(source, dest, {
     move_entry(&source, &dest).await
 })
 ```

--- a/.claude/skills/async-drop/gotchas.md
+++ b/.claude/skills/async-drop/gotchas.md
@@ -26,7 +26,7 @@ async fn good() -> Result<()> {
 // BETTER - use the macro
 async fn better() -> Result<()> {
     let resource = Resource::new();
-    with_async_drop_2!(resource, {
+    with_async_drop!(resource, {
         resource.do_work().await
     })
 }
@@ -302,4 +302,4 @@ Before submitting code with AsyncDrop:
 - [ ] `unsafe_into_inner_dont_drop()` only used internally, with member cleanup handled
 - [ ] Drop order correct for dependent members (reverse of construction)
 - [ ] Independent members dropped concurrently (Pattern 10)
-- [ ] Using `with_async_drop_2!` where possible
+- [ ] Using `with_async_drop!` where possible

--- a/.claude/skills/async-drop/helpers.md
+++ b/.claude/skills/async-drop/helpers.md
@@ -218,21 +218,6 @@ async_drop is complete and will cause bad performance.
 
 ## Utility Functions
 
-### `with_async_drop()`
-
-Function version of the macro for more complex scenarios.
-
-```rust
-pub async fn with_async_drop<T, R, E, F>(
-    mut value: AsyncDropGuard<T>,
-    f: impl FnOnce(&mut T) -> F,
-) -> Result<R, E>
-where
-    T: AsyncDrop + Debug,
-    E: From<<T as AsyncDrop>::Error>,
-    F: Future<Output = Result<R, E>>,
-```
-
 ### `async_drop_all()`
 
 Drops a tuple of guards concurrently. Waits for all of them even if some fail and returns
@@ -244,7 +229,7 @@ of them.
 async_drop_all((source_parent, dest_parent, maybe_self_blob)).await?;
 ```
 
-This is what the multi-guard form of `with_async_drop_2!` uses after its block.
+This is what the multi-guard form of `with_async_drop!` uses after its block.
 
 ### `flatten_async_drop()`
 

--- a/.claude/skills/async-drop/patterns.md
+++ b/.claude/skills/async-drop/patterns.md
@@ -58,17 +58,17 @@ impl AsyncDrop for CompositeResource {
 A type that also implements `Drop` cannot be destructured. Store its guard members
 in an `Option` and `.take()` them in `async_drop_impl` instead.
 
-## Pattern 3: Using `with_async_drop_2!` Macro
+## Pattern 3: Using `with_async_drop!` Macro
 
 The preferred approach when it fits - automatically handles cleanup:
 
 ```rust
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 
 async fn process_file(path: &Path) -> Result<Data> {
     let file = open_file(path).await?;  // Returns AsyncDropGuard<File>
 
-    with_async_drop_2!(file, {
+    with_async_drop!(file, {
         // Use file here
         let data = file.read_all().await?;
         process(data).await
@@ -81,32 +81,32 @@ async fn process_file(path: &Path) -> Result<Data> {
 
 ```rust
 // Basic - propagates async_drop errors as-is
-with_async_drop_2!(value, {
+with_async_drop!(value, {
     // ... work ...
     Ok(result)
 })
 
 // With error mapping - converts async_drop errors
-with_async_drop_2!(value, {
+with_async_drop!(value, {
     // ... work ...
     Ok(result)
 }, MyError::from)
 
 // Infallible - for types with Error = Never
-with_async_drop_2_infallible!(value, {
+with_async_drop_infallible!(value, {
     // ... work ...
     result
 })
 
 // Several independent guards - all forms accept a list; the guards are dropped
 // concurrently after the block (they must share the same error type)
-with_async_drop_2!(source, dest, {
+with_async_drop!(source, dest, {
     // ... work with source and dest ...
     Ok(result)
 })
 ```
 
-Prefer the multi-guard form over nesting one `with_async_drop_2!` inside another: it
+Prefer the multi-guard form over nesting one `with_async_drop!` inside another: it
 is flatter and drops the guards concurrently.
 
 ## Pattern 4: Keeping the Guard on Success, Dropping It on Error
@@ -362,7 +362,7 @@ async fn good_example(mut resource: AsyncDropGuard<R>) -> Result<()> {
 
 // BETTER - use the macro
 async fn best_example(resource: AsyncDropGuard<R>) -> Result<()> {
-    with_async_drop_2!(resource, {
+    with_async_drop!(resource, {
         resource.step1().await
     })
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ Types needing async cleanup use `AsyncDropGuard<T>`. See the async-drop skill fo
 - `async_drop()` consumes the guard: use-after-drop and double-drop are compile errors
 - Factory methods return `AsyncDropGuard<Self>`, never plain `Self`
 - Types with guard members must implement `AsyncDrop` to delegate: `async fn async_drop_impl(self)`, destructure `self` listing every field (no `..`), drop the guard members. No `#[async_trait]` on `AsyncDrop` impls
-- Use `with_async_drop_2!` macro when possible; otherwise call `async_drop()` on all exit paths
+- Use `with_async_drop!` macro when possible; otherwise call `async_drop()` on all exit paths
 - Panics are exceptions - ok to skip `async_drop()` on panic paths
 
 **Implementation**: `crates/utils/src/async_drop/`

--- a/crates/check/tests/common/entry_helpers.rs
+++ b/crates/check/tests/common/entry_helpers.rs
@@ -25,7 +25,7 @@ use cryfs_fsblobstore::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     path::AbsolutePathBuf,
-    with_async_drop_2,
+    with_async_drop,
 };
 use cryfs_utils::{data::Data, testutils::data_fixture::DataFixture};
 
@@ -941,7 +941,7 @@ where
     Box::pin(
         async move {
             let blob = fsblobstore.load(&dir_blob_id).await.unwrap().unwrap();
-            let (children, dir_children) = with_async_drop_2!(blob, {
+            let (children, dir_children) = with_async_drop!(blob, {
                 let blob = blob.as_dir().expect("Expected a directory blob");
                 let children = blob
                     .entries()
@@ -980,7 +980,7 @@ where
     Box::pin(
         async move {
             let blob = fsblobstore.load(&maybe_dir_blob_id).await.unwrap().unwrap();
-            with_async_drop_2!(blob, {
+            with_async_drop!(blob, {
                 if let Ok(blob) = blob.as_dir() {
                     let children = blob
                         .entries()

--- a/crates/check/tests/common/fixture.rs
+++ b/crates/check/tests/common/fixture.rs
@@ -19,7 +19,7 @@ use cryfs_utils::path::AbsolutePathBuf;
 use cryfs_utils::{
     async_drop::{AsyncDropGuard, SyncDrop},
     progress::SilentProgressBarManager,
-    with_async_drop_2,
+    with_async_drop,
 };
 use futures::{Future, future::BoxFuture, stream::StreamExt};
 use rand::{SeedableRng, rngs::SmallRng};
@@ -196,7 +196,7 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let root_blob = blobstore.load(&root_id).await.unwrap().unwrap();
                 let mut root = CreatedDirBlob::new(root_blob, AbsolutePathBuf::root());
-                with_async_drop_2!(root, {
+                with_async_drop!(root, {
                     Ok::<_, anyhow::Error>(
                         super::entry_helpers::create_some_blobs(blobstore, &mut root).await,
                     )
@@ -229,7 +229,7 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let parent_blob = blobstore.load(&parent.blob_id).await.unwrap().unwrap();
                 let mut parent = CreatedDirBlob::new(parent_blob, parent.referenced_as.path);
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let file =
                         super::entry_helpers::create_empty_file(blobstore, &mut parent, &name)
                             .await;
@@ -258,10 +258,10 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let parent_blob = blobstore.load(&parent.blob_id).await.unwrap().unwrap();
                 let mut parent = CreatedDirBlob::new(parent_blob, parent.referenced_as.path);
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let created_dir =
                         super::entry_helpers::create_empty_dir(blobstore, &mut parent, &name).await;
-                    with_async_drop_2!(created_dir, {
+                    with_async_drop!(created_dir, {
                         Ok::<_, anyhow::Error>((&*created_dir).into())
                     })
                 })
@@ -288,7 +288,7 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let parent_blob = blobstore.load(&parent.blob_id).await.unwrap().unwrap();
                 let mut parent_blob = CreatedDirBlob::new(parent_blob, parent.referenced_as.path);
-                with_async_drop_2!(parent_blob, {
+                with_async_drop!(parent_blob, {
                     let symlink = super::entry_helpers::create_symlink(
                         blobstore,
                         &mut parent_blob,
@@ -311,7 +311,7 @@ impl FilesystemFixture {
         self.update_fsblobstore(move |blobstore| {
             Box::pin(async move {
                 let mut parent = blobstore.load(&parent).await.unwrap().unwrap();
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let mut parent = parent.as_dir_mut().unwrap();
                     super::entry_helpers::add_file_entry(&mut parent, &name, blob_id);
                     Ok::<_, anyhow::Error>(())
@@ -327,7 +327,7 @@ impl FilesystemFixture {
         self.update_fsblobstore(move |blobstore| {
             Box::pin(async move {
                 let mut parent = blobstore.load(&parent).await.unwrap().unwrap();
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let mut parent = parent.as_dir_mut().unwrap();
                     super::entry_helpers::add_dir_entry(&mut parent, &name, blob_id);
                     Ok::<_, anyhow::Error>(())
@@ -343,7 +343,7 @@ impl FilesystemFixture {
         self.update_fsblobstore(move |blobstore| {
             Box::pin(async move {
                 let mut parent = blobstore.load(&parent).await.unwrap().unwrap();
-                with_async_drop_2!(parent, {
+                with_async_drop!(parent, {
                     let mut parent = parent.as_dir_mut().unwrap();
                     super::entry_helpers::add_symlink_entry(&mut parent, &name, blob_id);
                     Ok::<_, anyhow::Error>(())
@@ -358,7 +358,7 @@ impl FilesystemFixture {
         self.update_fsblobstore(|fsblobstore| {
             Box::pin(async move {
                 let blob = fsblobstore.load(&dir_blob).await.unwrap().unwrap();
-                with_async_drop_2!(blob, {
+                with_async_drop!(blob, {
                     let blob = blob.as_dir().unwrap();
                     Ok::<_, anyhow::Error>(
                         blob.entries()
@@ -1028,7 +1028,7 @@ impl FilesystemFixture {
             Box::pin(async move {
                 let dir = fsblobstore.load(&blob_info.blob_id).await.unwrap().unwrap();
                 let mut dir = CreatedDirBlob::new(dir, blob_info.referenced_as.path);
-                with_async_drop_2!(dir, {
+                with_async_drop!(dir, {
                     entry_helpers::add_entries_to_make_dir_large(fsblobstore, &mut dir).await;
                     Ok::<_, anyhow::Error>(())
                 })

--- a/crates/concurrent-store/src/inserting.rs
+++ b/crates/concurrent-store/src/inserting.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, hash::Hash};
 
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
-    safe_panic, with_async_drop_2_infallible,
+    safe_panic, with_async_drop_infallible,
 };
 
 use crate::{LoadedEntryGuard, entry::EntryLoadingWaiter, store::ConcurrentStoreInner};
@@ -60,7 +60,7 @@ where
         V: AsyncDrop + Debug + Send + Sync,
     {
         let InsertingInner { waiter, store } = self.inner.take().expect("Already destructed");
-        with_async_drop_2_infallible!(store, {
+        with_async_drop_infallible!(store, {
             Ok(waiter.wait_until_loaded(&store).await?.expect(
                 "Invariant violated: Inserting should never return None from the loading function",
             ))

--- a/crates/concurrent-store/src/loading_or_loaded.rs
+++ b/crates/concurrent-store/src/loading_or_loaded.rs
@@ -3,7 +3,7 @@ use std::{fmt::Debug, hash::Hash};
 
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
-    safe_panic, with_async_drop_2_infallible,
+    safe_panic, with_async_drop_infallible,
 };
 
 use crate::{LoadedEntryGuard, entry::EntryLoadingWaiter, store::ConcurrentStoreInner};
@@ -69,7 +69,7 @@ where
             LoadingOrLoadedInner::NotFound => Ok(None),
             LoadingOrLoadedInner::Loaded(loaded) => Ok(Some(loaded)),
             LoadingOrLoadedInner::Loading { store, waiter } => {
-                with_async_drop_2_infallible!(store, { waiter.wait_until_loaded(&store).await })
+                with_async_drop_infallible!(store, { waiter.wait_until_loaded(&store).await })
             }
         }
     }

--- a/crates/concurrent-store/src/store.rs
+++ b/crates/concurrent-store/src/store.rs
@@ -17,7 +17,7 @@ use crate::guard::LoadedEntryGuard;
 use cryfs_utils::async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard};
 use cryfs_utils::event::Event;
 use cryfs_utils::stream::for_each_unordered;
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 
 // TODO This is currently not cancellation safe. If a task waiting for an entry to load is cancelled, the num_waiters and num_unfulfilled_waiters counts will be wrong.
 
@@ -379,7 +379,7 @@ where
     ) -> EntryStateLoading<V, E> {
         let inner = AsyncDropArc::clone(&self.inner);
         let loading_task = async move {
-            with_async_drop_2!(inner, {
+            with_async_drop!(inner, {
                 // Run loading_fn concurrently, without a lock on `entries`.
                 let result = loading_fn.await;
 
@@ -620,7 +620,7 @@ where
         let (immediate_drop_request, entry) = loaded.into_inner();
         let this = AsyncDropArc::clone(this);
         async move {
-            with_async_drop_2!(this, {
+            with_async_drop!(this, {
                 // This will be awaited after the lock on entries is released, so we can concurrently drop
                 // the entry without blocking other operations.
                 match immediate_drop_request {
@@ -655,7 +655,7 @@ where
     {
         let this = AsyncDropArc::clone(this);
         async move {
-            with_async_drop_2!(this, {
+            with_async_drop!(this, {
                 Self::_execute_immediate_drop(&this, key, None, drop_fn).await;
                 Ok(())
             })

--- a/crates/cryfs-filesystem/src/filesystem/device.rs
+++ b/crates/cryfs-filesystem/src/filesystem/device.rs
@@ -4,7 +4,7 @@ use atomic_time::AtomicInstant;
 use cryfs_blockstore::RemoveResult;
 use cryfs_rustfs::AtimeUpdateBehavior;
 use cryfs_rustfs::object_based_api::Dir as _;
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 use futures::join;
 use maybe_owned::MaybeOwned;
 use std::sync::Arc;
@@ -85,7 +85,7 @@ where
     pub async fn sanity_check(&self) -> Result<()> {
         // Make sure we can load the root dir and load its children
         let rootdir = self.rootdir().await.context("Didn't find root blob")?;
-        with_async_drop_2!(rootdir, {
+        with_async_drop!(rootdir, {
             rootdir.entries().await.context("Couldn't load root blob")?;
             Ok(())
         })
@@ -371,7 +371,7 @@ where
 
             match self.load_two_blobs(source_parent, dest_parent).await? {
                 LoadTwoBlobsResult::AreSameBlob(blob) => {
-                    with_async_drop_2!(
+                    with_async_drop!(
                         blob,
                         {
                             blob.with_lock(async |blob| {
@@ -402,7 +402,7 @@ where
                     //      blobs at once is risky for deadlocks if not done in a consistent order.
                     // TODO Improve concurrency in this function
 
-                    with_async_drop_2!(
+                    with_async_drop!(
                         source_parent_blob,
                         dest_parent_blob,
                         {
@@ -431,7 +431,7 @@ where
                                 .ok_or(FsError::NodeDoesNotExist)?;
 
                             // TODO Drop self_blob concurrently with source_parent_blob and dest_parent_blob
-                            with_async_drop_2!(
+                            with_async_drop!(
                                 self_blob,
                                 {
                                     source_parent_blob
@@ -589,7 +589,7 @@ where
                 FsError::NodeDoesNotExist,
             )?;
 
-        with_async_drop_2!(
+        with_async_drop!(
             overwritten_blob,
             {
                 overwritten_blob.with_lock(async |overwritten_blob| {

--- a/crates/cryfs-filesystem/src/filesystem/dir.rs
+++ b/crates/cryfs-filesystem/src/filesystem/dir.rs
@@ -21,7 +21,7 @@ use cryfs_rustfs::{DirEntry, FsError, FsResult, NodeAttrs, NodeKind, object_base
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard, flatten_async_drop},
     path::PathComponent,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 #[derive(Debug)]
@@ -253,7 +253,7 @@ where
         self.node_info
             .concurrently_update_modification_timestamp_in_parent(async || {
                 let blob = self.load_blob().await?;
-                with_async_drop_2!(
+                with_async_drop!(
                     blob,
                     {
                         blob.with_lock(async |blob| {
@@ -300,12 +300,12 @@ where
         //      blobs at once is risky for deadlocks if not done in a consistent order.
 
         // TODO Improve concurrency in this function
-        with_async_drop_2!(newparent, {
+        with_async_drop!(newparent, {
             let (source_parent, dest_parent) = join!(self.load_blob(), newparent.load_blob());
             let (source_parent, dest_parent) =
                 flatten_async_drop(source_parent, dest_parent).await?;
             // TODO Drop newparent and self_blob concurrently with source_parent and dest_parent
-            with_async_drop_2!(
+            with_async_drop!(
                 source_parent,
                 dest_parent,
                 {
@@ -341,7 +341,7 @@ where
                             // TODO This branch means there was an entry in the parent dir but the blob itself doesn't exist. How should we handle this?
                             FsError::NodeDoesNotExist,
                         )?;
-                    with_async_drop_2!(
+                    with_async_drop!(
                         self_blob,
                         {
                             let entry = source_parent
@@ -439,7 +439,7 @@ where
         self.node_info
             .concurrently_maybe_update_access_timestamp_in_parent(async || {
                 let blob = self.load_blob().await?;
-                with_async_drop_2!(
+                with_async_drop!(
                     blob,
                     {
                         blob.with_lock(async |blob| {
@@ -561,7 +561,7 @@ where
         self.node_info
             .concurrently_update_modification_timestamp_in_parent( async || {
                 let self_blob = self.load_blob().await?;
-                with_async_drop_2!(self_blob, {
+                with_async_drop!(self_blob, {
                     let child_id = self_blob
                         .with_lock(async |self_blob| {
                             let self_blob = Self::blob_as_dir(&*self_blob)?;
@@ -741,7 +741,7 @@ where
         self.node_info.concurrently_update_modification_timestamp_in_parent( async || {
             let blob = self.load_blob().await?;
 
-            with_async_drop_2!(blob, {
+            with_async_drop!(blob, {
                 let removed = blob.with_lock(async |blob| {
                     let blob = Self::blob_as_dir_mut(&mut *blob)?;
                     // First remove the entry, then flush that change, and only then remove the blob.

--- a/crates/cryfs-filesystem/src/filesystem/node.rs
+++ b/crates/cryfs-filesystem/src/filesystem/node.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 #[cfg(feature = "testutils")]
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 #[cfg(feature = "testutils")]
 use futures::join;
 use std::fmt::Debug;
@@ -65,7 +65,7 @@ where
     async fn flush_blob(&self) -> FsResult<()> {
         // TODO We'd only have to flush it if it's actually in some cache, but it might be far down the stack in some blockstore cache.
         let blob = self.node_info.load_blob(&self.blobstore).await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |blob| {

--- a/crates/cryfs-filesystem/src/filesystem/node_info.rs
+++ b/crates/cryfs-filesystem/src/filesystem/node_info.rs
@@ -1,4 +1,4 @@
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 use std::fmt::Debug;
 use std::time::SystemTime;
 use tokio::join;
@@ -320,7 +320,7 @@ where
         new_size: NumBytes,
     ) -> FsResult<()> {
         let blob = self.load_blob(blobstore).await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |mut blob| {

--- a/crates/cryfs-filesystem/src/filesystem/open_file.rs
+++ b/crates/cryfs-filesystem/src/filesystem/open_file.rs
@@ -10,7 +10,7 @@ use cryfs_rustfs::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
     data::Data,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 use super::node_info::NodeInfo;
@@ -65,7 +65,7 @@ where
 
     async fn flush_file_contents(&self) -> FsResult<()> {
         let blob = self.load_blob().await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |mut blob| {
@@ -89,7 +89,7 @@ where
 
     async fn _read(&self, offset: NumBytes, size: NumBytes) -> FsResult<Data> {
         let blob = self.load_blob().await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |mut blob| {
@@ -119,7 +119,7 @@ where
 
     async fn _write(&self, offset: NumBytes, data: Data) -> FsResult<()> {
         let blob = self.load_blob().await?;
-        with_async_drop_2!(
+        with_async_drop!(
             blob,
             {
                 blob.with_lock(async |mut blob| {

--- a/crates/cryfs-filesystem/src/filesystem/symlink.rs
+++ b/crates/cryfs-filesystem/src/filesystem/symlink.rs
@@ -11,7 +11,7 @@ use cryfs_blobstore::BlobStore;
 use cryfs_rustfs::{FsError, FsResult, object_based_api::Symlink};
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
-    with_async_drop_2,
+    with_async_drop,
 };
 
 #[derive(Debug)]
@@ -72,7 +72,7 @@ where
         self.node_info
             .concurrently_maybe_update_access_timestamp_in_parent(async || {
                 let blob = self.load_blob().await?;
-                with_async_drop_2!(
+                with_async_drop!(
                     blob,
                     {
                         blob.with_lock(async |mut blob| {

--- a/crates/fsblobstore/src/concurrentfsblobstore/store.rs
+++ b/crates/fsblobstore/src/concurrentfsblobstore/store.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 use cryfs_blobstore::{BlobId, BlobStore, RemoveResult};
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard},
-    with_async_drop_2,
+    with_async_drop,
 };
 
 use crate::{
@@ -46,7 +46,7 @@ where
         let root_blob_id = *root_blob_id;
         let blobstore = AsyncDropArc::clone(&self.blobstore);
         LoadedBlobs::try_insert_loading(&self.loaded_blobs, root_blob_id, async move || {
-            with_async_drop_2!(blobstore, {
+            with_async_drop!(blobstore, {
                 blobstore.create_root_dir_blob(&root_blob_id).await
             })
             .map_err(Arc::new)
@@ -110,7 +110,7 @@ where
             blob_id,
             &self.blobstore,
             async move |blobstore| {
-                with_async_drop_2!(blobstore, { blobstore.load(&blob_id).await }).map_err(Arc::new)
+                with_async_drop!(blobstore, { blobstore.load(&blob_id).await }).map_err(Arc::new)
             },
         )
         .await?;

--- a/crates/rustfs/examples/inmemory/device.rs
+++ b/crates/rustfs/examples/inmemory/device.rs
@@ -10,7 +10,7 @@ use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     mutex::lock_in_ptr_order,
     path::AbsolutePath,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 use super::dir::{DirInode, InMemoryDirRef};
@@ -118,17 +118,17 @@ impl Device for InMemoryDevice {
                 return Err(FsError::InvalidOperation);
             };
             let new_parent = self.rootdir.load_node(new_parent_path)?;
-            with_async_drop_2!(new_parent, {
+            with_async_drop!(new_parent, {
                 let new_parent = new_parent.as_dir().await?;
-                with_async_drop_2!(new_parent, {
+                with_async_drop!(new_parent, {
                     if old_parent_path == new_parent_path {
                         // We're just renaming it within one directory
                         new_parent.rename(old_name, new_name)
                     } else {
                         let source_parent = self.rootdir.load_node(old_parent_path)?;
-                        with_async_drop_2!(source_parent, {
+                        with_async_drop!(source_parent, {
                             let source_parent = source_parent.as_dir().await?;
-                            with_async_drop_2!(source_parent, {
+                            with_async_drop!(source_parent, {
                                 // We're moving it to another directory
                                 let (mut source_inode, mut target_inode) =
                                     lock_in_ptr_order(&source_parent.inode(), &new_parent.inode());

--- a/crates/rustfs/examples/inmemory/dir.rs
+++ b/crates/rustfs/examples/inmemory/dir.rs
@@ -7,7 +7,7 @@ use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     mutex::lock_in_ptr_order,
     path::{PathComponent, PathComponentBuf},
-    with_async_drop_2,
+    with_async_drop,
 };
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
@@ -194,7 +194,7 @@ impl Dir for InMemoryDirRef {
         newparent: AsyncDropGuard<Self>,
         newname: &PathComponent,
     ) -> FsResult<()> {
-        with_async_drop_2!(newparent, {
+        with_async_drop!(newparent, {
             // We're moving it to another directory
             let (mut source_inode, mut target_inode) =
                 lock_in_ptr_order(&self.inode(), &newparent.inode());

--- a/crates/rustfs/examples/passthrough/dir.rs
+++ b/crates/rustfs/examples/passthrough/dir.rs
@@ -6,7 +6,7 @@ use cryfs_rustfs::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     path::{AbsolutePathBuf, PathComponent},
-    with_async_drop_2,
+    with_async_drop,
 };
 use nix::fcntl::{AT_FDCWD, AtFlags};
 use std::os::unix::fs::OpenOptionsExt;
@@ -63,7 +63,7 @@ impl Dir for PassthroughDir {
         newparent: AsyncDropGuard<Self>,
         newname: &PathComponent,
     ) -> FsResult<()> {
-        with_async_drop_2!(newparent, {
+        with_async_drop!(newparent, {
             let old_path = self.path.clone().push(oldname);
             let new_path = newparent.path.clone().push(newname);
             tokio::fs::rename(old_path, new_path).await.map_error()
@@ -134,7 +134,7 @@ impl Dir for PassthroughDir {
         let node = PassthroughDir::new(path.clone());
         // TODO Return value directly without another call but make sure it returns the same value
         let child_node = PassthroughNode::new(path);
-        let attrs = with_async_drop_2!(child_node, { child_node.getattr().await })?;
+        let attrs = with_async_drop!(child_node, { child_node.getattr().await })?;
         Ok((attrs, AsyncDropGuard::new(node)))
     }
 
@@ -172,7 +172,7 @@ impl Dir for PassthroughDir {
             .map_err(|_: tokio::task::JoinError| FsError::UnknownError)??;
         // TODO Return value directly without another call but make sure it returns the same value
         let node = PassthroughNode::new(path);
-        with_async_drop_2!(node, {
+        with_async_drop!(node, {
             let attrs = node.getattr().await?;
             let symlink = node.as_symlink().await?;
             Ok((attrs, symlink))

--- a/crates/rustfs/src/object_based_api/high_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/high_level_adapter.rs
@@ -15,7 +15,7 @@ use crate::high_level_api::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     path::AbsolutePath,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 // TODO Make sure each function checks the preconditions on its parameters, e.g. paths must be absolute, here and elsewhere.
@@ -135,7 +135,7 @@ where
             // TODO No unwrap
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, { node.getattr().await })?
+            with_async_drop!(node, { node.getattr().await })?
         };
         Ok(AttrResponse {
             ttl: TTL_GETATTR,
@@ -164,7 +164,7 @@ where
         } else {
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(Some(mode), None, None, None, None, None, None)
                     .await
             })?;
@@ -193,7 +193,7 @@ where
         } else {
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(None, uid, gid, None, None, None, None).await
             })?;
         }
@@ -221,7 +221,7 @@ where
         } else {
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(None, None, None, Some(size), None, None, None)
                     .await
             })?;
@@ -250,7 +250,7 @@ where
         } else {
             let fs = self.fs.read().unwrap();
             let node = fs.get().lookup(path).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(None, None, None, None, atime, mtime, None)
                     .await
             })?;
@@ -279,9 +279,9 @@ where
 
         let fs = self.fs.read().unwrap();
         let link = fs.get().lookup(path).await?;
-        with_async_drop_2!(link, {
+        with_async_drop!(link, {
             let link = link.as_symlink().await?;
-            with_async_drop_2!(link, { link.target().await })
+            with_async_drop!(link, { link.target().await })
         })
     }
 
@@ -314,9 +314,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_child_dir() ?
                 // TODO No need to return the child dir object to just immediately async_drop it
                 let (new_dir_attrs, new_dir) = parent_dir
@@ -341,9 +341,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 parent_dir.remove_child_file_or_symlink(&name).await
             })?;
             Ok(())
@@ -360,9 +360,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            with_async_drop_2!(parent_dir, { parent_dir.remove_child_dir(&name).await })?;
+            with_async_drop!(parent_dir, { parent_dir.remove_child_dir(&name).await })?;
             Ok(())
         })
     }
@@ -383,9 +383,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_child_symlink() ?
                 // TODO No need to return the symlink object to just immediately async_drop it
                 let (new_symlink_attrs, symlink) = parent_dir
@@ -444,7 +444,7 @@ where
 
         let fs = self.fs.read().unwrap();
         let file = fs.get().lookup(path).await?;
-        with_async_drop_2!(file, {
+        with_async_drop!(file, {
             let file = file.as_file().await?;
             let result = match File::into_open(file, flags).await {
                 Err(err) => Err(err),
@@ -589,9 +589,9 @@ where
 
         let fs = self.fs.read().unwrap();
         let dir = fs.get().lookup(path).await?;
-        with_async_drop_2!(dir, {
+        with_async_drop!(dir, {
             let dir = dir.as_dir().await?;
-            let entries = with_async_drop_2!(dir, { dir.entries().await })?;
+            let entries = with_async_drop!(dir, { dir.entries().await })?;
             let parent_entries = [
                 DirEntryOrReference::SelfReference,
                 DirEntryOrReference::ParentReference,
@@ -733,9 +733,9 @@ where
         })?;
         let fs = self.fs.read().unwrap();
         let parent_dir = fs.get().lookup(parent).await?;
-        with_async_drop_2!(parent_dir, {
+        with_async_drop!(parent_dir, {
             let parent_dir = parent_dir.as_dir().await?;
-            let (file_attrs, node, open_file) = with_async_drop_2!(parent_dir, {
+            let (file_attrs, node, open_file) = with_async_drop!(parent_dir, {
                 // TODO Can we avoid the parent_dir.async_drop if we do something like parent_dir.into_create_and_open_file() ?
                 // TODO No need to return the node just to immediately async_drop it below
                 parent_dir

--- a/crates/rustfs/src/object_based_api/interface/device.rs
+++ b/crates/rustfs/src/object_based_api/interface/device.rs
@@ -7,7 +7,7 @@ use crate::common::{FsError, FsResult, Statfs};
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropGuard},
     path::AbsolutePath,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 // TODO We only call this `Device` because that's the historical name from the c++ Cryfs version. We should probably rename this to `Filesystem`.
@@ -74,7 +74,7 @@ pub trait Device {
                         match dir {
                             Ok(dir) => {
                                 // TODO Can we avoid the async_drop here by using something like dir.into_lookup_child() ?
-                                with_async_drop_2!(dir, {
+                                with_async_drop!(dir, {
                                     let child = dir.lookup_child(component);
                                     child.await
                                 })
@@ -91,7 +91,7 @@ pub trait Device {
                     match dir {
                         Ok(dir) => {
                             // TODO Can we avoid the async_drop here by using something like dir.into_lookup_child() ?
-                            with_async_drop_2!(dir, {
+                            with_async_drop!(dir, {
                                 let child = dir.lookup_child(node_name);
                                 child.await
                             })

--- a/crates/rustfs/src/object_based_api/low_level_adapter.rs
+++ b/crates/rustfs/src/object_based_api/low_level_adapter.rs
@@ -26,7 +26,7 @@ use crate::{
 use cryfs_utils::{
     async_drop::{AsyncDrop, AsyncDropArc, AsyncDropGuard, async_drop_all, flatten_async_drop},
     path::PathComponent,
-    with_async_drop_2,
+    with_async_drop,
 };
 
 // TODO What are good TTLs here?
@@ -230,12 +230,12 @@ where
         let load_child = move |parent_node: &AsyncDropGuard<AsyncDropArc<Fs::Node>>| {
             let parent_node = AsyncDropArc::clone(parent_node); // TODO Why is this necessary?
             async move {
-                with_async_drop_2!(parent_node, {
+                with_async_drop!(parent_node, {
                     let parent_node_dir = parent_node
                         .as_dir()
                         .await
                         .expect("Error: Inode number is not a directory");
-                    with_async_drop_2!(parent_node_dir, {
+                    with_async_drop!(parent_node_dir, {
                         // TODO Can we avoid the async_drop here by using something like parent_node_dir.into_lookup_child() ?
                         parent_node_dir.lookup_child(&name_clone).await
                     })
@@ -248,7 +248,7 @@ where
             .add_or_increment_refcount(parent_ino, name.to_owned(), load_child)
             .await?;
 
-        with_async_drop_2!(child, {
+        with_async_drop!(child, {
             child.getattr().await.map(|attr| ReplyEntry {
                 ttl: TTL_LOOKUP,
                 ino,
@@ -288,7 +288,7 @@ where
                 .await?
         } else {
             let node = self.get_inode(ino).await?;
-            with_async_drop_2!(node, { node.getattr().await })?
+            with_async_drop!(node, { node.getattr().await })?
         };
 
         Ok(ReplyAttr {
@@ -328,7 +328,7 @@ where
                 .await?
         } else {
             let node = self.get_inode(ino).await?;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 node.setattr(mode, uid, gid, size, atime, mtime, ctime)
                     .await
             })?
@@ -358,7 +358,7 @@ where
             Err(err) => return callback.call(Err(err)),
         };
         let target = match inode.as_symlink().await {
-            Ok(inode_symlink) => with_async_drop_2!(inode_symlink, {
+            Ok(inode_symlink) => with_async_drop!(inode_symlink, {
                 let target = inode_symlink.target();
                 target.await
             }),
@@ -403,11 +403,11 @@ where
         // In my tests with fuser 0.12.0, umask is already auto-applied to mode and the `umask` argument is always `0`.
         // TODO see https://github.com/cberner/fuser/issues/256
         let parent = self.get_inode(parent_ino).await?;
-        let (attr, child) = with_async_drop_2!(parent, {
+        let (attr, child) = with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
 
             // TODO Can we avoid the async_drop here by using something like dir.into_create_child_dir() ?
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 let (attrs, child) = parent_dir
                     .create_child_dir(name, mode, req.uid, req.gid)
                     .await?;
@@ -436,9 +436,9 @@ where
         self.trigger_on_operation().await?;
 
         let parent = self.get_inode(parent_ino).await?;
-        with_async_drop_2!(parent, {
+        with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 parent_dir.remove_child_file_or_symlink(name).await?;
                 self._orphan_inode(parent_ino, name).await;
                 Ok::<_, FsError>(())
@@ -456,9 +456,9 @@ where
         self.trigger_on_operation().await?;
 
         let parent = self.get_inode(parent_ino).await?;
-        with_async_drop_2!(parent, {
+        with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 parent_dir.remove_child_dir(name).await?;
                 self._orphan_inode(parent_ino, name).await;
                 Ok::<_, FsError>(())
@@ -479,10 +479,10 @@ where
         // TODO Here (and maybe also in mkdir / create_file), existing nodes should be overwritten
 
         let parent = self.get_inode(parent_ino).await?;
-        let (attrs, child) = with_async_drop_2!(parent, {
+        let (attrs, child) = with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
             // TODO Can we avoid the async_drop here by using something like dir.into_create_child_symlink()?
-            with_async_drop_2!(parent_dir, {
+            with_async_drop!(parent_dir, {
                 let (attrs, child) = parent_dir
                     .create_child_symlink(name, link, req.uid, req.gid)
                     .await?;
@@ -518,9 +518,9 @@ where
         // TODO Check that oldparent+oldname/newparent+newname aren't ancestors of each other, or at least write a test that fuse already blocks that
         if oldparent_ino == newparent_ino {
             let shared_parent = self.get_inode(oldparent_ino).await?;
-            with_async_drop_2!(shared_parent, {
+            with_async_drop!(shared_parent, {
                 let parent_dir = shared_parent.as_dir().await?;
-                with_async_drop_2!(parent_dir, {
+                with_async_drop!(parent_dir, {
                     parent_dir.rename_child(oldname, newname).await?;
                     self._move_inode(oldparent_ino, oldname, newparent_ino, newname)
                         .await?;
@@ -534,7 +534,7 @@ where
             let (oldparent, newparent) = flatten_async_drop(oldparent, newparent).await?;
             let result = async {
                 let oldparent_dir = oldparent.as_dir().await?;
-                with_async_drop_2!(oldparent_dir, {
+                with_async_drop!(oldparent_dir, {
                     let newparent_dir = newparent.as_dir().await?;
                     oldparent_dir
                         .move_child_to(oldname, newparent_dir, newname)
@@ -572,7 +572,7 @@ where
         self.trigger_on_operation().await?;
 
         let inode = self.get_inode(ino).await?;
-        with_async_drop_2!(inode, {
+        with_async_drop!(inode, {
             let file = inode.as_file().await?;
             let open_file = File::into_open(file, flags);
             let open_file = open_file.await?;
@@ -674,7 +674,7 @@ where
 
         // TODO What to do with flags, lock_owner?
         let open_file = self.open_files.remove(fh);
-        with_async_drop_2!(open_file, {
+        with_async_drop!(open_file, {
             if flush {
                 // TODO Is this actually what the `flush` parameter should do?
                 open_file.flush().await?;
@@ -738,9 +738,9 @@ where
 
         let (node, parent_ino) = self.get_inode_and_parent_ino(ino).await?;
 
-        with_async_drop_2!(node, {
+        with_async_drop!(node, {
             let dir = node.as_dir().await?;
-            with_async_drop_2!(dir, {
+            with_async_drop!(dir, {
                 let offset = usize::try_from(offset).unwrap(); // TODO No unwrap
 
                 if offset == 0 {
@@ -954,10 +954,10 @@ where
         // In my tests with fuser 0.12.0, umask is already auto-applied to mode and the `umask` argument is always `0`.
         // TODO see https://github.com/cberner/fuser/issues/256
         let parent = self.get_inode(parent_ino).await?;
-        with_async_drop_2!(parent, {
+        with_async_drop!(parent, {
             let parent_dir = parent.as_dir().await?;
             // TODO Can we avoid the async_drop here by using something like dir.into_create_and_open_file() ?
-            let (attr, child_node, open_file) = with_async_drop_2!(parent_dir, {
+            let (attr, child_node, open_file) = with_async_drop!(parent_dir, {
                 parent_dir
                     .create_and_open_file(name, mode, req.uid, req.gid, flags)
                     .await

--- a/crates/rustfs/src/object_based_api/utils/inode_list/mod.rs
+++ b/crates/rustfs/src/object_based_api/utils/inode_list/mod.rs
@@ -3,7 +3,7 @@ use core::panic;
 use cryfs_concurrent_store::RequestImmediateDropResult;
 use cryfs_concurrent_store::{ConcurrentStore, LoadedEntryGuard};
 use cryfs_utils::stream::for_each_unordered;
-use cryfs_utils::with_async_drop_2;
+use cryfs_utils::with_async_drop;
 use derive_more::{Display, Error};
 use futures::future::BoxFuture;
 use futures::{FutureExt, future};
@@ -212,7 +212,7 @@ where
         ino: InodeNumber,
     ) -> FsResult<AsyncDropGuard<AsyncDropArc<Fs::Node>>> {
         let node = Self::_lookup_node(inner, ino)?;
-        with_async_drop_2!(node, {
+        with_async_drop!(node, {
             let inode_entry = AsyncDropArc::clone(node.value());
             Ok(inode_entry)
         })
@@ -229,7 +229,7 @@ where
 
         // TODO This Arc::clone is only necessary because MutexGuard can't project and get &mut on both inner.inodes and inner.inode_forest at the same time. Once Rust supports that, we can avoid this clone.
         let inodes = inner.inodes.clone_ref();
-        with_async_drop_2!(inodes, {
+        with_async_drop!(inodes, {
             let insert_result = inner
                 .inode_forest
                 .try_insert(parent_ino, name, node, async |node, new_child_ino| {
@@ -357,9 +357,9 @@ where
             >,
         >,
     ) -> FsResult<AsyncDropGuard<AsyncDropArc<Fs::Node>>> {
-        with_async_drop_2!(node_future, {
+        with_async_drop!(node_future, {
             let node = (&mut *node_future).await;
-            with_async_drop_2!(node, {
+            with_async_drop!(node, {
                 match node.as_inner() {
                     Err(err) => Err(err.clone()),
                     Ok(node) => Ok(AsyncDropArc::clone(node.value())),
@@ -399,7 +399,7 @@ where
 
         // TODO This Arc::clone is only necessary because MutexGuard can't project and get &mut on both inner.inodes and inner.inode_forest at the same time. Once Rust supports that, we can avoid this clone.
         let inodes = inner.inodes.clone_ref();
-        let (new_child_ino, new_node) = with_async_drop_2!(inodes, {
+        let (new_child_ino, new_node) = with_async_drop!(inodes, {
             let insert_result =
                 inner
                     .inode_forest
@@ -413,7 +413,7 @@ where
                                 // It's ok to capture the parent_node in this lambda, because
                                 // * If try_insert returns Ok, it always executes the lambda and we async_drop it here
                                 // * If try_insert returns Err, the lambda is never executed, but we panic below anyways.
-                                with_async_drop_2!(parent_node, {
+                                with_async_drop!(parent_node, {
                                     let node = loading_fn(&parent_node).await?;
                                     Ok(node)
                                 })
@@ -861,7 +861,7 @@ where
             use crate::object_based_api::Node as _;
 
             let guard = inode.wait_until_loaded().await.unwrap().unwrap();
-            with_async_drop_2!(guard, { guard.value().fsync(false).await })
+            with_async_drop!(guard, { guard.value().fsync(false).await })
         })
         .await?;
         Ok(())

--- a/crates/utils/src/async_drop/all.rs
+++ b/crates/utils/src/async_drop/all.rs
@@ -1,7 +1,7 @@
 //! Dropping several [AsyncDropGuard]s at once.
 //!
 //! [async_drop_all] takes a tuple of guards, drops all of them concurrently, and waits for
-//! all of them even if some fail. See [with_async_drop_2!](crate::with_async_drop_2) for the
+//! all of them even if some fail. See [with_async_drop!](crate::with_async_drop) for the
 //! macro form that also runs a block of code before dropping.
 
 use std::fmt::Debug;

--- a/crates/utils/src/async_drop/mod.rs
+++ b/crates/utils/src/async_drop/mod.rs
@@ -17,7 +17,6 @@ mod hash_map;
 pub use hash_map::AsyncDropHashMap;
 
 mod with;
-pub use with::with_async_drop;
 
 mod all;
 pub use all::{AsyncDropAllElement, AsyncDropTuple, async_drop_all};

--- a/crates/utils/src/async_drop/with.rs
+++ b/crates/utils/src/async_drop/with.rs
@@ -1,34 +1,26 @@
 //! RAII-style helpers for ensuring async_drop is called.
 //!
-//! This module provides macros and functions that ensure `async_drop` is called
-//! on an `AsyncDropGuard` even if the callback returns early or fails.
-
-use std::fmt::Debug;
-use std::future::Future;
-
-use super::{AsyncDrop, AsyncDropGuard};
-
-// TODO It seems that actually most of our call sites only use sync callbacks
-//      and have quite a hard time calling this because they need to wrap their callbacks into future::ready.
-//      Offer sync versions instead.
-
-// TODO Why does this need to be a macro? Can't call sites just use the function version?
+//! This module provides the [with_async_drop!](crate::with_async_drop) and
+//! [with_async_drop_infallible!](crate::with_async_drop_infallible) macros, which ensure
+//! `async_drop` is called on `AsyncDropGuard`s even if the block returns early or fails.
 
 /// Executes a block of code and ensures `async_drop` is called on the values afterward.
 ///
 /// This macro takes one or more `AsyncDropGuard`s and a block of code to execute. After the
 /// block completes (whether successfully or with an error), it calls `async_drop` on the values.
+/// It is a macro rather than a function so that the block can use the guards by name (and
+/// borrow them) while the macro still owns them and can consume them afterwards.
 /// Several values are dropped concurrently via [async_drop_all](crate::async_drop::async_drop_all),
 /// so they must be independent of each other and share the same error type.
 ///
 /// # Forms
 ///
-/// - `with_async_drop_2!(value, { ... })` - Propagates async_drop errors directly
-/// - `with_async_drop_2!(value, { ... }, err_map)` - Maps async_drop errors using `err_map`
-/// - `with_async_drop_2!(first, second, ..., { ... })` - Drops all values concurrently afterward
-/// - `with_async_drop_2!(first, second, ..., { ... }, err_map)` - Same, mapping async_drop errors
+/// - `with_async_drop!(value, { ... })` - Propagates async_drop errors directly
+/// - `with_async_drop!(value, { ... }, err_map)` - Maps async_drop errors using `err_map`
+/// - `with_async_drop!(first, second, ..., { ... })` - Drops all values concurrently afterward
+/// - `with_async_drop!(first, second, ..., { ... }, err_map)` - Same, mapping async_drop errors
 #[macro_export]
-macro_rules! with_async_drop_2 {
+macro_rules! with_async_drop {
     ($($value:ident),+ , $f:block) => {
         async {
             let result = (async || $f)().await;
@@ -49,11 +41,11 @@ macro_rules! with_async_drop_2 {
     };
 }
 
-/// Variant of [`with_async_drop_2!`] for types that return a `Never` error in their async_drop.
+/// Variant of [`with_async_drop!`] for types that return a `Never` error in their async_drop.
 ///
 /// Since the error type is `Never` (infallible), this macro unwraps the result directly.
 #[macro_export]
-macro_rules! with_async_drop_2_infallible {
+macro_rules! with_async_drop_infallible {
     ($($value:ident),+ , $f:block) => {
         async {
             use lockable::InfallibleUnwrap as _;
@@ -67,38 +59,9 @@ macro_rules! with_async_drop_2_infallible {
     };
 }
 
-/// Executes a callback with a reference to the contained value, then calls async_drop.
-///
-/// This function provides a more functional approach to ensuring cleanup. The callback
-/// receives a mutable reference to the inner value and can perform any operations needed.
-/// After the callback completes, `async_drop` is called automatically.
-///
-/// # Arguments
-///
-/// * `value` - The `AsyncDropGuard` containing the value to operate on
-/// * `f` - A callback that receives a mutable reference to the inner value
-///
-/// # Returns
-///
-/// Returns the result of the callback if both the callback and async_drop succeed.
-/// Returns an error if either the callback or async_drop fails.
-pub async fn with_async_drop<T, R, E, F>(
-    mut value: AsyncDropGuard<T>,
-    f: impl FnOnce(&mut T) -> F,
-) -> Result<R, E>
-where
-    T: AsyncDrop + Debug,
-    E: From<<T as AsyncDrop>::Error>,
-    F: Future<Output = Result<R, E>>,
-{
-    let result = f(&mut value).await;
-    value.async_drop().await?;
-    result
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::async_drop::{AsyncDrop, AsyncDropGuard};
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -127,41 +90,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_success() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let guard = TestValue::new(42, Arc::clone(&counter));
-
-        let result: Result<i32, &'static str> = with_async_drop(guard, |v| {
-            let val = v.value;
-            async move { Ok(val * 2) }
-        })
-        .await;
-
-        assert_eq!(Ok(84), result);
-        assert_eq!(1, counter.load(Ordering::SeqCst));
-    }
-
-    #[tokio::test]
-    async fn test_with_async_drop_callback_error() {
-        let counter = Arc::new(AtomicUsize::new(0));
-        let guard = TestValue::new(42, Arc::clone(&counter));
-
-        let result: Result<i32, &'static str> =
-            with_async_drop(guard, |_v| async move { Err("callback error") }).await;
-
-        assert_eq!(Err("callback error"), result);
-        // async_drop should still be called
-        assert_eq!(1, counter.load(Ordering::SeqCst));
-    }
-
-    #[tokio::test]
-    async fn test_with_async_drop_2_macro_multiple_guards_success() {
+    async fn test_with_async_drop_macro_multiple_guards_success() {
         let counter = Arc::new(AtomicUsize::new(0));
         let first = TestValue::new(1, Arc::clone(&counter));
         let second = TestValue::new(2, Arc::clone(&counter));
         let third = TestValue::new(3, Arc::clone(&counter));
 
-        let result: Result<i32, &'static str> = with_async_drop_2!(first, second, third, {
+        let result: Result<i32, &'static str> = with_async_drop!(first, second, third, {
             Ok(first.value + second.value + third.value)
         });
 
@@ -170,13 +105,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_macro_multiple_guards_block_error() {
+    async fn test_with_async_drop_macro_multiple_guards_block_error() {
         let counter = Arc::new(AtomicUsize::new(0));
         let first = TestValue::new(1, Arc::clone(&counter));
         let second = TestValue::new(2, Arc::clone(&counter));
 
         let result: Result<i32, &'static str> =
-            with_async_drop_2!(first, second, { Err("block error") });
+            with_async_drop!(first, second, { Err("block error") });
 
         assert_eq!(Err("block error"), result);
         // Both guards are dropped even though the block failed
@@ -184,20 +119,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_macro_multiple_guards_with_error_map() {
+    async fn test_with_async_drop_macro_multiple_guards_with_error_map() {
         let counter = Arc::new(AtomicUsize::new(0));
         let first = TestValue::new(1, Arc::clone(&counter));
         let second = TestValue::new(2, Arc::clone(&counter));
 
         let result: Result<i32, String> =
-            with_async_drop_2!(first, second, { Ok(84) }, |e: &str| e.to_string());
+            with_async_drop!(first, second, { Ok(84) }, |e: &str| e.to_string());
 
         assert_eq!(Ok(84), result);
         assert_eq!(2, counter.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_infallible_macro_multiple_guards() {
+    async fn test_with_async_drop_infallible_macro_multiple_guards() {
         #[derive(Debug)]
         struct InfallibleValue(Arc<AtomicUsize>);
         impl AsyncDrop for InfallibleValue {
@@ -212,30 +147,30 @@ mod tests {
         let first = AsyncDropGuard::new(InfallibleValue(Arc::clone(&counter)));
         let second = AsyncDropGuard::new(InfallibleValue(Arc::clone(&counter)));
 
-        let result: i32 = with_async_drop_2_infallible!(first, second, { 42 });
+        let result: i32 = with_async_drop_infallible!(first, second, { 42 });
 
         assert_eq!(42, result);
         assert_eq!(2, counter.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_macro_success() {
+    async fn test_with_async_drop_macro_success() {
         let counter = Arc::new(AtomicUsize::new(0));
         let value = TestValue::new(42, Arc::clone(&counter));
 
-        let result: Result<i32, &'static str> = with_async_drop_2!(value, { Ok(84) });
+        let result: Result<i32, &'static str> = with_async_drop!(value, { Ok(84) });
 
         assert_eq!(Ok(84), result);
         assert_eq!(1, counter.load(Ordering::SeqCst));
     }
 
     #[tokio::test]
-    async fn test_with_async_drop_2_macro_with_error_map() {
+    async fn test_with_async_drop_macro_with_error_map() {
         let counter = Arc::new(AtomicUsize::new(0));
         let value = TestValue::new(42, Arc::clone(&counter));
 
         let result: Result<i32, String> =
-            with_async_drop_2!(value, { Ok(84) }, |e: &str| e.to_string());
+            with_async_drop!(value, { Ok(84) }, |e: &str| e.to_string());
 
         assert_eq!(Ok(84), result);
         assert_eq!(1, counter.load(Ordering::SeqCst));


### PR DESCRIPTION
Stacked on #643 (base branch is `claude/async-drop-error-noise`). Only the last commit belongs to this PR. Once #643 is squash-merged, this PR needs to be rebased onto `main`; I'll do that.

## Summary

After #642 there were still two ways to run a block and then `async_drop` its guards: the `with_async_drop_2!` macro and a `with_async_drop` function. This PR leaves one: the macro, now called `with_async_drop!`.

- **Remove the `with_async_drop` function**, its two tests and its re-export from `cryfs_utils::async_drop`. It had zero call sites, and it cannot do what the macro does: the macro lets the block use the guards by name (and borrow them) while the macro still owns them and consumes them afterwards. A function has to hand the guard in as a callback argument instead. The macro docs now say this so the "why is this a macro?" TODO could go too.
- **Rename** `with_async_drop_2!` → `with_async_drop!` and `with_async_drop_2_infallible!` → `with_async_drop_infallible!` at every call site (25 files). The `_2` suffix only existed to avoid clashing with the function.
- Update `CLAUDE.md` and `.claude/skills/async-drop/` (removed the function section from `helpers.md`, renamed the macro everywhere).

No behavior change; the macro bodies are untouched.

## Testing

- `cargo fmt --all`, `cargo check --workspace --all-targets` clean (only pre-existing warnings in `check` and `cryfs-cli/tests/args.rs`).
- `cargo test -p cryfs-utils -p cryfs-concurrent-store -p cryfs-rustfs -p cryfs-fsblobstore` pass.
- Full suite left to CI.

## AI disclosure

Per `AI_POLICY.md`: this change was drafted with Claude Code (session linked below) at the maintainer's request and direction. It removes an unused function and renames a macro; no security-relevant code is touched. Please review as you would any AI-assisted change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGpoUYe98AX1tyACHy6Mqt

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGpoUYe98AX1tyACHy6Mqt)_